### PR TITLE
feat(kube-prometheus-stack): route Alertmanager alerts to Telegram

### DIFF
--- a/kubernetes/apps/monitoring/kube-prometheus-stack/app/alertmanager-telegram-secret.sops.yaml
+++ b/kubernetes/apps/monitoring/kube-prometheus-stack/app/alertmanager-telegram-secret.sops.yaml
@@ -1,8 +1,5 @@
 # yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/v1/secret_v1.json
-# NOT YET ENCRYPTED — placeholder only.
-# Before committing: replace ENC_PLACEHOLDER with your real Telegram bot token
-# from @BotFather, then encrypt in place with:
-#   sops -e -i kubernetes/apps/monitoring/kube-prometheus-stack/app/alertmanager-telegram-secret.sops.yaml
+# SOPS-encrypted Secret holding the Telegram bot token for Alertmanager (key: stringData.bot-token).
 apiVersion: v1
 kind: Secret
 metadata:

--- a/kubernetes/apps/monitoring/kube-prometheus-stack/app/alertmanager-telegram-secret.sops.yaml
+++ b/kubernetes/apps/monitoring/kube-prometheus-stack/app/alertmanager-telegram-secret.sops.yaml
@@ -1,0 +1,28 @@
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/v1/secret_v1.json
+# NOT YET ENCRYPTED — placeholder only.
+# Before committing: replace ENC_PLACEHOLDER with your real Telegram bot token
+# from @BotFather, then encrypt in place with:
+#   sops -e -i kubernetes/apps/monitoring/kube-prometheus-stack/app/alertmanager-telegram-secret.sops.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: alertmanager-telegram-secret
+  namespace: monitoring
+stringData:
+  bot-token: ENC[AES256_GCM,data:TJ9am5Ygblr8SuNcsvcctZu3fIQG9qCte4Lrn6fbU11OMQYkyhUMivuTvGl28g==,iv:VS8bCE4WnWk+l9gKLRkOpDfHZq9NRglsoZ1iLep650I=,tag:Qr0NJosAs61aZRyehbJN2g==,type:str]
+sops:
+  age:
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAwMWdWN0pOa3NBYTVJYzgv
+        S3VEaXBwYkxJbmkyZmxQcHhxT1F2UWw0b2s4CjhBTE1HQ3hTUW9yNVAwUG1YL1Zz
+        N3lRVDREa3JPd0Rac1lZczJjVFE4MTgKLS0tIGJWS0hSVng3MFpGeHF4b05VbTBH
+        dEQyNWtQR3hnM1FuUS90SmFFVm9uNGcKSRgTNr1rmtrbUVwRDLXo/JMXBHwJoamq
+        Ezvifr3uSW0moaLLJSJWjT1s7wuE+jmrvcQnCFkq+HvwRlEsnflFTA==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1gekuxnpd95l5j8gsvmpsn2mewnevd0c5y5v66p4trzcqhmpn0svqkmnyy7
+  encrypted_regex: ^(data|stringData)$
+  lastmodified: "2026-07-05T21:34:16Z"
+  mac: ENC[AES256_GCM,data:JkOjiusn6ireSCuKx2uGX9H+IizBqW1SxOcioSyc/qo7U+HAGMaB/NAE6aB2CCGTjN4ZZMaATCadGf7pZlRKp9EUF6GmMoZLWtjXz5XMMuL+mf+fVh5qnT0N0Vv5QFQuMWWvYELk7lMHzQ6nmZdEjI0gqrpFS3T+pk1epFhgk+c=,iv:UiE5RpPMhzQ8sOy5aYZkexlB6iE5nl/sVRzho4JMIxo=,tag:QBhXVA7i/U+0qofv80Qs8A==,type:str]
+  mac_only_encrypted: true
+  version: 3.13.2

--- a/kubernetes/apps/monitoring/kube-prometheus-stack/app/alertmanagerconfig.yaml
+++ b/kubernetes/apps/monitoring/kube-prometheus-stack/app/alertmanagerconfig.yaml
@@ -1,0 +1,22 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/monitoring.coreos.com/alertmanagerconfig_v1alpha1.json
+apiVersion: monitoring.coreos.com/v1alpha1
+kind: AlertmanagerConfig
+metadata:
+  name: telegram
+  namespace: monitoring
+spec:
+  route:
+    receiver: telegram
+    groupBy: ["alertname"]
+    groupWait: 30s
+    groupInterval: 5m
+    repeatInterval: 4h
+  receivers:
+    - name: telegram
+      telegramConfigs:
+        - botToken:
+            name: alertmanager-telegram-secret
+            key: bot-token
+          chatID: 8854064758
+          sendResolved: true

--- a/kubernetes/apps/monitoring/kube-prometheus-stack/app/kustomization.yaml
+++ b/kubernetes/apps/monitoring/kube-prometheus-stack/app/kustomization.yaml
@@ -25,3 +25,5 @@ resources:
   - ./httproute-prometheus.yaml
   - ./grafana-secret.sops.yaml
   - ./thanos-objstore-config.sops.yaml
+  - ./alertmanagerconfig.yaml
+  - ./alertmanager-telegram-secret.sops.yaml


### PR DESCRIPTION
## Summary
- Adds an `AlertmanagerConfig` CR (`alertmanagerconfig.yaml`) with a catch-all route to a Telegram receiver — all firing/resolved alerts notify, with `sendResolved: true` so you get an all-clear message too.
- Adds a SOPS-encrypted Secret (`alertmanager-telegram-secret.sops.yaml`) holding the Telegram bot token, referenced via `secretKeyRef` from the `AlertmanagerConfig`.
- No changes to `helmrelease.yaml` needed — the chart's default `alertmanagerConfigSelector: {}` / `alertmanagerConfigNamespaceSelector: {}` already discover any `AlertmanagerConfig` cluster-wide, so it's picked up automatically.
- Chat ID (`8854064758`, a private DM chat, not secret) is set directly in the CR.

## Why
User's alerting stack (Prometheus/Alertmanager/Grafana) currently has no notification receivers wired up at all — alerts fire into the void. Telegram was chosen as the fastest channel for the user to respond to.

## Test plan
- [x] YAML parses and kustomization lists both new files
- [ ] `kustomize build kubernetes/apps/monitoring/kube-prometheus-stack/app` (kustomize binary not available in this worktree)
- [ ] `task build path=monitoring/kube-prometheus-stack` (needs local age.key/kubeconfig)
- [ ] Flux Local CI diff on this PR
- [ ] After merge: confirm Alertmanager reconciles the `AlertmanagerConfig` and a test alert produces a Telegram message from `KoopmansAlertbot`

🤖 Generated with [Claude Code](https://claude.com/claude-code)