### PR TITLE
fix(minio): make bootstrap jobs fail loudly and bound detection time

### DIFF
--- a/kubernetes/apps/storage/minio/app/bucket-bootstrap-job.yaml
+++ b/kubernetes/apps/storage/minio/app/bucket-bootstrap-job.yaml
@@ -7,6 +7,16 @@
 # Manual equivalent:
 #   kubectl -n storage exec deploy/minio -- mc mb --ignore-existing \
 #     local/observability-thanos local/observability-loki
+#
+# Failure detection relies on kube-prometheus-stack's default KubeJobFailed
+# alert (kube_job_failed > 0, for: 15m) — verified this fires for Jobs in any
+# namespace including storage, but only once the Job reaches a terminal
+# Failed condition. backoffLimit is lowered from the Kubernetes default of 6
+# (which could take 90+ minutes to exhaust here, since each attempt repeats
+# the ~15 minute wait-for-minio loop below) so a persistent failure surfaces
+# in well under an hour. activeDeadlineSeconds is a hard ceiling in case `mc`
+# hangs outright, which wouldn't otherwise produce the exit code backoffLimit
+# needs to count an attempt as failed.
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -17,6 +27,8 @@ metadata:
     # by deleting it: kubectl -n storage delete job minio-bucket-bootstrap
     kustomize.toolkit.fluxcd.io/prune: "false"
 spec:
+  backoffLimit: 2
+  activeDeadlineSeconds: 3600
   template:
     spec:
       restartPolicy: OnFailure
@@ -27,6 +39,7 @@ spec:
             - /bin/sh
             - -c
             - |
+              set -e
               RETRIES=0; MAX_RETRIES=180
               until mc alias set local http://minio.storage.svc.cluster.local:9000 \
                 "$MINIO_ROOT_USER" "$MINIO_ROOT_PASSWORD"; do

--- a/kubernetes/apps/storage/minio/app/bucket-quota-bootstrap-job.yaml
+++ b/kubernetes/apps/storage/minio/app/bucket-quota-bootstrap-job.yaml
@@ -18,6 +18,16 @@
 # Manual equivalent:
 #   mc admin bucket quota local/observability-thanos --size 45GiB
 #   mc admin bucket quota local/observability-loki --size 2GiB
+#
+# Failure detection relies on kube-prometheus-stack's default KubeJobFailed
+# alert (kube_job_failed > 0, for: 15m) — verified this fires for Jobs in any
+# namespace including storage, but only once the Job reaches a terminal
+# Failed condition. backoffLimit is lowered from the Kubernetes default of 6
+# (which could take 90+ minutes to exhaust here, since each attempt repeats
+# the ~15 minute wait-for-minio loop below) so a persistent failure surfaces
+# in well under an hour. activeDeadlineSeconds is a hard ceiling in case `mc`
+# hangs outright, which wouldn't otherwise produce the exit code backoffLimit
+# needs to count an attempt as failed.
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -31,6 +41,8 @@ metadata:
     #   kubectl -n storage delete job minio-bucket-quota-bootstrap
     kustomize.toolkit.fluxcd.io/prune: "false"
 spec:
+  backoffLimit: 2
+  activeDeadlineSeconds: 3600
   template:
     spec:
       restartPolicy: OnFailure

--- a/kubernetes/apps/storage/minio/app/thanos-user-bootstrap-job.yaml
+++ b/kubernetes/apps/storage/minio/app/thanos-user-bootstrap-job.yaml
@@ -12,6 +12,17 @@
 #   mc admin policy create local thanos-observability-rw /tmp/policy.json
 #   mc admin user add local <thanos accessKey> <thanos secretKey>
 #   mc admin policy attach local thanos-observability-rw --user <thanos accessKey>
+#
+# Failure detection relies on kube-prometheus-stack's default KubeJobFailed
+# alert (kube_job_failed > 0, for: 15m) — verified this fires for Jobs in any
+# namespace including storage, but only once the Job reaches a terminal
+# Failed condition. backoffLimit is lowered from the Kubernetes default of 6
+# (which could take 90+ minutes to exhaust here, since each attempt repeats
+# the ~15 minute wait-for-minio loop below) so a persistent failure — e.g.
+# Thanos silently losing write access to its bucket — surfaces in well under
+# an hour instead. activeDeadlineSeconds is a hard ceiling in case `mc` hangs
+# outright, which wouldn't otherwise produce the exit code backoffLimit needs
+# to count an attempt as failed.
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -25,6 +36,8 @@ metadata:
     # the resources list.
     kustomize.toolkit.fluxcd.io/prune: "false"
 spec:
+  backoffLimit: 2
+  activeDeadlineSeconds: 3600
   template:
     spec:
       restartPolicy: OnFailure


### PR DESCRIPTION
## Summary
Follow-up on "Silent bootstrap-job failure" from the Minio safeguards review. Verified (not assumed) that kube-prometheus-stack's default `KubeJobFailed` alert genuinely covers these Jobs — `defaultRules.rules.kubernetesApps: true`, `appNamespacesTarget: ".*"`, and kube-state-metrics collects the `jobs` resource by default, none of which are overridden in this repo's `kube-prometheus-stack` HelmRelease. It fires on `kube_job_failed > 0` for 15m.

That verification surfaced two real problems the alert can't help with on its own:

1. **`bucket-bootstrap-job.yaml` had no `set -e`.** A failed `mc mb` would still let the script exit 0 — the Job reports `Complete` even though the buckets it's supposed to guarantee never got created. No alert, default or custom, can catch a failure the script itself swallows. Added `set -e` (matching `thanos-user-bootstrap-job.yaml`, which already had it, and `bucket-quota-bootstrap-job.yaml`, which picked it up from a concurrent Copilot-authored fix already on `main`).
2. **No `backoffLimit`/`activeDeadlineSeconds` on any of the three bootstrap Jobs.** With the Kubernetes default `backoffLimit: 6` and `restartPolicy: OnFailure`, each retry replays the ~15-minute wait-for-minio loop before failing — worst case 90+ minutes before the Job reaches a terminal `Failed` condition and `kube_job_failed` even has a chance to go true. Set `backoffLimit: 2` on all three so a persistent failure (bad creds, malformed policy JSON — the kind of thing that silently costs Thanos its write access) surfaces in well under an hour. Also added `activeDeadlineSeconds: 3600` as a hard ceiling: an outright `mc` hang never produces the exit code `backoffLimit` needs to count an attempt as failed, so without a deadline the Job would just sit `Active` forever.

No new PrometheusRule — the generic `KubeJobFailed` is adequate once these Jobs can actually report failure; a bespoke duplicate wasn't worth the added alert surface.

## Test plan
- [x] `kubectl kustomize kubernetes/apps/storage/minio/app` builds cleanly
- [ ] After Flux reconciles: confirm all three Jobs still complete successfully with the tighter `backoffLimit`
- [ ] Optional: force a transient failure (e.g. scale Minio to 0 briefly before re-running a bootstrap Job) to confirm `KubeJobFailed` actually fires within the expected window

🤖 Generated with [Claude Code](https://claude.com/claude-code)