### PR TITLE
fix(monitoring): give Thanos Grafana datasource an explicit uid

### DIFF
--- a/kubernetes/apps/monitoring/kube-prometheus-stack/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/kube-prometheus-stack/app/helmrelease.yaml
@@ -140,6 +140,15 @@ spec:
       additionalDataSources:
         - name: Thanos
           type: prometheus
+          # Explicit uid required: without one, this collided with Loki's own
+          # auto-assigned uid at provisioning time (Grafana crash-looped with
+          # "Datasource provisioning error: data source with the same uid
+          # already exists" once a second uid-less additionalDataSources entry
+          # was introduced). Loki is deliberately left without an explicit uid
+          # since it's worked unmodified for months; changing it risks
+          # orphaning any dashboard panel that already references its current
+          # auto-assigned uid.
+          uid: thanos
           url: http://thanos-query.monitoring.svc.cluster.local:10902
           access: proxy
           isDefault: true


### PR DESCRIPTION
## Summary
Fixes a live production regression introduced by #263 (Phase 4 - Grafana Datasource Cutover). Grafana is currently crash-looping on the cluster with:
```
Datasource provisioning error: data source with the same uid already exists
```

## Root cause
`additionalDataSources` had two entries with no explicit `uid`: the newly-added `Thanos` entry (from #263) and the pre-existing `Loki` entry (working unmodified for ~90 days). Grafana's provisioning auto-assigns a uid when one isn't specified, and once there were *two* uid-less entries in the same list, they collided. The chart's own built-in default entries (`Prometheus Local`, `Alertmanager`) were never affected because they've always carried explicit `uid` fields (`uid: prometheus`, `uid: alertmanager`) — the same convention this fix now applies to `Thanos`.

This was caught by live-cluster verification while validating Phase 4 ahead of merging Phase 5 (#265) — confirmed via `kubectl -n monitoring get configmap kube-prometheus-stack-grafana-datasource -o jsonpath='{.data.datasource\.yaml}'` showing the correct rendered datasource list, followed by the Grafana pod itself crash-looping on that exact config.

## Fix
One field added to the `Thanos` entry only:
```yaml
- name: Thanos
  type: prometheus
  uid: thanos
  url: http://thanos-query.monitoring.svc.cluster.local:10902
  access: proxy
  isDefault: true
```

**`Loki` is deliberately left untouched** — no `uid` added to it. It's been stable for months without one; forcing an explicit `uid` now could silently change its identity if any existing dashboard panel references it by its current auto-assigned uid, trading a known-working state for an unverified one. Since giving `Thanos` a unique explicit uid removes it from whatever uid-collision path caused the crash, `Loki` returns to being the sole uid-less entry — the same state it was in for the 90 days before this bug existed.

## Files Changed
- `kubernetes/apps/monitoring/kube-prometheus-stack/app/helmrelease.yaml` — 9 lines added (1 field + explanatory comment), no other changes. Branch is a single commit (`d283311`) cut fresh from `main`.

## Validation
- `python3 -c "import yaml; ..."` (`yaml.safe_load_all`) → parses clean
- `kubectl kustomize kubernetes/apps/monitoring/kube-prometheus-stack/app` → renders clean; confirmed `uid: thanos` present on the Thanos entry and no `uid` field added to Loki
- `kubectl kustomize kubernetes/apps/monitoring` (parent tree) → exit 0
- Looped `kubectl kustomize` over every `kubernetes/apps/*/*/app` directory in the repo (full regression sweep) → all still build clean
- `git diff main --stat` → confirmed exactly 1 file changed, 9 insertions, 0 deletions

Commands to run post-merge (cluster-side) to confirm the fix actually resolves the crash-loop:
```bash
kubectl -n monitoring get pods -l app.kubernetes.io/name=grafana
# Should show 0 restarts climbing further and status Running, not CrashLoopBackOff.
# If Flux hasn't picked it up within a minute or two:
flux reconcile helmrelease kube-prometheus-stack -n monitoring --with-source
kubectl -n monitoring rollout restart deployment kube-prometheus-stack-grafana
kubectl -n monitoring rollout status deployment kube-prometheus-stack-grafana
# Then confirm in the Grafana UI: Thanos (default), Prometheus Local, Loki, Alertmanager all present.
```

## Risks
- Low. Single additive field on the one entry that's actually new/untested; the entry that's been working for months is untouched.
- If Grafana was already crash-looping before this merges, the pod is stuck in `CrashLoopBackOff` and won't pick up the fix on its own until either Flux reconciles the updated HelmRelease *and* the Deployment rolls a new pod, or someone forces a rollout restart — included above.

## Rollback
1. Revert this commit (removes the `uid: thanos` line).
2. This reintroduces the crash-loop bug from #263 — **not a safe rollback target**, only useful if this specific fix somehow made things worse in some unanticipated way. If so, the real rollback is to revert #263 entirely (the whole Grafana datasource cutover), not just this hotfix.
3. `flux reconcile helmrelease kube-prometheus-stack -n monitoring --with-source` to apply whichever state you land on.

## Notes
- No changes to Phase 5 (#265) — that PR is unaffected by this fix and can proceed independently once this merges and Grafana is confirmed healthy again.
- If you already applied the manual stop-gap directly to the live ConfigMap (`kubectl edit configmap kube-prometheus-stack-grafana-datasource`) to restore service immediately, this PR's content matches that edit exactly — merging it just makes the cluster's actual state match git again, no double-application risk.
