### PR TITLE
fix(ci): quiet kubescape's unmapped-CRD warnings

### DIFF
--- a/.github/workflows/security-scan.yaml
+++ b/.github/workflows/security-scan.yaml
@@ -79,7 +79,13 @@ jobs:
       - name: Run Kubescape (NSA framework)
         id: kubescape
         continue-on-error: true
-        run: kubescape scan framework nsa rendered.yaml 2>&1 | tee kubescape-results.txt
+        # --logger error: without a live cluster to query, kubescape can't resolve
+        # CRD kinds (Kustomization, HelmRelease, HTTPRoute, ...) via api-resources
+        # and logs a warning per resource for it — ~200 harmless lines on this repo.
+        # None of those kinds carry a pod spec, so no NSA control applies to them
+        # anyway; raising the log threshold drops the noise without touching the
+        # actual scan results.
+        run: kubescape scan framework nsa rendered.yaml --logger error 2>&1 | tee kubescape-results.txt
 
       - name: Publish summary
         if: always()


### PR DESCRIPTION
## Summary

Follow-up to #287. The Kubescape step in `security-scan.yaml` was printing ~200 lines like:

```
{"level":"warn","msg":"unsupported/unmapped object kind","kind":"Kustomization","id":"...","error":"resource not found. resource 'kustomizations' unknown. Make sure the resource is found at `kubectl api-resources`"}
```

for every Flux/CRD resource in the rendered manifests (`Kustomization`, `HelmRelease`, `OCIRepository`, `HelmRepository`, `HTTPRoute`, `ServiceMonitor`, ...). Root cause: Kubescape scans a static file with no live cluster to query, so it can't resolve custom resource kinds via API discovery the way it normally would (`kubectl api-resources`) — it logs a warning per resource instead. Benign (none of those kinds carry a pod spec, so no NSA control ever applies to them; the compliance score and control table are unaffected), but it's a lot of noise for a report meant to be skimmed periodically.

- Adds `--logger error` to the `kubescape scan` invocation, which raises the CLI's log threshold above `warning` — a real Kubescape flag for this (`-l`/`--logger`, levels: debug/info/success/warning/error/fatal), not a string-filter hack. Actual scan results print through a separate code path and are unaffected.

## Test plan

- [x] YAML validity checked locally.
- [ ] Manually triggering `workflow_dispatch` on this branch to confirm the warning lines are gone and the compliance table/score still print correctly.


---
_Generated by [Claude Code](https://claude.ai/code/session_01EogQtnH1sNcfXiKUUD1E5U)_