### PR TITLE
feat(minio): add per-bucket quotas with quota alerting and dashboard

### DIFF
--- a/kubernetes/apps/monitoring/kube-prometheus-stack/app/grafana-dashboard-minio.yaml
+++ b/kubernetes/apps/monitoring/kube-prometheus-stack/app/grafana-dashboard-minio.yaml
@@ -1,0 +1,155 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-dashboard-minio
+  namespace: monitoring
+  labels:
+    grafana_dashboard: "1"
+data:
+  minio-overview.json: |
+    {
+      "annotations": {"list": []},
+      "editable": true,
+      "graphTooltip": 1,
+      "panels": [
+        {
+          "id": 1,
+          "type": "stat",
+          "title": "Thanos Bucket Quota Used",
+          "gridPos": {"h": 4, "w": 6, "x": 0, "y": 0},
+          "targets": [
+            {
+              "expr": "minio_bucket_usage_total_bytes{bucket=\"observability-thanos\"} / minio_bucket_quota_total_bytes{bucket=\"observability-thanos\"}",
+              "legendFormat": "used"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "unit": "percentunit",
+              "min": 0,
+              "max": 1,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {"color": "green", "value": null},
+                  {"color": "yellow", "value": 0.70},
+                  {"color": "red", "value": 0.90}
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "options": {"reduceOptions": {"calcs": ["lastNotNull"]}, "colorMode": "background"}
+        },
+        {
+          "id": 2,
+          "type": "stat",
+          "title": "Loki Bucket Quota Used",
+          "gridPos": {"h": 4, "w": 6, "x": 6, "y": 0},
+          "targets": [
+            {
+              "expr": "minio_bucket_usage_total_bytes{bucket=\"observability-loki\"} / minio_bucket_quota_total_bytes{bucket=\"observability-loki\"}",
+              "legendFormat": "used"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "unit": "percentunit",
+              "min": 0,
+              "max": 1,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {"color": "green", "value": null},
+                  {"color": "yellow", "value": 0.70},
+                  {"color": "red", "value": 0.90}
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "options": {"reduceOptions": {"calcs": ["lastNotNull"]}, "colorMode": "background"}
+        },
+        {
+          "id": 3,
+          "type": "stat",
+          "title": "Cluster Capacity Used",
+          "gridPos": {"h": 4, "w": 6, "x": 12, "y": 0},
+          "targets": [
+            {
+              "expr": "1 - (minio_cluster_capacity_usable_free_bytes / minio_cluster_capacity_usable_total_bytes)",
+              "legendFormat": "used"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "unit": "percentunit",
+              "min": 0,
+              "max": 1,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {"color": "green", "value": null},
+                  {"color": "yellow", "value": 0.70},
+                  {"color": "red", "value": 0.85}
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "options": {"reduceOptions": {"calcs": ["lastNotNull"]}, "colorMode": "background"}
+        },
+        {
+          "id": 4,
+          "type": "stat",
+          "title": "Drives Offline",
+          "gridPos": {"h": 4, "w": 6, "x": 18, "y": 0},
+          "targets": [
+            {"expr": "minio_cluster_drive_offline_total", "legendFormat": "offline"}
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "unit": "none",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {"color": "green", "value": null},
+                  {"color": "red", "value": 1}
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "options": {"reduceOptions": {"calcs": ["lastNotNull"]}, "colorMode": "background"}
+        },
+        {
+          "id": 5,
+          "type": "timeseries",
+          "title": "Bucket Usage vs Quota",
+          "gridPos": {"h": 8, "w": 24, "x": 0, "y": 4},
+          "targets": [
+            {"expr": "minio_bucket_usage_total_bytes{bucket=\"observability-thanos\"}", "legendFormat": "thanos used"},
+            {"expr": "minio_bucket_quota_total_bytes{bucket=\"observability-thanos\"}", "legendFormat": "thanos quota"},
+            {"expr": "minio_bucket_usage_total_bytes{bucket=\"observability-loki\"}", "legendFormat": "loki used"},
+            {"expr": "minio_bucket_quota_total_bytes{bucket=\"observability-loki\"}", "legendFormat": "loki quota"}
+          ],
+          "fieldConfig": {
+            "defaults": {"min": 0, "unit": "bytes", "custom": {"lineWidth": 2, "fillOpacity": 10}},
+            "overrides": [
+              {
+                "matcher": {"id": "byRegexp", "options": "/quota/"},
+                "properties": [{"id": "custom.lineStyle", "value": {"dash": [10, 10]}}]
+              }
+            ]
+          }
+        }
+      ],
+      "schemaVersion": 39,
+      "style": "dark",
+      "tags": ["minio", "storage", "thanos", "loki"],
+      "templating": {"list": []},
+      "time": {"from": "now-30d", "to": "now"},
+      "title": "Minio Overview",
+      "version": 1
+    }

--- a/kubernetes/apps/monitoring/kube-prometheus-stack/app/kustomization.yaml
+++ b/kubernetes/apps/monitoring/kube-prometheus-stack/app/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
   - ./helmrelease-crds.yaml
   - ./helmrelease.yaml
   - ./grafana-dashboard-n8n.yaml
+  - ./grafana-dashboard-minio.yaml
   - ./grafana-dashboard-longhorn.yaml
   - ./grafana-dashboard-hosts.yaml
   - ./grafana-dashboard-apiserver-watch-cache.yaml

--- a/kubernetes/apps/monitoring/kube-prometheus-stack/app/prometheusrule-minio.yaml
+++ b/kubernetes/apps/monitoring/kube-prometheus-stack/app/prometheusrule-minio.yaml
@@ -66,3 +66,27 @@ spec:
           annotations:
             summary: Minio is returning S3 server errors
             description: Minio has served 5xx errors to S3 clients (Thanos sidecar/compactor/store-gateway) over the last 10 minutes.
+
+        - alert: MinioBucketQuotaApproaching
+          # `and minio_bucket_quota_total_bytes > 0` guards against divide-by-zero
+          # for any bucket that never gets a quota set.
+          expr: |
+            (minio_bucket_usage_total_bytes / minio_bucket_quota_total_bytes) > 0.70
+            and minio_bucket_quota_total_bytes > 0
+          for: 30m
+          labels:
+            severity: warning
+          annotations:
+            summary: Minio bucket is approaching its quota
+            description: Bucket {{ $labels.bucket }} has been above 70% of its configured quota for 30 minutes. Growing the PVC or raising the quota is worth planning now, before writes start failing.
+
+        - alert: MinioBucketQuotaCritical
+          expr: |
+            (minio_bucket_usage_total_bytes / minio_bucket_quota_total_bytes) > 0.90
+            and minio_bucket_quota_total_bytes > 0
+          for: 15m
+          labels:
+            severity: critical
+          annotations:
+            summary: Minio bucket is nearly at its quota
+            description: Bucket {{ $labels.bucket }} has been above 90% of its configured quota for 15 minutes. Writes to this bucket (Thanos block uploads or Loki chunks) will start failing once the quota is hit.

--- a/kubernetes/apps/storage/minio/app/bucket-quota-bootstrap-job.yaml
+++ b/kubernetes/apps/storage/minio/app/bucket-quota-bootstrap-job.yaml
@@ -1,0 +1,70 @@
+---
+# Bucket quota bootstrap Job — runs once after Minio is healthy.
+# Sets a hard quota per bucket so a runaway write pattern (e.g. a cardinality
+# explosion in Thanos) fails writes instead of filling the shared 50Gi PVC and
+# taking the whole node down.
+#
+# These are backstop values, not a capacity plan: the Thanos compactor's own
+# retention (30d raw + 90d/5m + 1y/1h — see monitoring/thanos/app/helmrelease.yaml)
+# can plausibly need more than 50Gi total under normal operation, so a tightly
+# tuned quota risks rejecting legitimate writes. Revisit both the quota and the
+# PVC size once minio_bucket_usage_total_bytes (scraped via probe-bucket-metrics.yaml)
+# has a few weeks of real data.
+#
+# observability-loki is currently unused (Loki runs with storage.type: filesystem,
+# see monitoring/loki/app/helmrelease.yaml) — its quota here is just a guard
+# against silent growth if that ever changes, not a tuned value.
+#
+# Manual equivalent:
+#   mc admin bucket quota local/observability-thanos --size 45GiB
+#   mc admin bucket quota local/observability-loki --size 2GiB
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: minio-bucket-quota-bootstrap
+  namespace: storage
+  annotations:
+    # Remove this job from Flux management after first successful run
+    # by deleting it: kubectl -n storage delete job minio-bucket-quota-bootstrap
+    kustomize.toolkit.fluxcd.io/prune: "false"
+spec:
+  template:
+    spec:
+      restartPolicy: OnFailure
+      containers:
+        - name: mc
+          image: quay.io/minio/mc:RELEASE.2025-08-13T08-35-41Z
+          command:
+            - /bin/sh
+            - -c
+            - |
+              RETRIES=0; MAX_RETRIES=180
+              until mc alias set local http://minio.storage.svc.cluster.local:9000 \
+                "$MINIO_ROOT_USER" "$MINIO_ROOT_PASSWORD"; do
+                RETRIES=$((RETRIES + 1))
+                if [ "$RETRIES" -ge "$MAX_RETRIES" ]; then
+                  echo "ERROR: minio did not become ready after $((MAX_RETRIES * 5))s, giving up"
+                  exit 1
+                fi
+                echo "waiting for minio... (attempt $RETRIES/$MAX_RETRIES)"; sleep 5
+              done
+              mc admin bucket quota local/observability-thanos --size 45GiB
+              mc admin bucket quota local/observability-loki --size 2GiB
+              echo "bucket quotas set"
+          env:
+            - name: MINIO_ROOT_USER
+              valueFrom:
+                secretKeyRef:
+                  name: minio-root-credentials
+                  key: rootUser
+            - name: MINIO_ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: minio-root-credentials
+                  key: rootPassword
+          resources:
+            requests:
+              cpu: 10m
+              memory: 64Mi
+            limits:
+              memory: 256Mi

--- a/kubernetes/apps/storage/minio/app/bucket-quota-bootstrap-job.yaml
+++ b/kubernetes/apps/storage/minio/app/bucket-quota-bootstrap-job.yaml
@@ -24,8 +24,11 @@ metadata:
   name: minio-bucket-quota-bootstrap
   namespace: storage
   annotations:
-    # Remove this job from Flux management after first successful run
-    # by deleting it: kubectl -n storage delete job minio-bucket-quota-bootstrap
+    # prune: false prevents Flux from auto-deleting this Job if it is ever
+    # removed from kustomization.yaml (completed Job acts as an audit record).
+    # To fully remove: first delete this resource from kustomization.yaml and
+    # push to Git, then manually clean up the completed Job:
+    #   kubectl -n storage delete job minio-bucket-quota-bootstrap
     kustomize.toolkit.fluxcd.io/prune: "false"
 spec:
   template:
@@ -38,6 +41,7 @@ spec:
             - /bin/sh
             - -c
             - |
+              set -e
               RETRIES=0; MAX_RETRIES=180
               until mc alias set local http://minio.storage.svc.cluster.local:9000 \
                 "$MINIO_ROOT_USER" "$MINIO_ROOT_PASSWORD"; do

--- a/kubernetes/apps/storage/minio/app/kustomization.yaml
+++ b/kubernetes/apps/storage/minio/app/kustomization.yaml
@@ -6,5 +6,7 @@ resources:
   - ./helmrelease.yaml
   - ./minio-root-credentials.sops.yaml
   - ./bucket-bootstrap-job.yaml
+  - ./bucket-quota-bootstrap-job.yaml
+  - ./probe-bucket-metrics.yaml
   - ./thanos-user-credentials.sops.yaml
   - ./thanos-user-bootstrap-job.yaml

--- a/kubernetes/apps/storage/minio/app/probe-bucket-metrics.yaml
+++ b/kubernetes/apps/storage/minio/app/probe-bucket-metrics.yaml
@@ -1,0 +1,28 @@
+---
+# The Minio chart's own ServiceMonitor/Probe (enabled via helmrelease.yaml
+# metrics.serviceMonitor) only cover /minio/v2/metrics/cluster and
+# /minio/v2/metrics/node — it doesn't scrape /minio/v2/metrics/bucket, which
+# is the only endpoint that exposes minio_bucket_usage_total_bytes and
+# minio_bucket_quota_total_bytes (both labeled by `bucket`). This Probe fills
+# that gap so bucket-quota alerts and dashboards have something to query.
+# Mirrors the chart's own minio-cluster Probe: MINIO_PROMETHEUS_AUTH_TYPE is
+# "public" (see helmrelease.yaml), so no bearer token is needed, and the
+# "prober" is Minio itself rather than a real blackbox-exporter — Minio
+# ignores the injected target param and just returns the requested path.
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
+  name: minio-bucket
+  namespace: storage
+  labels:
+    app: minio
+spec:
+  jobName: minio-bucket
+  prober:
+    url: minio.storage:9000
+    path: /minio/v2/metrics/bucket
+    scheme: http
+  targets:
+    staticConfig:
+      static:
+        - minio.storage


### PR DESCRIPTION
## Summary
- `bucket-quota-bootstrap-job.yaml`: sets a hard `mc admin bucket quota` on both buckets (`observability-thanos` 45GiB, `observability-loki` 2GiB) so a runaway write pattern fails writes instead of filling the shared 50Gi PVC and taking Minio down.
- `probe-bucket-metrics.yaml`: the Minio chart's bundled ServiceMonitor/Probe (enabled in #268) only cover `/metrics/cluster` and `/metrics/node` — neither exposes `minio_bucket_usage_total_bytes` or `minio_bucket_quota_total_bytes`. Adds a Probe for `/minio/v2/metrics/bucket` so those are actually scraped.
- `prometheusrule-minio.yaml`: `MinioBucketQuotaApproaching` (>70%, warning, 30m) and `MinioBucketQuotaCritical` (>90%, critical, 15m).
- `grafana-dashboard-minio.yaml`: per-bucket quota headroom, overall cluster capacity, drives-offline, and a usage-vs-quota trend panel.

### On the quota numbers
These are deliberately generous backstops, not a tuned capacity plan. The Thanos compactor's own retention (30d raw + 90d at 5m + 1y at 1h — see `monitoring/thanos/app/helmrelease.yaml`) can plausibly need more than the entire 50Gi PVC under *normal* operation: 30 days of raw blocks alone is roughly 55-80GB at this repo's own documented ~2.7GB/day ingestion rate (see the retention comment in `kube-prometheus-stack/app/helmrelease.yaml`). A tightly tuned quota would risk rejecting legitimate Thanos writes, not just catching abnormal growth.

`observability-loki`'s quota is a placeholder — Loki currently runs with `storage.type: filesystem`, not S3, so that bucket is unused today.

**Follow-up needed, not done here**: once `minio_bucket_usage_total_bytes` has a few weeks of real data, revisit both the quota values and the Minio PVC size (currently 50Gi, `longhorn-2-no-backup`, `allowVolumeExpansion: true`) together — growing the PVC is the more likely real fix for the retention math above a quota adjustment alone.

## Test plan
- [x] `kubectl kustomize kubernetes/apps/storage/minio/app` builds cleanly
- [x] `kubectl kustomize kubernetes/apps/monitoring/kube-prometheus-stack/app` builds cleanly
- [x] Dashboard JSON parses (`json.loads` round-trip)
- [ ] After Flux reconciles: confirm `mc admin bucket quota local/observability-thanos` shows 45GiB and hasn't rejected any writes
- [ ] Confirm `minio_bucket_usage_total_bytes` and `minio_bucket_quota_total_bytes` appear in Prometheus (new `minio-bucket` Probe target)

🤖 Generated with [Claude Code](https://claude.com/claude-code)