### PR TITLE
fix(longhorn): reduce snapshot amplification on Prometheus TSDB volumes

### DIFF
--- a/kubernetes/apps/storage/longhorn-system/app/default-jobs.yaml
+++ b/kubernetes/apps/storage/longhorn-system/app/default-jobs.yaml
@@ -4,15 +4,12 @@ metadata:
   name: longhorn-default-snapshot-job
   namespace: storage
 spec:
-  cron: "15 * * * *" # every hour at minute 15
+  cron: "15 */6 * * *" # every 6 hours at minute 15
   task: "snapshot"
   groups:
   - default
   retain: 3
   concurrency: 2
-#  labels:
-#    label/1: a
-#    label/2: b
 
 ---
 
@@ -28,9 +25,6 @@ spec:
   - default
   retain: 3
   concurrency: 2
-#  labels:
-#    label/1: a
-#    label/2: b
 
 ---
 
@@ -40,12 +34,26 @@ metadata:
   name: longhorn-snapshot-only-job
   namespace: storage
 spec:
-  cron: "15 * * * *" # every hour at minute 15
+  cron: "15 */6 * * *" # every 6 hours at minute 15
   task: "snapshot"
   groups:
   - snapshot-only
   retain: 3
   concurrency: 2
-#  labels:
-#    label/1: a
-#    label/2: b
+
+---
+
+# Prometheus TSDB continuous writes cause hourly snapshot chains to exceed retain: 3 faster than cleanup runs.
+# This daily job targets the tsdb group — opt volumes in via the longhorn-tsdb StorageClass.
+apiVersion: longhorn.io/v1beta2
+kind: RecurringJob
+metadata:
+  name: longhorn-tsdb-snapshot-job
+  namespace: storage
+spec:
+  cron: "15 4 * * *" # every day at 4:15 AM
+  task: "snapshot"
+  groups:
+  - tsdb
+  retain: 2
+  concurrency: 1

--- a/kubernetes/apps/storage/longhorn-system/app/default-jobs.yaml
+++ b/kubernetes/apps/storage/longhorn-system/app/default-jobs.yaml
@@ -43,7 +43,7 @@ spec:
 
 ---
 
-# Prometheus TSDB continuous writes cause hourly snapshot chains to exceed retain: 3 faster than cleanup runs.
+# Prometheus TSDB continuous writes cause frequent snapshot chains to exceed retain: 3 faster than cleanup runs.
 # This daily job targets the tsdb group — opt volumes in via the longhorn-tsdb StorageClass.
 apiVersion: longhorn.io/v1beta2
 kind: RecurringJob

--- a/kubernetes/apps/storage/longhorn-system/app/storageclasses.yaml
+++ b/kubernetes/apps/storage/longhorn-system/app/storageclasses.yaml
@@ -88,7 +88,7 @@ parameters:
 
 ---
 # TSDB/write-heavy volumes (e.g., Prometheus) — daily snapshot only via longhorn-tsdb-snapshot-job.
-# Operator: reprovision or relabel Prometheus PVCs to use this class to stop hourly snapshot amplification.
+# Operator: reprovision or relabel Prometheus PVCs to use this class to stop 6-hourly snapshot amplification.
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:

--- a/kubernetes/apps/storage/longhorn-system/app/storageclasses.yaml
+++ b/kubernetes/apps/storage/longhorn-system/app/storageclasses.yaml
@@ -85,3 +85,22 @@ parameters:
   dataLocality: best-effort
   replicaAutoBalance: best-effort
   recurringJobSelector: "[]"
+
+---
+# TSDB/write-heavy volumes (e.g., Prometheus) — daily snapshot only via longhorn-tsdb-snapshot-job.
+# Operator: reprovision or relabel Prometheus PVCs to use this class to stop hourly snapshot amplification.
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: longhorn-tsdb
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "false"
+provisioner: driver.longhorn.io
+allowVolumeExpansion: true
+reclaimPolicy: Delete
+volumeBindingMode: Immediate
+parameters:
+  numberOfReplicas: "2"
+  dataLocality: best-effort
+  replicaAutoBalance: best-effort
+  recurringJobSelector: '[{"name":"tsdb","isGroup":true}]'


### PR DESCRIPTION
## Phase
Phase 1 - Prometheus Storage Stabilization

## Scope
- Update Longhorn recurring job policy to reduce snapshot amplification risk for Prometheus TSDB
- Reduce default and snapshot-only group snapshot frequency from hourly to every 6 hours
- Add dedicated `tsdb` recurring job (daily, retain: 2) for write-heavy TSDB volumes
- Add `longhorn-tsdb` StorageClass to opt Prometheus PVCs into lighter snapshot policy

## Files Changed
- [x] `kubernetes/apps/storage/longhorn-system/app/default-jobs.yaml`
  - `longhorn-default-snapshot-job`: cron `15 * * * *` → `15 */6 * * *` (hourly → every 6 hours)
  - `longhorn-snapshot-only-job`: cron `15 * * * *` → `15 */6 * * *` (hourly → every 6 hours)
  - Added `longhorn-tsdb-snapshot-job`: daily at 04:15, `tsdb` group, retain: 2, concurrency: 1
- [x] `kubernetes/apps/storage/longhorn-system/app/storageclasses.yaml`
  - Added `longhorn-tsdb` StorageClass: 2 replicas, `recurringJobSelector: '[{"name":"tsdb","isGroup":true}]'`

## Validation
- [x] YAML parses — `default-jobs.yaml` (4 docs), `storageclasses.yaml` (6 docs), no errors
- [x] Longhorn recurring jobs valid — `kubectl kustomize` builds all 4 RecurringJob resources cleanly
- [x] New `longhorn-tsdb` StorageClass present in kustomize build output
- [x] No impact to unrelated workloads beyond intended policy scope — backup job unchanged, all existing StorageClasses unchanged

Commands run:
```bash
# Static validation (run locally, no cluster access required)
kubectl kustomize kubernetes/apps/storage/longhorn-system/app

# Post-merge runtime checks
kubectl -n storage get recurringjobs.longhorn.io -o wide
kubectl get storageclasses | grep longhorn
kubectl -n storage get volumes.longhorn.io -o wide
```

Kustomize build output confirmed all resources present:
- `RecurringJob/longhorn-default-snapshot-job` ✓
- `RecurringJob/longhorn-default-backup-job` ✓ (unchanged)
- `RecurringJob/longhorn-snapshot-only-job` ✓
- `RecurringJob/longhorn-tsdb-snapshot-job` ✓ (new)
- `StorageClass/longhorn-tsdb` ✓ (new)
- All 5 pre-existing StorageClasses ✓ (unchanged)

## Risks
- [x] **Default and snapshot-only groups now get 6-hour snapshots instead of hourly** — RPO increases from ~1h to ~6h for all volumes on these groups. Daily backup job is unchanged; full recovery remains available. Acceptable for homelab use.
- [x] **Prometheus PVCs are not automatically migrated to `longhorn-tsdb`** — the 6-hour frequency reduction helps immediately, but full amplification relief requires migrating Prometheus PVCs (see manual steps below).
- [x] **`recurringJobSelector` JSON format assumed valid for Longhorn v1beta2** — format `[{"name":"tsdb","isGroup":true}]` follows Longhorn documentation for StorageClass parameter.
- [x] **No impact to non-storage workloads** — changes are scoped to Longhorn policy only; Prometheus, Loki, and all other app HelmReleases are untouched.

## Rollback
1. Revert both changed files to main:
   ```bash
   git checkout main -- kubernetes/apps/storage/longhorn-system/app/default-jobs.yaml
   git checkout main -- kubernetes/apps/storage/longhorn-system/app/storageclasses.yaml
   ```
2. Push revert commit to trigger Flux reconciliation.
3. Verify recurring jobs restored to hourly schedule:
   ```bash
   kubectl -n storage get recurringjobs.longhorn.io -o wide
   ```
4. If `longhorn-tsdb` StorageClass was bound to PVCs before rollback: those PVCs continue to exist but lose their group assignment. No data loss. Longhorn will apply volume-level defaults.

## Notes
- [x] **Manual follow-up required to fully resolve Prometheus amplification:**
  Prometheus PVCs cannot be live-migrated to a new StorageClass. Operator must either:
  - **Option A (preferred):** Use the Longhorn UI to change the Prometheus volume's recurring job group from `default` → `tsdb` directly. No re-provisioning required.
  - **Option B:** Back up Prometheus data, delete and re-create the PVC using `storageClassName: longhorn-tsdb`, restore data.
  Until migrated, Prometheus volumes remain on the `default` group (now 6-hourly, down from hourly).
- [x] `longhorn-tsdb` StorageClass is available for all future TSDB-style workloads without further changes.
- [x] This phase has no upstream dependency — can merge independently of Phase 0.

## Coordinator Merge Gate
- [ ] Dependency phases merged
- [ ] Contracts unchanged or explicitly updated
- [ ] No plaintext secret data
- [ ] Runtime checks included in PR
- [ ] Rollback section present