### PR TITLE
feat(monitoring): cut Grafana default metrics datasource to Thanos Query (Phase 4)

### DIFF
--- a/kubernetes/apps/monitoring/kube-prometheus-stack/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/kube-prometheus-stack/app/helmrelease.yaml
@@ -129,7 +129,20 @@ spec:
           memory: 128Mi
         limits:
           memory: 512Mi
+      # Rename the chart's auto-provisioned Prometheus datasource and demote it from
+      # default now that Thanos Query (below) provides the unified short+long-term view.
+      # Kept as a secondary datasource for debugging sidecar/upload issues directly
+      # against local Prometheus, bypassing Thanos Query's fan-out.
+      sidecar:
+        datasources:
+          name: "Prometheus Local"
+          isDefaultDatasource: false
       additionalDataSources:
+        - name: Thanos
+          type: prometheus
+          url: http://thanos-query.monitoring.svc.cluster.local:10902
+          access: proxy
+          isDefault: true
         - name: Loki
           type: loki
           url: http://loki.monitoring.svc.cluster.local:3100


### PR DESCRIPTION
## Phase
Phase 4 - Grafana Datasource Cutover

## Scope
- Add Thanos datasource and set default
- Keep local Prometheus datasource as secondary

## Contract Values
- Default datasource: Thanos
- Secondary datasource: Prometheus Local

## Files Changed
- `kubernetes/apps/monitoring/kube-prometheus-stack/app/helmrelease.yaml` — only file touched, per this phase's allowed-edits list. Two additions inside the existing `grafana:` block:
  - `grafana.sidecar.datasources.name: "Prometheus Local"` + `isDefaultDatasource: false` — renames and demotes the chart's auto-provisioned Prometheus datasource (previously named `Prometheus`, previously default)
  - New entry in `grafana.additionalDataSources`: `Thanos` (`type: prometheus`, `url: http://thanos-query.monitoring.svc.cluster.local:10902`, `isDefault: true`)

Branch is a single commit (`5389240`) cut fresh from `main` — exactly this one file, 13 insertions, no other diff. No dashboard files changed. No changes to `kubernetes/flux` or `talos`.

## Validation
- [x] YAML parses
- [x] Flux/Kustomize paths valid
- [ ] Grafana pod healthy — pending cluster deploy
- [ ] Dashboards load — pending cluster deploy
- [ ] Query works with both datasources — pending cluster deploy

Commands run (static/render-time; no live cluster access available to the agent):
- `git diff main --stat` → confirmed exactly 1 file changed, 13 insertions, 0 deletions
- `python3 -c "import yaml; ..."` (`yaml.safe_load_all`) on the changed file → parses clean
- `kubectl kustomize kubernetes/apps/monitoring/kube-prometheus-stack/app` → renders clean; confirmed both `name: Thanos` (with `isDefault: true` and the correct URL) and `name: Prometheus Local` (with `isDefaultDatasource: false`) appear in the rendered HelmRelease values
- `kubectl kustomize kubernetes/apps/monitoring` (parent tree) → exit 0
- Looped `kubectl kustomize` over every `kubernetes/apps/*/*/app` directory in the repo (full regression sweep) → all still build clean, no other app broken
- **Verified the Thanos Query URL is real, not assumed**: pulled the actual `bjw-s-labs/app-template` v5.0.1 chart via `helm pull` and ran `helm template` against the real values from `kubernetes/apps/monitoring/thanos/app/helmrelease.yaml` (Phase 2, already on `main` via #262). Confirmed the rendered Service is literally named `thanos-query`, matching the hostname wired into this PR.

Commands to run post-merge (cluster-side, not run by the agent):
```bash
kubectl -n monitoring get pods -l app.kubernetes.io/name=grafana
kubectl -n monitoring get helmreleases
# Confirm both datasources are provisioned and Thanos is default:
kubectl -n monitoring exec deploy/kube-prometheus-stack-grafana -- \
  curl -s -u <admin-user>:<admin-password> http://localhost:3000/api/datasources
# Spot-check a query against each datasource in the Grafana UI (Explore view):
#   - Thanos (default): should return both recent and >14d-old data
#   - Prometheus Local: should return only data within local retention (14d)
```

## Risks
- **Every dashboard that queries the default datasource by implicit reference (not by explicit datasource UID) now queries Thanos Query instead of Prometheus directly.** Thanos Query adds a network hop and depends on the Phase 3 sidecar + Store Gateway being healthy — if either degrades, dashboards relying on the default datasource degrade too, even though local Prometheus itself is fine. `Prometheus Local` remains available as a manual fallback in Explore, but dashboards won't fail over to it automatically.
- **Query latency may increase slightly** for recent-data queries now routed through Thanos Query's fan-out (sidecar + Store Gateway) instead of hitting Prometheus directly. Not expected to be significant at homelab scale, but unverified without a live cluster.
- **This inherits all of Phase 2/3's unresolved risks** (untested Compactor/Store Gateway retention and PVC sizing, DNS-based sidecar discovery, bootstrap-Job race window) since Phase 4's correctness is entirely dependent on Thanos Query actually having data to serve. Those phases are already merged to `main` via #262, so this isn't blocking — just inherited exposure.
- No new secrets, no new components, no namespace/RBAC changes — the smallest-blast-radius phase so far in this series.

## Rollback
1. Revert the `sidecar.datasources` block and the `Thanos` entry in `additionalDataSources` in `kube-prometheus-stack/app/helmrelease.yaml` — this restores the chart's default auto-provisioned `Prometheus` datasource as default and removes the `Thanos` entry.
2. `flux reconcile kustomization monitoring --with-source` (or `helmrelease reconcile kube-prometheus-stack -n monitoring`) to apply.
3. Validate dashboard query behavior restored — confirm dashboards default back to querying local Prometheus directly and load without a Thanos Query dependency.
4. No data loss risk: this phase only changes which datasource Grafana queries by default — it deletes nothing, and Prometheus/Thanos themselves are untouched.

## Notes
- **Dashboard rewrites avoided** — no dashboard JSON/ConfigMap changes in this PR, per the phase's own constraint. Dashboards that hardcode a datasource UID (rather than using the implicit default) are unaffected either way and continue querying whatever they were pointed at before.
- **This PR assumes Phase 3 is confirmed healthy on the live cluster** (sidecar uploading blocks, Prometheus stable) — that was confirmed out-of-band before this phase was started, not independently re-verified here.
- **Branch history note**: this PR was originally drafted against a stale integration branch and carried an unrelated 1,502-line diff. It has been reset to a single commit cut fresh from current `main`, so this PR now contains only the Phase 4 change described above.
- Local Prometheus retention/storage settings are untouched — Phase 5 (retention optimization) is the appropriate place to revisit those now that Thanos is the default read path.
