### PR TITLE
fix(loki): stabilize HelmRelease by keeping delete request store on filesystem

### DIFF
--- a/kubernetes/apps/monitoring/loki/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/loki/app/helmrelease.yaml
@@ -68,11 +68,10 @@ spec:
         retention_period: 14d
       compactor:
         retention_enabled: true
-        # Matches the active (latest) schemaConfig period's object_store, since
-        # that's where the compactor's delete-request markers should live going
-        # forward. The old filesystem-period logs age out under the same
-        # retention_period and get cleaned up from the local volume as usual.
-        delete_request_store: s3
+        # Keep delete-request markers on the local volume until the S3 cutover
+        # has been validated in-cluster; this avoids hard-failing startup if
+        # object storage connectivity is degraded during rollout.
+        delete_request_store: filesystem
       schemaConfig:
         configs:
           # Pre-cutover: existing logs already written to the local filesystem


### PR DESCRIPTION
## Summary
This PR fixes a Loki HelmRelease upgrade loop where upgrades stalled on the Loki StatefulSet and repeatedly remediated via rollback.

The change keeps `compactor.delete_request_store` on `filesystem` during the S3 migration window, instead of requiring S3-backed delete markers immediately.

## Scope
Phase-scoped, single-file change:
- `kubernetes/apps/monitoring/loki/app/helmrelease.yaml`

## Change Details
- Switched:
  - `loki.compactor.delete_request_store: s3`
  - to `loki.compactor.delete_request_store: filesystem`
- Kept migration schema periods intact.

## Validation
Commands run:
```bash
kustomize build kubernetes/apps/monitoring/loki/app
```
Result:
- Render succeeded (`kustomize build ok`).

Runtime diagnosis performed before fix (cluster-side):
- `helmrelease/loki` showed repeated `UpgradeFailed` / `RetriesExceeded` with rollback remediation.
- Loki pod rollout repeatedly hit readiness/backoff windows during attempted upgrade and then rolled back.

## Risks / Assumptions
- Delete-request markers remain local until explicitly switched back to S3.
- This is a stabilization step; final S3 compactor marker storage can be re-enabled after object-store cutover is verified stable.

## Rollback
To revert this behavior:
1. Restore `delete_request_store: s3` in `kubernetes/apps/monitoring/loki/app/helmrelease.yaml`.
2. Reconcile Flux:
```bash
flux reconcile source git flux-system -n flux-system
flux reconcile kustomization loki -n monitoring --with-source
```
3. Verify:
```bash
kubectl -n monitoring get helmrelease loki
kubectl -n monitoring get pods -l app.kubernetes.io/instance=loki
```

## Dependency Order
- No new cross-phase dependency introduced.
- Change is safe as an isolated Loki stabilization fix.
