### PR TITLE
feat(monitoring): reduce Prometheus local retention now that Thanos is validated (Phase 5)

### DIFF
--- a/kubernetes/apps/monitoring/kube-prometheus-stack/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/kube-prometheus-stack/app/helmrelease.yaml
@@ -67,8 +67,16 @@ spec:
     prometheus:
       prometheusSpec:
         replicas: 1
-        retention: 14d
-        retentionSize: 38GB
+        # Reduced from 14d/38GB now that the Thanos sidecar (Phase 3) and Query/Store
+        # Gateway/Compactor (Phase 2, confirmed healthy in Phase 4) provide validated
+        # long-term durability in Minio. Local Prometheus now only needs to cover:
+        #   - fast local queries for recording/alerting rules
+        #   - a buffer window in case block uploads to Minio lag or fail transiently
+        # 3d/10GB is a conservative buffer (~3x the ~2.7GB/day observed at the prior
+        # 14d/38GB ratio) — well short of the Thanos Compactor's own 30d raw retention,
+        # so there's no gap between "local" and "long-term" coverage.
+        retention: 3d
+        retentionSize: 10GB
         enableRemoteWriteReceiver: true
         # Discover all ServiceMonitors and PodMonitors in the cluster
         serviceMonitorSelectorNilUsesHelmValues: false
@@ -87,10 +95,15 @@ spec:
               accessModes: ["ReadWriteOnce"]
               resources:
                 requests:
+                  # PVC size intentionally left at 45Gi rather than shrunk to match the
+                  # new retentionSize: most storage classes (including Longhorn) don't
+                  # support in-place PVC shrink, so reducing this would require a
+                  # disruptive volume recreation. The retention/retentionSize policy
+                  # above is what actually bounds disk usage; the extra headroom here
+                  # is unused but harmless.
                   storage: 45Gi
         # Thanos sidecar: uploads TSDB blocks to Minio (observability-thanos bucket) for
-        # long-term storage. Local retention/retentionSize above are left unchanged —
-        # the sidecar uploads without affecting local disk usage or query behavior.
+        # long-term storage.
         thanos:
           image: quay.io/thanos/thanos:v0.39.2
           objectStorageConfig:

--- a/kubernetes/apps/monitoring/kube-prometheus-stack/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/kube-prometheus-stack/app/helmrelease.yaml
@@ -74,7 +74,7 @@ spec:
         #   - a buffer window in case block uploads to Minio lag or fail transiently
         # 3d/10GB is a conservative buffer (~3x the ~2.7GB/day observed at the prior
         # 14d/38GB ratio) — well short of the Thanos Compactor's own 30d raw retention,
-        # so there's no gap between "local" and "long-term" coverage.
+        # so, assuming timely sidecar uploads, there's no intended gap between "local" and "long-term" coverage.
         retention: 3d
         retentionSize: 10GB
         enableRemoteWriteReceiver: true


### PR DESCRIPTION
## Phase
Phase 5 - Retention Optimization

## Scope
- Reduce local Prometheus retention pressure
- Enforce long-term retention in Thanos compactor policy

## Files Changed
- `kubernetes/apps/monitoring/kube-prometheus-stack/app/helmrelease.yaml` — only file touched, per this phase's allowed-edits list. 17 insertions / 4 deletions: `prometheus.prometheusSpec.retention` and `.retentionSize` reduced, plus documentation comments explaining the rationale and clarifying that the 45Gi PVC is intentionally left unresized.

Branch is a single commit (`9de1224`) cut fresh from `main` (which already has Phases 0, 2, 3, and 4 merged). No changes to `kubernetes/apps/monitoring/thanos/app/helmrelease.yaml` — see Policy Change Summary below for why. No changes to `kubernetes/flux` or `talos`.

## Policy Change Summary
- Local Prometheus retention old -> new: `14d` -> `3d`
- Local Prometheus retentionSize old -> new: `38GB` -> `10GB`
- Thanos compactor retention settings: **unchanged, already explicit from Phase 2** — `--retention.resolution-raw=30d`, `--retention.resolution-5m=90d`, `--retention.resolution-1h=1y` (`kubernetes/apps/monitoring/thanos/app/helmrelease.yaml:115-117`). This phase's acceptance criterion ("Thanos compactor retention policy is explicit") was already satisfied before this PR, so no edit was needed there.
- PVC size: unchanged at `45Gi` (see Notes for why this wasn't shrunk to match).

Rationale for 3d/10GB: now that the Thanos sidecar (Phase 3) and Query/Store Gateway/Compactor (Phase 2, confirmed healthy in Phase 4) provide validated long-term durability in Minio, local Prometheus only needs to cover (a) fast local queries for recording/alerting rules and (b) a buffer window against transient upload lag/failures — not full long-term storage. 3d is a conservative ~3x buffer over the prior observed ~2.7GB/day ratio (14d/38GB), and sits well inside the Compactor's own 30d raw-retention window, so there's no coverage gap between "local" and "long-term."

## Validation
- [ ] Prometheus healthy after retention update — pending cluster deploy
- [ ] Thanos compactor healthy — pending cluster deploy (unaffected by this PR, but listed per template)
- [ ] Query continuity acceptable — pending cluster deploy

Commands run (static/render-time; no live cluster access available to the agent):
- `python3 -c "import yaml; ..."` (`yaml.safe_load_all`) on the changed file → parses clean
- `kubectl kustomize kubernetes/apps/monitoring/kube-prometheus-stack/app` → renders clean; confirmed `retention: 3d` and `retentionSize: 10GB` appear in the rendered HelmRelease values
- `kubectl kustomize kubernetes/apps/monitoring` (parent tree) → exit 0
- Looped `kubectl kustomize` over every `kubernetes/apps/*/*/app` directory in the repo (full regression sweep) → all still build clean, no other app broken
- `git diff main --stat` → confirmed exactly 1 file changed, 17 insertions, 4 deletions
- Confirmed Thanos Compactor's retention flags are already explicit and required no change: `grep -n "retention.resolution" kubernetes/apps/monitoring/thanos/app/helmrelease.yaml` → `--retention.resolution-raw=30d`, `--retention.resolution-5m=90d`, `--retention.resolution-1h=1y`

Commands to run post-merge (cluster-side, not run by the agent):
```bash
kubectl -n monitoring get pods
kubectl -n monitoring get helmreleases
# Confirm Prometheus applied the new retention config:
kubectl -n monitoring exec prometheus-kube-prometheus-stack-prometheus-0 -c prometheus -- \
  wget -qO- http://localhost:9090/api/v1/status/flags | grep -i retention
# Confirm actual disk usage stays within the new 10GB target after compaction settles:
kubectl -n monitoring exec prometheus-kube-prometheus-stack-prometheus-0 -c prometheus -- du -sh /prometheus
# Spot-check query continuity across the old/new retention boundary (should fail over to Thanos Query seamlessly since Phase 4 made it default):
#   Explore a >3d-old query in Grafana against the default (Thanos) datasource
```

## Risks
- **3d/10GB is an estimate, not validated against real query load or actual measured local disk usage** — no cluster access from this environment. If actual daily ingestion is higher than the ~2.7GB/day assumed from the prior 14d/38GB ratio (e.g. cardinality growth since that baseline was set), Prometheus could hit `retentionSize` before 3 days elapse, which is self-correcting (Prometheus just compacts/deletes oldest blocks sooner) but would shrink the effective local buffer below the intended 3 days.
- **Local retention is now shorter than the interval between some Thanos block uploads.** Prometheus ships TSDB blocks to Minio on its normal 2-hour block cycle; if an upload is delayed for close to 3 days (Minio outage, network partition, etc.), the source block could be locally deleted before it's shipped, meaning it would never reach Thanos. This is the direct trade-off of this phase and is the reason 3d was chosen as a conservative floor rather than something more aggressive.
- **Recording rules or alerts that query further back than 3 days directly against local Prometheus** (bypassing Grafana's Thanos-default datasource) will now see gaps. Anything going through the Thanos Query datasource (default since Phase 4) is unaffected.
- No new components, no secrets, no namespace/RBAC changes — same minimal blast radius pattern as Phase 4.

## Rollback
1. Revert `retention`/`retentionSize` back to `14d`/`38GB` in `kube-prometheus-stack/app/helmrelease.yaml`.
2. `flux reconcile kustomization monitoring --with-source` (or `helmrelease reconcile kube-prometheus-stack -n monitoring`) to apply.
3. Re-check Prometheus and Thanos health — confirm Prometheus's `/api/v1/status/flags` reflects the reverted values and the pod restarts cleanly.
4. No data loss risk from the rollback itself: reverting only widens the local retention window going forward, it doesn't restore data already compacted away under the tighter window. Any data already shipped to Minio via the Thanos sidecar remains queryable via Thanos Query regardless of this setting.

## Notes (manual steps)
- **No SOPS/secret changes in this PR** — pure values change, nothing to encrypt.
- **PVC left at 45Gi, not shrunk to match `retentionSize: 10GB`.** Longhorn (like most CSI drivers) doesn't support in-place PVC shrink — reducing the PVC would require a disruptive manual volume recreation (delete + recreate PVC, restore from a Longhorn snapshot/backup if needed). The retention/retentionSize policy is what actually bounds disk usage; the unused headroom on the existing volume is harmless and left alone deliberately. If reclaiming that space is ever desired, it's a manual, separate, disruptive operation — not something this PR attempts.
- **Recommended manual follow-up after merge**: watch `kubectl -n monitoring get pvc` and actual TSDB disk usage (`du -sh /prometheus` inside the pod) for a few days to confirm the 3d/10GB assumption holds against real ingestion volume before considering it final.
