### PR TITLE
fix(database): grant cert-controller RBAC to write events in default namespace

### DIFF
--- a/kubernetes/apps/database/mariadb-operator/app/kustomization.yaml
+++ b/kubernetes/apps/database/mariadb-operator/app/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
   - ./helmrepository.yaml
   - ./helmrelease-crds.yaml
   - ./helmrelease.yaml
+  - ./rbac-default-events.yaml

--- a/kubernetes/apps/database/mariadb-operator/app/rbac-default-events.yaml
+++ b/kubernetes/apps/database/mariadb-operator/app/rbac-default-events.yaml
@@ -1,0 +1,35 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: mariadb-operator-cert-controller-default-events
+  namespace: default
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  - apiGroups:
+      - events.k8s.io
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: mariadb-operator-cert-controller-default-events
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: mariadb-operator-cert-controller-default-events
+subjects:
+  - kind: ServiceAccount
+    name: mariadb-operator-cert-controller-cert-controller
+    namespace: database


### PR DESCRIPTION
The mariadb-operator-cert-controller SA in the database namespace lacked permission to create/patch warning events in the default namespace via both the core API group and events.k8s.io.

Adds a Role + RoleBinding in the default namespace scoped to the mariadb-operator-cert-controller-cert-controller SA.