### PR TITLE
feat(monitoring): deploy Thanos foundation and Prometheus sidecar integration (Phase 2 + Phase 3)

### DIFF
--- a/kubernetes/apps/monitoring/kube-prometheus-stack/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/kube-prometheus-stack/app/helmrelease.yaml
@@ -88,6 +88,15 @@ spec:
               resources:
                 requests:
                   storage: 45Gi
+        # Thanos sidecar: uploads TSDB blocks to Minio (observability-thanos bucket) for
+        # long-term storage. Local retention/retentionSize above are left unchanged —
+        # the sidecar uploads without affecting local disk usage or query behavior.
+        thanos:
+          image: quay.io/thanos/thanos:v0.39.2
+          objectStorageConfig:
+            existingSecret:
+              name: thanos-objstore-config
+              key: objstore.yml
         additionalScrapeConfigs:
           - job_name: "opnsense-telegraf"
             scrape_interval: 30s

--- a/kubernetes/apps/monitoring/kube-prometheus-stack/app/kustomization.yaml
+++ b/kubernetes/apps/monitoring/kube-prometheus-stack/app/kustomization.yaml
@@ -22,3 +22,4 @@ resources:
   - ./httproute.yaml
   - ./httproute-prometheus.yaml
   - ./grafana-secret.sops.yaml
+  - ./thanos-objstore-config.sops.yaml

--- a/kubernetes/apps/monitoring/kube-prometheus-stack/app/thanos-objstore-config.sops.yaml
+++ b/kubernetes/apps/monitoring/kube-prometheus-stack/app/thanos-objstore-config.sops.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: thanos-objstore-config
+  namespace: monitoring
+stringData:
+  objstore.yml: ENC[AES256_GCM,data:m0HXPaUK34mL+s1wDgZJ+KLYcvlXqzU3BOo8gCcFRGOZhc+iiwPk9BVTRCyxwOU5WXaqe45R//qX7QOkRoKbOnBojThrGlfcAFbP71u8scogNqc4SbvpQk60+otE0uU2pD2epPEBZrDTBm6B/zS1EAM+NeG56Eq0962LOuCcNDoTXzjtT/spG+U6ZBPIf+KyEbzRK4gcKEoGm0qK5PpOUf87OmFGWGRWRIBEQug+3TgIH1CCuGzwj+xOJohbdQ2pOGWe7vg7yZ6xhqrrBF1q,iv:wrQpIxMcirjvg3RzsDd+FHeUTDwLNEXay8daV4tsOOI=,tag:esfe9mXbgcO7d6JBcMdOTQ==,type:str]
+sops:
+  age:
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBFdEoveWZqcGltYXZEVm9Z
+        VHdnaEJpWlJYcVVmeklHZDBxT3pGKzB1S3dZCm1pWHRISDQrZzR0UFBydXFsT3Bm
+        TGljZjNkREI3ZUpvU3lJSmxhZTJjRUUKLS0tIENRRU0vRlViZm9yM0t2VkVXT0pQ
+        M1IvSUJtb1JQWGZoeTVVZG1lY09BbFkKeyEIYCWnHy34wQUqhSMo36jTVDnhPC77
+        1ggt79EkhIANV3K21waDbComJmRoi/7pp1LbItQTfxbNc0CgKHeMJA==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1gekuxnpd95l5j8gsvmpsn2mewnevd0c5y5v66p4trzcqhmpn0svqkmnyy7
+  encrypted_regex: ^(data|stringData)$
+  lastmodified: "2026-07-03T02:26:55Z"
+  mac: ENC[AES256_GCM,data:d8yyj6rVzMlv9Ad1GAIADC1wCYkpBVibKXG4X+DddLAkSjJ0lV0tFyXOTsIlgmrsfaSth3liK8MY9MZXjtM1+2Z42i12kEMKjWQ8uNTpuK5jVNwqFWzaaDxzM7hHbxqCdTIqCtdOn5xZ70raN80CCbKacaikC5wFMIY1vrPJU2Q=,iv:xxM/lJT7NaSreqDS0E5+rdIyWN/Bko34IGd1ZJJKnkc=,tag:G/lfTXkxSnTgpxlLBw8Ehg==,type:str]
+  mac_only_encrypted: true
+  version: 3.13.2

--- a/kubernetes/apps/monitoring/kustomization.yaml
+++ b/kubernetes/apps/monitoring/kustomization.yaml
@@ -11,3 +11,4 @@ resources:
   - ./alloy/ks.yaml
   - ./kube-prometheus-stack/ks.yaml
   - ./loki/ks.yaml
+  - ./thanos/ks.yaml

--- a/kubernetes/apps/monitoring/thanos/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/thanos/app/helmrelease.yaml
@@ -1,0 +1,197 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app thanos
+spec:
+  interval: 1h
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  install:
+    remediation:
+      retries: -1
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  values:
+    # bitnami/thanos was dropped: as of the Bitnami Aug 2025 catalog change,
+    # docker.io/bitnami/thanos is no longer published for free (manifest pulls 404).
+    # Deployed here directly against the upstream quay.io/thanos/thanos image instead.
+    controllers:
+      query:
+        containers:
+          app:
+            image:
+              repository: quay.io/thanos/thanos
+              tag: v0.39.2
+            args:
+              - query
+              - --http-address=0.0.0.0:10902
+              - --grpc-address=0.0.0.0:10901
+              # Matches the external_labels Prometheus Operator sets when replicas > 1.
+              - --query.replica-label=prometheus_replica
+              # Sidecar (recent data): discovered via the "prometheus-operated" headless
+              # Service that Prometheus Operator creates automatically once the sidecar
+              # is configured on the Prometheus CR (see kube-prometheus-stack HelmRelease).
+              - --store=dnssrv+_grpc._tcp.prometheus-operated.monitoring.svc.cluster.local
+              # Store Gateway (historical blocks from Minio) — single replica, direct address.
+              - --store=thanos-storegateway.monitoring.svc.cluster.local:10901
+            probes:
+              liveness: &probes
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /-/healthy
+                    port: 10902
+                  initialDelaySeconds: 10
+                  periodSeconds: 15
+                  timeoutSeconds: 5
+                  failureThreshold: 3
+              readiness:
+                <<: *probes
+                spec:
+                  httpGet:
+                    path: /-/ready
+                    port: 10902
+                  initialDelaySeconds: 10
+                  periodSeconds: 15
+                  timeoutSeconds: 5
+                  failureThreshold: 3
+            resources:
+              requests:
+                cpu: 50m
+                memory: 128Mi
+              limits:
+                memory: 512Mi
+
+      storegateway:
+        containers:
+          app:
+            image:
+              repository: quay.io/thanos/thanos
+              tag: v0.39.2
+            args:
+              - store
+              - --data-dir=/data
+              - --objstore.config-file=/etc/thanos/objstore.yml
+              - --http-address=0.0.0.0:10902
+              - --grpc-address=0.0.0.0:10901
+            probes:
+              liveness: *probes
+              readiness:
+                <<: *probes
+                spec:
+                  httpGet:
+                    path: /-/ready
+                    port: 10902
+                  initialDelaySeconds: 10
+                  periodSeconds: 15
+                  timeoutSeconds: 5
+                  failureThreshold: 3
+            resources:
+              requests:
+                cpu: 50m
+                memory: 128Mi
+              limits:
+                memory: 512Mi
+
+      compactor:
+        # Compactor must run as a singleton against a given bucket path — never scale replicas.
+        containers:
+          app:
+            image:
+              repository: quay.io/thanos/thanos
+              tag: v0.39.2
+            args:
+              - compact
+              - --data-dir=/data
+              - --objstore.config-file=/etc/thanos/objstore.yml
+              - --http-address=0.0.0.0:10902
+              - --wait
+              - --retention.resolution-raw=30d
+              - --retention.resolution-5m=90d
+              - --retention.resolution-1h=1y
+            probes:
+              liveness: *probes
+              readiness:
+                enabled: false
+            resources:
+              requests:
+                cpu: 50m
+                memory: 128Mi
+              limits:
+                memory: 1Gi
+
+    service:
+      query:
+        controller: query
+        ports:
+          http:
+            port: &queryPort 10902
+          grpc:
+            port: 10901
+      storegateway:
+        controller: storegateway
+        ports:
+          http:
+            port: 10902
+          grpc:
+            port: 10901
+
+    route:
+      query:
+        annotations:
+          gethomepage.dev/enabled: "true"
+          gethomepage.dev/icon: thanos
+          gethomepage.dev/title: Thanos Query
+          gethomepage.dev/description: "Long-term Prometheus metrics"
+          gethomepage.dev/group: "Monitoring"
+        hostnames:
+          - thanos.${SECRET_DOMAIN}
+        parentRefs:
+          - name: envoy-internal
+            namespace: network
+            sectionName: https
+        rules:
+          - backendRefs:
+              - identifier: query
+                port: *queryPort
+
+    persistence:
+      storegateway-data:
+        existingClaim: thanos-storegateway-data
+        advancedMounts:
+          storegateway:
+            app:
+              - path: /data
+
+      storegateway-objstore-config:
+        type: secret
+        name: thanos-objstore-config
+        advancedMounts:
+          storegateway:
+            app:
+              - path: /etc/thanos/objstore.yml
+                subPath: objstore.yml
+                readOnly: true
+
+      compactor-data:
+        existingClaim: thanos-compactor-data
+        advancedMounts:
+          compactor:
+            app:
+              - path: /data
+
+      compactor-objstore-config:
+        type: secret
+        name: thanos-objstore-config
+        advancedMounts:
+          compactor:
+            app:
+              - path: /etc/thanos/objstore.yml
+                subPath: objstore.yml
+                readOnly: true

--- a/kubernetes/apps/monitoring/thanos/app/kustomization.yaml
+++ b/kubernetes/apps/monitoring/thanos/app/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./ocirepository.yaml
+  - ./helmrelease.yaml
+  - ./pvc-storegateway.yaml
+  - ./pvc-compactor.yaml

--- a/kubernetes/apps/monitoring/thanos/app/ocirepository.yaml
+++ b/kubernetes/apps/monitoring/thanos/app/ocirepository.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: app-template
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/monitoring/thanos/app/pvc-compactor.yaml
+++ b/kubernetes/apps/monitoring/thanos/app/pvc-compactor.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: thanos-compactor-data
+spec:
+  accessModes: ["ReadWriteOnce"]
+  resources:
+    requests:
+      storage: 20Gi
+  storageClassName: longhorn-1-no-backup

--- a/kubernetes/apps/monitoring/thanos/app/pvc-storegateway.yaml
+++ b/kubernetes/apps/monitoring/thanos/app/pvc-storegateway.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: thanos-storegateway-data
+spec:
+  accessModes: ["ReadWriteOnce"]
+  resources:
+    requests:
+      storage: 10Gi
+  storageClassName: longhorn-1-no-backup

--- a/kubernetes/apps/monitoring/thanos/ks.yaml
+++ b/kubernetes/apps/monitoring/thanos/ks.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: thanos
+spec:
+  # kube-prometheus-stack owns the Prometheus sidecar (write path) and the
+  # thanos-objstore-config secret this release's Store Gateway/Compactor read from.
+  # minio owns the thanos-user-bootstrap Job that provisions the Minio IAM user
+  # thanos-objstore-config authenticates as. Note: minio's Kustomization has no
+  # healthChecks and wait: false, so this dependsOn only guarantees apply order,
+  # not that the bootstrap Job has finished — see Risks in the phase PR.
+  dependsOn:
+    - name: kube-prometheus-stack
+    - name: minio
+      namespace: storage
+  interval: 1h
+  path: ./kubernetes/apps/monitoring/thanos/app
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: monitoring
+  wait: false

--- a/kubernetes/apps/monitoring/thanos/ks.yaml
+++ b/kubernetes/apps/monitoring/thanos/ks.yaml
@@ -7,9 +7,9 @@ spec:
   # kube-prometheus-stack owns the Prometheus sidecar (write path) and the
   # thanos-objstore-config secret this release's Store Gateway/Compactor read from.
   # minio owns the thanos-user-bootstrap Job that provisions the Minio IAM user
-  # thanos-objstore-config authenticates as. Note: minio's Kustomization has no
-  # healthChecks and wait: false, so this dependsOn only guarantees apply order,
-  # not that the bootstrap Job has finished — see Risks in the phase PR.
+  # thanos-objstore-config authenticates as. minio's Kustomization defines a
+  # healthCheck on that Job, so this dependsOn waits until the IAM bootstrap has
+  # completed successfully before Thanos is applied.
   dependsOn:
     - name: kube-prometheus-stack
     - name: minio

--- a/kubernetes/apps/storage/minio/app/kustomization.yaml
+++ b/kubernetes/apps/storage/minio/app/kustomization.yaml
@@ -6,3 +6,5 @@ resources:
   - ./helmrelease.yaml
   - ./minio-root-credentials.sops.yaml
   - ./bucket-bootstrap-job.yaml
+  - ./thanos-user-credentials.sops.yaml
+  - ./thanos-user-bootstrap-job.yaml

--- a/kubernetes/apps/storage/minio/app/thanos-user-bootstrap-job.yaml
+++ b/kubernetes/apps/storage/minio/app/thanos-user-bootstrap-job.yaml
@@ -32,6 +32,7 @@ spec:
             - /bin/sh
             - -c
             - |
+              set -e
               RETRIES=0; MAX_RETRIES=60
               until mc alias set local http://minio.storage.svc.cluster.local:9000 \
                 "$MINIO_ROOT_USER" "$MINIO_ROOT_PASSWORD"; do
@@ -61,8 +62,20 @@ spec:
               }
               POLICY
 
-              mc admin policy create local thanos-observability-rw /tmp/thanos-policy.json
-              mc admin user add local "$THANOS_ACCESS_KEY" "$THANOS_SECRET_KEY"
+              # Idempotent: create policy only if it does not already exist
+              if ! mc admin policy info local thanos-observability-rw > /dev/null 2>&1; then
+                mc admin policy create local thanos-observability-rw /tmp/thanos-policy.json
+              else
+                echo "policy thanos-observability-rw already exists, skipping"
+              fi
+
+              # Idempotent: create user only if it does not already exist
+              if ! mc admin user info local "$THANOS_ACCESS_KEY" > /dev/null 2>&1; then
+                mc admin user add local "$THANOS_ACCESS_KEY" "$THANOS_SECRET_KEY"
+              else
+                echo "user $THANOS_ACCESS_KEY already exists, skipping"
+              fi
+
               mc admin policy attach local thanos-observability-rw --user "$THANOS_ACCESS_KEY"
               echo "thanos minio user ready"
           env:

--- a/kubernetes/apps/storage/minio/app/thanos-user-bootstrap-job.yaml
+++ b/kubernetes/apps/storage/minio/app/thanos-user-bootstrap-job.yaml
@@ -1,0 +1,94 @@
+---
+# Thanos IAM user bootstrap Job — runs once after Minio is healthy.
+# Creates a Minio user scoped to only the observability-thanos bucket (not the
+# root credentials) and attaches it to the credentials already generated and
+# SOPS-encrypted in thanos-user-credentials.sops.yaml. The Prometheus sidecar,
+# Thanos Store Gateway, and Thanos Compactor all authenticate as this user via
+# kubernetes/apps/monitoring/kube-prometheus-stack/app/thanos-objstore-config.sops.yaml,
+# which holds the same accessKey/secretKey pair.
+#
+# Manual equivalent:
+#   mc alias set local http://minio.storage.svc.cluster.local:9000 <root user> <root password>
+#   mc admin policy create local thanos-observability-rw /tmp/policy.json
+#   mc admin user add local <thanos accessKey> <thanos secretKey>
+#   mc admin policy attach local thanos-observability-rw --user <thanos accessKey>
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: thanos-user-bootstrap
+  namespace: storage
+  annotations:
+    # Remove this job from Flux management after first successful run
+    # by deleting it: kubectl -n storage delete job thanos-user-bootstrap
+    kustomize.toolkit.fluxcd.io/prune: "false"
+spec:
+  template:
+    spec:
+      restartPolicy: OnFailure
+      containers:
+        - name: mc
+          image: quay.io/minio/mc:RELEASE.2025-08-13T08-35-41Z
+          command:
+            - /bin/sh
+            - -c
+            - |
+              RETRIES=0; MAX_RETRIES=60
+              until mc alias set local http://minio.storage.svc.cluster.local:9000 \
+                "$MINIO_ROOT_USER" "$MINIO_ROOT_PASSWORD"; do
+                RETRIES=$((RETRIES + 1))
+                if [ "$RETRIES" -ge "$MAX_RETRIES" ]; then
+                  echo "ERROR: minio did not become ready after $((MAX_RETRIES * 5))s, giving up"
+                  exit 1
+                fi
+                echo "waiting for minio... (attempt $RETRIES/$MAX_RETRIES)"; sleep 5
+              done
+
+              cat > /tmp/thanos-policy.json <<POLICY
+              {
+                "Version": "2012-10-17",
+                "Statement": [
+                  {
+                    "Effect": "Allow",
+                    "Action": ["s3:ListBucket", "s3:GetBucketLocation"],
+                    "Resource": ["arn:aws:s3:::observability-thanos"]
+                  },
+                  {
+                    "Effect": "Allow",
+                    "Action": ["s3:GetObject", "s3:PutObject", "s3:DeleteObject"],
+                    "Resource": ["arn:aws:s3:::observability-thanos/*"]
+                  }
+                ]
+              }
+              POLICY
+
+              mc admin policy create local thanos-observability-rw /tmp/thanos-policy.json
+              mc admin user add local "$THANOS_ACCESS_KEY" "$THANOS_SECRET_KEY"
+              mc admin policy attach local thanos-observability-rw --user "$THANOS_ACCESS_KEY"
+              echo "thanos minio user ready"
+          env:
+            - name: MINIO_ROOT_USER
+              valueFrom:
+                secretKeyRef:
+                  name: minio-root-credentials
+                  key: rootUser
+            - name: MINIO_ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: minio-root-credentials
+                  key: rootPassword
+            - name: THANOS_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: thanos-user-credentials
+                  key: accessKey
+            - name: THANOS_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: thanos-user-credentials
+                  key: secretKey
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              memory: 64Mi

--- a/kubernetes/apps/storage/minio/app/thanos-user-bootstrap-job.yaml
+++ b/kubernetes/apps/storage/minio/app/thanos-user-bootstrap-job.yaml
@@ -18,8 +18,11 @@ metadata:
   name: thanos-user-bootstrap
   namespace: storage
   annotations:
-    # Remove this job from Flux management after first successful run
-    # by deleting it: kubectl -n storage delete job thanos-user-bootstrap
+    # prune: false prevents Flux from deleting this Job if the pod outlives the
+    # reconcile window. To fully decommission this Job, remove it from
+    # storage/minio/app/kustomization.yaml — kubectl delete alone won't work
+    # because Flux will recreate it on the next reconcile while it remains in
+    # the resources list.
     kustomize.toolkit.fluxcd.io/prune: "false"
 spec:
   template:

--- a/kubernetes/apps/storage/minio/app/thanos-user-credentials.sops.yaml
+++ b/kubernetes/apps/storage/minio/app/thanos-user-credentials.sops.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: thanos-user-credentials
+  namespace: storage
+stringData:
+  accessKey: ENC[AES256_GCM,data:xswAras5lUhB0PasdagEL1SKTUUAYLs=,iv:r2bPXALClLIHyDL9mnJAJ3azN/UULcj3e3CmfF/lcTk=,tag:ImKs3JhdOj9SumtOU7YhtA==,type:str]
+  secretKey: ENC[AES256_GCM,data:nT0XBAHWg1ZPeDOz9MveV7aeQP1tObi4dvmxPVvcBJHmR88wbCSLYQ==,iv:a+0M9WlfrDo5uIoq/G0V7N9nr+t1yXl4K8Seq93vBAg=,tag:q33Lx2ai4SQ26P8BU9fm5w==,type:str]
+sops:
+  age:
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBqeUZMTFFBZGsyWVNLM0k0
+        Y1FXN0ZrQjIzTnZ6YW1STmN5NWVOV2YyY3pzCmx1MDF0QzRVWkY4VlhiU2FvcXY3
+        MXl6dFFXOFlieWdGZm5ReVRjbmpnUG8KLS0tIG42dmU3Q1NjSXNVSE1yODRSNW5R
+        aWtxRUVpdllBWGxsb25iVWdkL2ltd2sK93ANnmkdvkQxKU6U6x8zBDMUGUFGlTUr
+        mfjsNKY9uspcFOuDk3IulUyB3FJ+LJXcw3yn/iiCztsz5/Tzfbd7MQ==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1gekuxnpd95l5j8gsvmpsn2mewnevd0c5y5v66p4trzcqhmpn0svqkmnyy7
+  encrypted_regex: ^(data|stringData)$
+  lastmodified: "2026-07-03T02:26:55Z"
+  mac: ENC[AES256_GCM,data:iavmP3Tf7pGM88x4u5ogRSFwzQFHJyY1oKMH4gC1+Pumxdn9f8561fJ0/WHCkZdJWf5o1PDv4a6aKlKmgkkr+xKGp72uk68I5MDcb8DeKyLTfXBSBXHD4v+rvW3XMV8Voo3SPvclbiT7u8eUIbottpXhnUigcXLx8bBzR2ptBOg=,iv:HxcYrjtJN/8nzUAZgyUkkA/5TAMPEAIv+tAGdPFx2Y8=,tag:MPdWG4hATpbGsQ1x5eF57g==,type:str]
+  mac_only_encrypted: true
+  version: 3.13.2

--- a/kubernetes/apps/storage/minio/ks.yaml
+++ b/kubernetes/apps/storage/minio/ks.yaml
@@ -4,6 +4,14 @@ kind: Kustomization
 metadata:
   name: minio
 spec:
+  # Gate this Kustomization's Ready condition on the Thanos IAM bootstrap Job
+  # completing, so thanos's `dependsOn: minio` actually waits for the scoped
+  # Minio user to exist instead of only waiting for apply to succeed.
+  healthChecks:
+    - apiVersion: batch/v1
+      kind: Job
+      name: thanos-user-bootstrap
+      namespace: storage
   interval: 1h
   path: ./kubernetes/apps/storage/minio/app
   postBuild:


### PR DESCRIPTION
## Phase
Phase 2 - Thanos Foundation
Phase 3 - Prometheus Thanos Integration

This PR combines both phases: Phase 3's sidecar wiring has no effect without Phase 2's
Query/Store Gateway/Compactor deployed to actually serve the blocks it uploads, and both
share the same `thanos-objstore-config` secret — splitting them would leave an
intermediate state where Prometheus uploads blocks nothing can read. Phase 4 (Grafana
datasource cutover) is explicitly deferred to its own PR — see Notes.

## Scope
**Phase 2:**
- Deploy Thanos Query, Store Gateway, and Compactor in the `monitoring` namespace via a new `thanos` app
- Provision a dedicated, bucket-scoped Minio IAM user for Thanos (not root credentials) and wire it into an encrypted objstore secret

**Phase 3:**
- Enable the Thanos sidecar on the existing kube-prometheus-stack Prometheus CR
- Wire the sidecar to the same `thanos-objstore-config` secret (write path)

### Design change from the original draft: no `bitnami/thanos`
The initial draft used the `bitnami/thanos` Helm chart. During review I confirmed
`docker.io/bitnami/thanos` no longer resolves for free — manifest pulls return `404`,
and Bitnami's own Docker Hub page states the image "is no longer available for free
through Docker Hub" (their Aug 2025 catalog change). Deploying that chart as-is would
have produced `ImagePullBackOff` on every Thanos pod. Query, Store Gateway, and
Compactor are now deployed via `bjw-s-labs/app-template` (this repo's standard chart
for apps without an official free chart — see `prowlarr`, `n8n`, etc.) directly against
the upstream `quay.io/thanos/thanos:v0.39.2` image. No Bitnami dependency remains
anywhere in this PR.

This branch is rebased onto main past #260 (Bitnami → native `minio/minio` chart
migration for storage/minio). Verified compatibility directly against the native
chart source: `existingSecret` still reads `rootUser`/`rootPassword` from
`minio-root-credentials`, the default API port is still `9000`, and the Service name
still resolves to `minio` — nothing in this PR needed to change as a result.

## Contract Values
- Objstore endpoint: `minio.storage.svc.cluster.local:9000`
- Bucket: `observability-thanos`
- Objstore secret: `thanos-objstore-config` (namespace: `monitoring`) — holds a dedicated Thanos Minio user, not root credentials
- Minio IAM credentials secret: `thanos-user-credentials` (namespace: `storage`)
- Minio policy: `thanos-observability-rw` — read/write on `observability-thanos` only, attached to the Thanos user
- Thanos Query Prometheus-API endpoint: `http://thanos-query.monitoring.svc.cluster.local:10902`
- Sidecar StoreAPI discovery: DNS SRV on `prometheus-operated.monitoring.svc.cluster.local` (Prometheus Operator's implicit headless service)
- Store Gateway StoreAPI: `thanos-storegateway.monitoring.svc.cluster.local:10901` (direct address, single replica)

## Files Changed
**New — `thanos` app (Phase 2):**
- `kubernetes/apps/monitoring/thanos/ks.yaml` — Flux Kustomization (`dependsOn: kube-prometheus-stack`, `dependsOn: minio` in `storage`)
- `kubernetes/apps/monitoring/thanos/app/kustomization.yaml`
- `kubernetes/apps/monitoring/thanos/app/ocirepository.yaml` — `bjw-s-labs/app-template` v5.0.1
- `kubernetes/apps/monitoring/thanos/app/helmrelease.yaml` — Query, Store Gateway, Compactor controllers against `quay.io/thanos/thanos:v0.39.2`; Compactor retention 30d raw / 90d 5m / 1y 1h; HTTPRoute for Query UI at `thanos.${SECRET_DOMAIN}`
- `kubernetes/apps/monitoring/thanos/app/pvc-storegateway.yaml` — 10Gi, `longhorn-1-no-backup`
- `kubernetes/apps/monitoring/thanos/app/pvc-compactor.yaml` — 20Gi, `longhorn-1-no-backup`

**New — Minio IAM provisioning (Phase 2, in `storage/minio`):**
- `kubernetes/apps/storage/minio/app/thanos-user-credentials.sops.yaml` — SOPS-encrypted, dedicated Thanos access/secret key pair
- `kubernetes/apps/storage/minio/app/thanos-user-bootstrap-job.yaml` — one-shot Job (mirrors the existing `bucket-bootstrap-job.yaml` pattern) that uses Minio root creds at runtime to create the scoped IAM user and attach the `thanos-observability-rw` policy
- `kubernetes/apps/storage/minio/app/kustomization.yaml` — registers both files above
- `kubernetes/apps/storage/minio/ks.yaml` — adds `healthChecks` gate on the `thanos-user-bootstrap` Job so `dependsOn: minio` waits for the IAM user to actually exist, not just for apply to succeed

**New — objstore secret (Phase 3, shared by sidecar + Phase 2 components):**
- `kubernetes/apps/monitoring/kube-prometheus-stack/app/thanos-objstore-config.sops.yaml` — SOPS-encrypted, holds the dedicated Thanos Minio user's credentials

**Modified:**
- `kubernetes/apps/monitoring/kube-prometheus-stack/app/helmrelease.yaml` — adds `prometheus.prometheusSpec.thanos` (sidecar image `quay.io/thanos/thanos:v0.39.2` + `objectStorageConfig.existingSecret`); local `retention`/`retentionSize` unchanged
- `kubernetes/apps/monitoring/kube-prometheus-stack/app/kustomization.yaml` — registers the new secret
- `kubernetes/apps/monitoring/kustomization.yaml` — registers `./thanos/ks.yaml`

No changes to `kubernetes/flux` or `talos`.

## Validation
- [x] YAML parses
- [x] Flux/Kustomize paths valid
- [x] Secret encryption verified — both new `.sops.yaml` files contain a `sops:` metadata block and `ENC[AES256_GCM...]` values under `stringData`, matching this repo's `.sops.yaml` `encrypted_regex: ^(data|stringData)$` policy and age recipient. No plaintext credential material is committed.
- [ ] Thanos components healthy — pending cluster deploy
- [ ] Thanos can read/write object store — pending cluster deploy
- [ ] Prometheus StatefulSet healthy — pending cluster deploy
- [ ] Sidecar healthy — pending cluster deploy
- [ ] No alerting disruption observed — pending cluster deploy
- [ ] Block shipping evidence captured — pending cluster deploy

Commands run (static/render-time; no live cluster access available to the agent):
- `python3 -c "import yaml; ..."` (`yaml.safe_load_all`) across all touched files → all parse clean
- Structural check for `sops:` + `ENC[AES256_GCM` markers on both new `.sops.yaml` files → both confirmed encrypted
- `kubectl kustomize` on `thanos/app`, `kube-prometheus-stack/app`, `storage/minio/app` individually → all render clean
- `kubectl kustomize kubernetes/apps/monitoring` and `kubernetes/apps/storage` (parent trees) → both exit 0
- Looped `kubectl kustomize` over every `kubernetes/apps/*/*/app` directory in the repo (full regression sweep) → all still build clean, no other app broken
- Verified image availability directly against the registry: `docker.io/bitnami/thanos` manifest pull → `404` (confirmed dead); `quay.io/thanos/thanos` and `ghcr.io/bjw-s-labs/helm/app-template` confirmed public and pullable
- Verified native MinIO chart compatibility directly against chart source (`charts.min.io` v5.4.0): `existingSecret` expects `rootUser`/`rootPassword` keys (match), default API port `9000` (match), Service name resolves to `minio` (match)
- Rebased onto current `main` (post-#260) — clean rebase, no conflicts, full regression sweep re-run and still passing

Commands to run post-merge (cluster-side):
```bash
kubectl -n storage get jobs thanos-user-bootstrap
kubectl -n storage logs job/thanos-user-bootstrap
kubectl -n monitoring get helmreleases
kubectl -n monitoring get pods
kubectl -n monitoring get svc
kubectl -n monitoring get prometheus
kubectl -n monitoring logs -l app.kubernetes.io/name=thanos-query
kubectl -n monitoring logs <prometheus-pod> -c thanos-sidecar
```

## Risks
- **Sidecar enablement triggers a Prometheus StatefulSet pod rollout** — expect a brief scrape/alerting gap while the pod restarts. Local `retention`/`retentionSize` are unchanged, so no data loss.
- **Retention values (30d/90d/1y) and PVC sizes (10Gi Store Gateway, 20Gi Compactor) are untested assumptions**, not validated against real block volume. Watch `kubectl -n monitoring get pvc` after deploy.
- **DNS-based StoreAPI discovery (`prometheus-operated` headless service) depends on Prometheus Operator's implicit behavior** once a sidecar is configured — can't be verified until deployed.
- Single Prometheus replica means `--query.replica-label=prometheus_replica` is inert today — harmless, only pays off if replicas are ever scaled up.

## Rollback
1. Remove `./thanos/ks.yaml` from `kubernetes/apps/monitoring/kustomization.yaml` and push — Flux prunes the `thanos` Kustomization (Query, Store Gateway, Compactor, and their PVCs).
2. Revert the `thanos:` block in `kubernetes/apps/monitoring/kube-prometheus-stack/app/helmrelease.yaml` — removes the sidecar container; Prometheus itself returns to its pre-PR spec.
3. Remove `./thanos-objstore-config.sops.yaml` from `kube-prometheus-stack/app/kustomization.yaml` and delete the file. If already applied: `kubectl -n monitoring delete secret thanos-objstore-config`.
4. Remove `./thanos-user-credentials.sops.yaml`, `./thanos-user-bootstrap-job.yaml`, and the `healthChecks` addition from `storage/minio`. The Minio IAM user/policy are additive and inert if unreferenced; `mc admin user remove local <thanos accessKey>` cleans up fully if desired.
5. `flux reconcile kustomization monitoring --with-source` (and `storage` if step 4 was applied).
6. Minio and the `observability-thanos` bucket (Phase 0) are untouched by any of the above.

## Notes
- **Credentials are real and already encrypted in this PR** — no manual SOPS step is required before merge. Minting this new IAM identity (rather than reusing Minio root credentials) required explicit repo-owner authorization during review.
- **Phase 4 (Grafana datasource cutover) is intentionally excluded from this PR** — an earlier draft repointed Grafana's default datasource directly, which didn't satisfy Phase 4's "Thanos default + Prometheus Local secondary" contract; reverted and left for a dedicated Phase 4 PR.
- **Block-shipping evidence is a real acceptance criterion and is not yet satisfied** — this phase isn't "done" until post-merge logs confirm the sidecar is uploading blocks and Store Gateway/Query can read them back.
- **Root Minio credentials are used in exactly one place**: `thanos-user-bootstrap-job.yaml`, transiently, to perform the one-time admin action of creating the scoped Thanos IAM user and attaching its policy (Minio requires admin/root privileges to create users — a scoped user can't mint its own peers). Thanos itself (sidecar, Store Gateway, Compactor) never authenticates as root; it only ever uses `thanos-objstore-config`.
- No dashboard rewrites were made or are needed for this phase.
