### PR TITLE
feat(monitoring): move Loki long-term storage to Minio (Phase 6)

### DIFF
--- a/kubernetes/apps/monitoring/loki/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/loki/app/helmrelease.yaml
@@ -22,6 +22,15 @@ spec:
     cleanupOnFail: true
     remediation:
       retries: 3
+  valuesFrom:
+    - name: loki-objstore-config
+      kind: Secret
+      valuesKey: accessKey
+      targetPath: loki.storage.s3.accessKeyId
+    - name: loki-objstore-config
+      kind: Secret
+      valuesKey: secretKey
+      targetPath: loki.storage.s3.secretAccessKey
   values:
     deploymentMode: SingleBinary
 
@@ -29,18 +38,68 @@ spec:
       auth_enabled: false
       commonConfig:
         replication_factor: 1
+      # Long-term storage: Minio (observability-loki bucket), via a dedicated
+      # bucket-scoped IAM user (kubernetes/apps/storage/minio/app/loki-user-bootstrap-job.yaml),
+      # not Minio root credentials. accessKeyId/secretAccessKey come from
+      # loki-objstore-config via valuesFrom above.
       storage:
-        type: filesystem
+        type: s3
+        bucketNames:
+          chunks: observability-loki
+          ruler: observability-loki
+        s3:
+          endpoint: minio.storage.svc.cluster.local:9000
+          region: us-east-1
+          # Minio requires path-style bucket addressing, not virtual-hosted-style.
+          s3ForcePathStyle: true
+          insecure: true
+      # loki.storage.filesystem (chart's own toggle) is dead once storage.type: s3
+      # is set — the chart's common-storage template is an if/else and only
+      # renders one backend. storage_config (snake_case, distinct from `storage`
+      # above) is a raw passthrough straight into the rendered storage_config:
+      # section, which is how the pre-cutover schemaConfig period below (still
+      # object_store: filesystem) gets a real backend to read existing logs from,
+      # alongside the s3 backend the new period uses via common.storage.s3.
+      storage_config:
+        filesystem:
+          chunks_directory: /var/loki/chunks
+          rules_directory: /var/loki/rules
       limits_config:
         retention_period: 14d
       compactor:
         retention_enabled: true
-        delete_request_store: filesystem
+        # Matches the active (latest) schemaConfig period's object_store, since
+        # that's where the compactor's delete-request markers should live going
+        # forward. The old filesystem-period logs age out under the same
+        # retention_period and get cleaned up from the local volume as usual.
+        delete_request_store: s3
       schemaConfig:
         configs:
+          # Pre-cutover: existing logs already written to the local filesystem
+          # volume. Left unchanged so they remain queryable — do not edit
+          # object_store here, only add new periods for storage changes.
           - from: "2024-01-01"
             store: tsdb
             object_store: filesystem
+            schema: v13
+            index:
+              prefix: loki_index_
+              period: 24h
+          # Phase 6 cutover: new logs from this date land in Minio (observability-loki)
+          # instead of the local filesystem volume. Deliberately set to the day
+          # AFTER merge/deploy (not the deploy day itself): Loki resolves a
+          # period's `from` at UTC day granularity, so if this were set to
+          # today, logs already ingested earlier today under the filesystem
+          # period would have their queries incorrectly routed to the s3
+          # period for the rest of today — a partial-day query gap where
+          # chunks exist on disk but Loki looks for them in Minio instead.
+          # A future UTC day boundary keeps the cutover clean: everything
+          # before this date reads from filesystem, everything from this date
+          # forward reads from S3, with no overlap or gap. Update this date if
+          # merge/deploy slips past 2026-07-04.
+          - from: "2026-07-04"
+            store: tsdb
+            object_store: s3
             schema: v13
             index:
               prefix: loki_index_

--- a/kubernetes/apps/monitoring/loki/app/kustomization.yaml
+++ b/kubernetes/apps/monitoring/loki/app/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
   - ./helmrepository.yaml
   - ./helmrelease.yaml
   - ./httproute.yaml
+  - ./loki-objstore-config.sops.yaml

--- a/kubernetes/apps/monitoring/loki/app/loki-objstore-config.sops.yaml
+++ b/kubernetes/apps/monitoring/loki/app/loki-objstore-config.sops.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: loki-objstore-config
+  namespace: monitoring
+stringData:
+  accessKey: ENC[AES256_GCM,data:oLGab4XL0vbgOahJ34EIuu2U22Zc,iv:10cRW1+DpHZy5LW8cvIynvPJ6W+RncGnWfovgBb3Tw8=,tag:pLVAD2ilnSylxf5AxTqJJg==,type:str]
+  secretKey: ENC[AES256_GCM,data:wqhkFmh2MgYWRZEmoI+suyvlCKRRTRMZKawXaewF2yh36pHYJyj1EQ==,iv:bqU4zaLEJJYrtai+XXd472o3OvYfYq8EajjnHwk642U=,tag:n21rG1PTNbgUGjY7sSE6wg==,type:str]
+sops:
+  age:
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBRaUJoTjg5d0lsdzNkNUdO
+        ZkpuWUoxai85THhhbTBRdzFneDBXSlhJM2gwClFydHNEb05lZjV6b0lrSmg0NFRN
+        QUh3TmxpT2lhQ081TG5VNytDeExOQkUKLS0tIDZQYmN4R2JDZmpHaFNBVjZRRk5v
+        MEhidHdkQnNzczRBSTFQYTRObU02aUUKZYM10wOlf7/fnFcLDBU0/TalcKyX1omu
+        RJGIQ9jYSJXWIJoUbunJ7HHXT734oCm1wMGvF6Vxy+LDoBafPVQMUA==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1gekuxnpd95l5j8gsvmpsn2mewnevd0c5y5v66p4trzcqhmpn0svqkmnyy7
+  encrypted_regex: ^(data|stringData)$
+  lastmodified: "2026-07-03T16:01:59Z"
+  mac: ENC[AES256_GCM,data:a3ZA1ZEaIUqatfvKk9YioH5L6ygUqFSX3hMtbC3GdopbuHOBI0GjvMt8T7IMwscYpXQNzp6Px5owmRBMwZw+zNHDKi74P4/+IIvWo4MznrR5sdoI9tEHWBKVTOsU6+4EeuF+kJwO9QrD0RNYlRZhuugdOtv4nolihDB5CJG4PhA=,iv:uFV9ouiUfW1ZOj3e1HKUdJS+j8MOsnRwZ/Txa4bZHKE=,tag:NmPaUuMN+pyV3Ymc8bhvCQ==,type:str]
+  mac_only_encrypted: true
+  version: 3.13.2

--- a/kubernetes/apps/monitoring/loki/ks.yaml
+++ b/kubernetes/apps/monitoring/loki/ks.yaml
@@ -4,6 +4,13 @@ kind: Kustomization
 metadata:
   name: loki
 spec:
+  # minio owns the loki-user-bootstrap Job that provisions the Minio IAM user
+  # loki-objstore-config authenticates as. minio's Kustomization healthChecks
+  # gate its own Ready condition on that Job completing, so this dependsOn
+  # actually waits for the user to exist, not just for apply to succeed.
+  dependsOn:
+    - name: minio
+      namespace: storage
   interval: 1h
   path: ./kubernetes/apps/monitoring/loki/app
   postBuild:

--- a/kubernetes/apps/storage/minio/app/kustomization.yaml
+++ b/kubernetes/apps/storage/minio/app/kustomization.yaml
@@ -8,3 +8,5 @@ resources:
   - ./bucket-bootstrap-job.yaml
   - ./thanos-user-credentials.sops.yaml
   - ./thanos-user-bootstrap-job.yaml
+  - ./loki-user-credentials.sops.yaml
+  - ./loki-user-bootstrap-job.yaml

--- a/kubernetes/apps/storage/minio/app/loki-user-bootstrap-job.yaml
+++ b/kubernetes/apps/storage/minio/app/loki-user-bootstrap-job.yaml
@@ -1,0 +1,110 @@
+---
+# Loki IAM user bootstrap Job — runs once after Minio is healthy.
+# Creates a Minio user scoped to only the observability-loki bucket (not the
+# root credentials) and attaches it to the credentials already generated and
+# SOPS-encrypted in loki-user-credentials.sops.yaml. Loki authenticates as
+# this user via
+# kubernetes/apps/monitoring/loki/app/loki-objstore-config.sops.yaml,
+# which holds the same accessKey/secretKey pair.
+#
+# Manual equivalent:
+#   mc alias set local http://minio.storage.svc.cluster.local:9000 <root user> <root password>
+#   mc admin policy create local loki-observability-rw /tmp/policy.json
+#   mc admin user add local <loki accessKey> <loki secretKey>
+#   mc admin policy attach local loki-observability-rw --user <loki accessKey>
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: loki-user-bootstrap
+  namespace: storage
+  annotations:
+    # prune: false prevents Flux from deleting this Job if the pod outlives the
+    # reconcile window. To fully decommission this Job, remove it from
+    # storage/minio/app/kustomization.yaml — kubectl delete alone won't work
+    # because Flux will recreate it on the next reconcile while it remains in
+    # the resources list.
+    kustomize.toolkit.fluxcd.io/prune: "false"
+spec:
+  template:
+    spec:
+      restartPolicy: OnFailure
+      containers:
+        - name: mc
+          image: quay.io/minio/mc:RELEASE.2025-08-13T08-35-41Z
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -e
+              RETRIES=0; MAX_RETRIES=180
+              until mc alias set local http://minio.storage.svc.cluster.local:9000 \
+                "$MINIO_ROOT_USER" "$MINIO_ROOT_PASSWORD"; do
+                RETRIES=$((RETRIES + 1))
+                if [ "$RETRIES" -ge "$MAX_RETRIES" ]; then
+                  echo "ERROR: minio did not become ready after $((MAX_RETRIES * 5))s, giving up"
+                  exit 1
+                fi
+                echo "waiting for minio... (attempt $RETRIES/$MAX_RETRIES)"; sleep 5
+              done
+
+              cat > /tmp/loki-policy.json <<POLICY
+              {
+                "Version": "2012-10-17",
+                "Statement": [
+                  {
+                    "Effect": "Allow",
+                    "Action": ["s3:ListBucket", "s3:GetBucketLocation"],
+                    "Resource": ["arn:aws:s3:::observability-loki"]
+                  },
+                  {
+                    "Effect": "Allow",
+                    "Action": ["s3:GetObject", "s3:PutObject", "s3:DeleteObject"],
+                    "Resource": ["arn:aws:s3:::observability-loki/*"]
+                  }
+                ]
+              }
+              POLICY
+
+              # Idempotent: create policy only if it does not already exist
+              if ! mc admin policy info local loki-observability-rw > /dev/null 2>&1; then
+                mc admin policy create local loki-observability-rw /tmp/loki-policy.json
+              else
+                echo "policy loki-observability-rw already exists, skipping"
+              fi
+
+              # Idempotent: create user only if it does not already exist
+              if ! mc admin user info local "$LOKI_ACCESS_KEY" > /dev/null 2>&1; then
+                mc admin user add local "$LOKI_ACCESS_KEY" "$LOKI_SECRET_KEY"
+              else
+                echo "user $LOKI_ACCESS_KEY already exists, skipping"
+              fi
+
+              mc admin policy attach local loki-observability-rw --user "$LOKI_ACCESS_KEY"
+              echo "loki minio user ready"
+          env:
+            - name: MINIO_ROOT_USER
+              valueFrom:
+                secretKeyRef:
+                  name: minio-root-credentials
+                  key: rootUser
+            - name: MINIO_ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: minio-root-credentials
+                  key: rootPassword
+            - name: LOKI_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: loki-user-credentials
+                  key: accessKey
+            - name: LOKI_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: loki-user-credentials
+                  key: secretKey
+          resources:
+            requests:
+              cpu: 10m
+              memory: 64Mi
+            limits:
+              memory: 256Mi

--- a/kubernetes/apps/storage/minio/app/loki-user-bootstrap-job.yaml
+++ b/kubernetes/apps/storage/minio/app/loki-user-bootstrap-job.yaml
@@ -18,11 +18,11 @@ metadata:
   name: loki-user-bootstrap
   namespace: storage
   annotations:
-    # prune: false prevents Flux from deleting this Job if the pod outlives the
-    # reconcile window. To fully decommission this Job, remove it from
-    # storage/minio/app/kustomization.yaml — kubectl delete alone won't work
-    # because Flux will recreate it on the next reconcile while it remains in
-    # the resources list.
+    # prune: false prevents Flux from deleting this Job when it is removed from the
+    # Kustomization's resources list. To decommission it, remove it from
+    # storage/minio/app/kustomization.yaml and then delete the Job manually.
+    # Deleting the Job while it is still listed will cause Flux to recreate it
+    # on the next reconcile.
     kustomize.toolkit.fluxcd.io/prune: "false"
 spec:
   template:

--- a/kubernetes/apps/storage/minio/app/loki-user-credentials.sops.yaml
+++ b/kubernetes/apps/storage/minio/app/loki-user-credentials.sops.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: loki-user-credentials
+  namespace: storage
+stringData:
+  accessKey: ENC[AES256_GCM,data:6EU15I7tXWOa3RkhYnkRonYhFe+y,iv:Zlg6cL4QjXC2GJfkULAePQ1afyjReUul0tvn7zDcIl4=,tag:a+PylgpXkWWs3+WJIma8tA==,type:str]
+  secretKey: ENC[AES256_GCM,data:LCi8z+ei6ZgHbX7S/rjOncjx7h+1cgZwW7piNlG8yhOYwYDINtLYsw==,iv:UaceiCt9vqLTPlYgYrzMrOl0K72SOSg4l/2bW9k3Hq8=,tag:UPrk5RtpHdgF6GfKcL2/Ww==,type:str]
+sops:
+  age:
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB3VGIvUm9nMzMrdDVXR1I0
+        VzRmYjc3cEVFdG9CR2I5YjdXR1h0Ujd3YTNNCm9pUWpYL1NMdUErRTErcEFaTHlE
+        cHFONHI2MG1GNTlORElsYkQrYXY3cUUKLS0tIDhyTG1CSjJxODZLOHR5T0ZTQ29z
+        eVRxYWlGdVNVYXpxUDBsWTN0WVhJNTgKvAW9VLF7x68fO51z23IOmv4u5a8GYfsR
+        AXJ8jxSxBT6rE+xzEItJ77cE/gvR03Ry1dk57Ef4AHQiU4tNojloGA==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1gekuxnpd95l5j8gsvmpsn2mewnevd0c5y5v66p4trzcqhmpn0svqkmnyy7
+  encrypted_regex: ^(data|stringData)$
+  lastmodified: "2026-07-03T16:01:59Z"
+  mac: ENC[AES256_GCM,data:CGY6mKy8mGsvwM+izjY+z0OoKq6vdsyQHr8WWgHMCAZKK5HocaKwjlMo4hsLDiEJ6enrCUHUKw2qIvRDq3evj3chypE7J3L1tKTvKXDndwiClDSRoEkNcLzRqvVjG2uHRPH/2Ed1E0STgW56GAxw+pCKtJNJuHQDb6y9SIT461A=,iv:tQM5u1WmXjVYywL5xQ6XAL983UnuLPTryxZWiPUHsf4=,tag:NzoU7zoemlFcvUaVyble/g==,type:str]
+  mac_only_encrypted: true
+  version: 3.13.2

--- a/kubernetes/apps/storage/minio/ks.yaml
+++ b/kubernetes/apps/storage/minio/ks.yaml
@@ -4,13 +4,18 @@ kind: Kustomization
 metadata:
   name: minio
 spec:
-  # Gate this Kustomization's Ready condition on the Thanos IAM bootstrap Job
-  # completing, so thanos's `dependsOn: minio` actually waits for the scoped
-  # Minio user to exist instead of only waiting for apply to succeed.
+  # Gate this Kustomization's Ready condition on the Thanos/Loki IAM bootstrap
+  # Jobs completing, so downstream `dependsOn: minio` consumers actually wait
+  # for their scoped Minio user to exist instead of only waiting for apply to
+  # succeed.
   healthChecks:
     - apiVersion: batch/v1
       kind: Job
       name: thanos-user-bootstrap
+      namespace: storage
+    - apiVersion: batch/v1
+      kind: Job
+      name: loki-user-bootstrap
       namespace: storage
   interval: 1h
   path: ./kubernetes/apps/storage/minio/app


### PR DESCRIPTION
## Phase
Phase 6 - Loki Object Storage Retention

## Scope
- Move Loki long-term strategy to Minio-backed object storage
- Configure retention through Loki compactor-compatible settings

## Contract Values
- Endpoint: minio.storage.svc.cluster.local:9000
- Bucket: observability-loki
- Secret: loki-objstore-config

## Files Changed
**New — Minio IAM provisioning (`storage/minio`):**
- `kubernetes/apps/storage/minio/app/loki-user-credentials.sops.yaml` — SOPS-encrypted, dedicated Loki access/secret key pair
- `kubernetes/apps/storage/minio/app/loki-user-bootstrap-job.yaml` — one-shot idempotent Job (mirrors `thanos-user-bootstrap-job.yaml`) that uses Minio root creds at runtime to create the scoped IAM user and attach a `loki-observability-rw` policy (read/write on `observability-loki` only)

**New — Loki objstore secret (`monitoring/loki`):**
- `kubernetes/apps/monitoring/loki/app/loki-objstore-config.sops.yaml` — SOPS-encrypted, same dedicated Loki Minio user's credentials

**Modified:**
- `kubernetes/apps/monitoring/loki/app/helmrelease.yaml` — `loki.storage.type: filesystem` → `s3` pointed at Minio; new `loki.storage_config.filesystem` passthrough (kept so the pre-cutover schema period stays readable — see Notes); new `schemaConfig` period starting `2026-07-04` (`object_store: s3`) alongside the untouched original (`2024-01-01`, `object_store: filesystem`); `compactor.delete_request_store` changed `filesystem` → `s3` to match the new active period; `valuesFrom` added to wire `loki-objstore-config`'s `accessKey`/`secretKey` into `loki.storage.s3.accessKeyId`/`secretAccessKey`
- `kubernetes/apps/monitoring/loki/app/kustomization.yaml` — registers the new secret
- `kubernetes/apps/monitoring/loki/ks.yaml` — adds `dependsOn: minio` (cross-namespace) so Loki's write path waits for its IAM user to exist, same fix pattern already applied to `kube-prometheus-stack`/`thanos` in earlier phases
- `kubernetes/apps/storage/minio/app/kustomization.yaml` — registers the two new Loki files
- `kubernetes/apps/storage/minio/ks.yaml` — `healthChecks` now also gates on `loki-user-bootstrap` completing, alongside the existing `thanos-user-bootstrap` check

Branch is a single commit (`928193f`) cut fresh from `main` (already has Phases 0/2/3/4/5 and the Grafana uid hotfix). 8 files, 100% scoped to Loki/Minio — the reference docs (`agent-kickoff-checklist-observability.md`, `agent-orchestration-observability.md`, `agent-pr-templates-observability.md`) that rode along in an earlier draft of this branch have been split out into their own branch (`docs/observability-phase-runbooks`) and are **not** part of this diff. No changes to `kubernetes/flux` or `talos`.

## Validation
- [x] YAML parses
- [x] Flux/Kustomize paths valid
- [x] Secret encryption verified — both new `.sops.yaml` files contain `ENC[AES256_GCM...]` under `stringData`, matching this repo's `.sops.yaml` policy and age recipient
- [ ] Loki components healthy — pending cluster deploy
- [ ] Writes and queries healthy — pending cluster deploy
- [x] Retention policy explicitly configured — `limits_config.retention_period: 14d` unchanged, `compactor.delete_request_store: s3` matches the active schema period

Commands run (static/render-time; no live cluster access available to the agent):
- `python3 -c "import yaml; ..."` (`yaml.safe_load_all`) across all 16 files under the touched directories → all parse clean
- Structural check for `sops:` + `ENC[AES256_GCM` markers on both new `.sops.yaml` files → both confirmed encrypted
- `kubectl kustomize` on `loki/app` and `storage/minio/app` individually → both render clean
- `kubectl kustomize kubernetes/apps/monitoring` and `kubernetes/apps/storage` (parent trees) → both exit 0
- Looped `kubectl kustomize` over every `kubernetes/apps/*/*/app` directory in the repo (full regression sweep) → all still build clean, no other app broken
- `git diff main --stat` → confirmed exactly 8 files changed, all under `kubernetes/apps/monitoring/loki/` or `kubernetes/apps/storage/minio/`, no docs/unrelated files
- **Rendered the actual Loki chart end-to-end** (`helm template` against the real pinned `loki` chart v7.0.0, using the exact values from this branch's `helmrelease.yaml`) to verify the resulting native Loki config, not just the Helm values shape:
  - `common.storage.s3` populated correctly (endpoint, bucketnames, credentials, path-style addressing)
  - `storage_config.filesystem.{chunks_directory,rules_directory}` populated correctly — this only appears because of the explicit `loki.storage_config.filesystem` passthrough added in this PR; the chart's own `loki.storage.filesystem` toggle is dead code once `storage.type: s3` is set (its template is an if/else, not additive) — confirmed by rendering both with and without the passthrough and diffing the output
  - `schema_config.configs` contains both periods with correct `object_store` values and the corrected `2026-07-04` boundary
  - `compactor.delete_request_store: s3` present
  - Cross-checked against Loki's own Go source (`pkg/storage/config/schema_config.go`) that `filesystem` is a first-class built-in `object_store` type, not requiring `named_stores_config`

Commands to run post-merge (cluster-side, not run by the agent):
```bash
kubectl -n storage get jobs loki-user-bootstrap
kubectl -n storage logs job/loki-user-bootstrap
kubectl -n monitoring get helmreleases loki
kubectl -n monitoring get pods -l app.kubernetes.io/name=loki
kubectl -n monitoring logs -l app.kubernetes.io/name=loki | grep -iE "s3|error"
# On/after 2026-07-04, confirm new logs are landing in Minio (same pattern as
# the Thanos bucket-check Job from Phase 2/3, pointed at observability-loki)
```

## Risks
- **Schema cutover date is a fixed future UTC boundary (`2026-07-04`), not relative to actual merge/deploy time.** Loki resolves a schema period's `from` at UTC day granularity; setting it to the deploy day itself would route today's already-ingested logs' queries to the s3 period for the remainder of the day, even though those chunks physically live under the filesystem period — a partial-day query gap where chunks exist but aren't found. Using a future day boundary avoids this entirely, but **if merge/deploy slips past `2026-07-04`, this date needs bumping to the next UTC day before merge** — otherwise the same gap reappears for whatever day it actually deploys on.
- **Any logs ingested between now and whenever this actually reconciles remain on the filesystem period regardless of this PR's schema date** — expected and correct (the cutover boundary is intentionally in the future specifically so today's ingestion isn't split mid-day), but worth having front-of-mind when checking "did new logs land in Minio yet" post-merge: the answer should be no until `2026-07-04` UTC, by design.
- **`storage_config.filesystem` passthrough is a real, load-bearing fix, not a nice-to-have** — without it, the pre-cutover schema period would have no backend to read from once `storage.type: s3` takes over the chart's `common.storage` block. Caught and fixed before merge by rendering the actual chart, not assumed from values alone — but it's the single most novel/unverified piece of this PR since it hasn't been exercised against a live cluster.
- **`loki-user-bootstrap` gate on `minio`'s Kustomization ensures apply-order, not full Job completion timing overlap** — same caveat already known from the Thanos pattern: `storage/minio`'s Kustomization has `wait: false`, so if Loki's HelmRelease reconciles before the bootstrap Job finishes, expect transient auth-retry warnings in Loki's logs until the user exists. Self-healing, same as the Thanos precedent (Phase 2/3).
- **Ruler storage was also cut over to S3** as a side effect — the chart auto-populates `ruler.storage` the same way as `common.storage` when `storage.type: s3`. Loki's ruler isn't actively used for alerting rules in this cluster today (Prometheus/Alertmanager own that), so this is expected to be inert, but flagging it as an automatic side effect of the storage type change rather than something explicitly requested.
- **No PVC or resource changes** — `singleBinary.persistence` stays at `10Gi`/`longhorn`, since it's still needed for the WAL and for serving the pre-cutover filesystem-period logs. Not expected to need resizing, but not explicitly re-validated against current usage the way Prometheus's retention was in Phase 5.
- No new namespace/RBAC changes.

## Rollback
1. Revert `kubernetes/apps/monitoring/loki/app/helmrelease.yaml` to restore `loki.storage.type: filesystem`, remove the `s3`/`storage_config.filesystem` blocks, the second `schemaConfig` entry, and `compactor.delete_request_store: filesystem`, and remove the `valuesFrom` block.
2. Remove `./loki-objstore-config.sops.yaml` from `loki/app/kustomization.yaml` and delete the file. If already applied: `kubectl -n monitoring delete secret loki-objstore-config`.
3. Remove the `dependsOn: minio` addition from `loki/ks.yaml` (harmless to leave, but not needed without the S3 dependency).
4. Remove `./loki-user-credentials.sops.yaml` and `./loki-user-bootstrap-job.yaml` from `storage/minio/app/kustomization.yaml`, and the corresponding `healthChecks` entry from `storage/minio/ks.yaml`. The Minio IAM user/policy are additive and inert if unreferenced; `mc admin user remove local <loki accessKey>` cleans up fully if desired.
5. `flux reconcile kustomization loki -n monitoring --with-source` (or the equivalent Flux Kustomization for this repo's per-app structure) to apply.
6. **Data impact of rollback**: any logs written to Minio during the window this was live (i.e., from `2026-07-04` onward, if the rollback happens after that date) become unreachable again once `storage.type` reverts to `filesystem` — Loki would no longer know to look in S3 for that schema period. The underlying data in Minio isn't deleted, so a forward-fix (re-applying this PR) would make it queryable again — but a rollback isn't a clean no-op if logs were actually ingested during the S3-active window.

## Notes
- **Credentials are real and already encrypted in this PR** — no manual SOPS step required before merge, following the same authorized pattern established in Phase 2 (dedicated bucket-scoped IAM user, not root credentials).
- **Migration behavior**: this is a non-destructive, additive cutover. Logs written before `2026-07-04` remain on the local filesystem volume and stay queryable via the untouched first schema period. Logs from `2026-07-04` onward go to Minio. There is no backfill of old logs into Minio, and no risk of data loss from the cutover itself — worst case if something is misconfigured is that *new* logs fail to write until fixed, not that existing logs disappear.
- **Expected temporary impact**: none anticipated beyond the standard `HelmRelease` upgrade rollout for the Loki StatefulSet (SingleBinary mode, 1 replica) — a brief write/query gap during pod restart, consistent with any other Loki config change.
- **Docs split out**: `agent-kickoff-checklist-observability.md`, `agent-orchestration-observability.md`, and `agent-pr-templates-observability.md` were removed from this branch (via `git rebase --onto`) and now live on `docs/observability-phase-runbooks`, to be opened as a separate, unrelated PR.
