### PR TITLE
chore(monitoring): align kube-prometheus-stack to 87.5.1

### DIFF
--- a/bootstrap/helmfile.d/00-crds.yaml
+++ b/bootstrap/helmfile.d/00-crds.yaml
@@ -22,4 +22,4 @@ releases:
   - name: kube-prometheus-stack
     namespace: observability
     chart: oci://ghcr.io/prometheus-community/charts/kube-prometheus-stack
-    version: 86.3.2
+    version: 87.5.1

--- a/kubernetes/apps/monitoring/kube-prometheus-stack/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/kube-prometheus-stack/app/helmrelease.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       # renovate: registryUrl=https://prometheus-community.github.io/helm-charts
       chart: kube-prometheus-stack
-      version: "86.3.2"
+      version: "87.5.1"
       sourceRef:
         kind: HelmRepository
         name: prometheus-community

--- a/templates/config/bootstrap/helmfile.d/00-crds.yaml.j2
+++ b/templates/config/bootstrap/helmfile.d/00-crds.yaml.j2
@@ -26,4 +26,4 @@ releases:
   - name: kube-prometheus-stack
     namespace: observability
     chart: oci://ghcr.io/prometheus-community/charts/kube-prometheus-stack
-    version: 86.3.2
+    version: 87.5.1


### PR DESCRIPTION
This PR combines the intent of #249 and #250 into one cohesive monitoring-stack update.

Supersedes:
- #249
- #250

## What changed
- Bump kube-prometheus-stack CRD extraction version:
  - `bootstrap/helmfile.d/00-crds.yaml`: `86.3.2` -> `87.5.1`
  - `templates/config/bootstrap/helmfile.d/00-crds.yaml.j2`: `86.3.2` -> `87.5.1`
- Bump kube-prometheus-stack HelmRelease chart version:
  - `kubernetes/apps/monitoring/kube-prometheus-stack/app/helmrelease.yaml`: `"86.3.2"` -> `"87.5.1"`

## Why combine
Keeping these changes in one PR avoids version skew between bootstrap CRDs and the in-cluster monitoring chart.

## Validation
- Ran `task validate` (kubeconform): monitoring manifests validated, including kube-prometheus-stack resources.
- Ran `task build path=monitoring/kube-prometheus-stack`: failed due pre-existing decrypted SOPS artifact detection (`.decrypted~*.sops.*`) in the app path guard.
