### PR TITLE
feat(minio): add recurring bitrot-scrub CronJob

### DIFF
--- a/kubernetes/apps/storage/minio/app/heal-cronjob.yaml
+++ b/kubernetes/apps/storage/minio/app/heal-cronjob.yaml
@@ -1,0 +1,98 @@
+---
+# Recurring bitrot scrub. Minio verifies an object's checksum on every read,
+# but that only catches corruption for objects something actually reads —
+# this proactively scans everything on a schedule instead of waiting for a
+# client to stumble onto a bad object.
+#
+# Standalone mode runs a single drive with no erasure coding, so `mc admin
+# heal` can DETECT corruption (checksum mismatch) but generally can't REPAIR
+# it — there's no parity/replica within Minio itself to reconstruct from.
+# Treat this as a bitrot canary, not full self-healing, unless the deployment
+# moves to a multi-drive erasure-coded topology (see chat notes: this Helm
+# chart only supports that via mode: distributed with a suitable
+# drivesPerNode, even for a single node — mode: standalone hardcodes exactly
+# one mount path/PVC. Not done here — it's a disruptive re-provision, not a
+# value flip, and would stack Minio's own EC parity on top of Longhorn's
+# existing 2x replication under longhorn-2-no-backup for redundancy that's
+# largely already covered at the block layer).
+#
+# `mc admin heal` always exits 0 even when it finds objects it couldn't fully
+# heal (verified against mc's own source — DisplayAndFollowHealStatus always
+# returns nil), so success/failure here is inferred from the output itself
+# via a conservative keyword heuristic, not a parsed API contract. Tune the
+# grep pattern after reviewing a real run's output if it proves noisy.
+#
+# Failure detection relies on kube-prometheus-stack's default KubeJobFailed
+# alert (kube_job_failed > 0, for: 15m) — verified in a prior change to cover
+# Jobs in any namespace including storage. CronJob-spawned Jobs are ordinary
+# Jobs, so no separate PrometheusRule is needed here.
+#
+# Manual equivalent:
+#   mc admin heal --recursive local/
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: minio-heal
+  namespace: storage
+spec:
+  schedule: "0 3 * * 0" # Sunday 03:00
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 1
+      # A full recursive heal scan can run long depending on object count;
+      # generous relative to the current ~50Gi deployment.
+      activeDeadlineSeconds: 7200
+      template:
+        spec:
+          restartPolicy: OnFailure
+          containers:
+            - name: mc
+              image: quay.io/minio/mc:RELEASE.2025-08-13T08-35-41Z
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  set -e
+                  RETRIES=0; MAX_RETRIES=12
+                  until mc alias set local http://minio.storage.svc.cluster.local:9000 \
+                    "$MINIO_ROOT_USER" "$MINIO_ROOT_PASSWORD"; do
+                    RETRIES=$((RETRIES + 1))
+                    if [ "$RETRIES" -ge "$MAX_RETRIES" ]; then
+                      echo "ERROR: minio unreachable after $((MAX_RETRIES * 5))s, giving up"
+                      exit 1
+                    fi
+                    echo "waiting for minio... (attempt $RETRIES/$MAX_RETRIES)"; sleep 5
+                  done
+
+                  OUTPUT=$(mc admin heal --recursive local/ 2>&1) || {
+                    echo "$OUTPUT"
+                    echo "ERROR: mc admin heal exited non-zero"
+                    exit 1
+                  }
+                  echo "$OUTPUT"
+
+                  if echo "$OUTPUT" | grep -qiE "fail|corrupt|offline|error|unable to heal"; then
+                    echo "ERROR: heal output indicates a problem, see above"
+                    exit 1
+                  fi
+                  echo "heal scan clean"
+              env:
+                - name: MINIO_ROOT_USER
+                  valueFrom:
+                    secretKeyRef:
+                      name: minio-root-credentials
+                      key: rootUser
+                - name: MINIO_ROOT_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: minio-root-credentials
+                      key: rootPassword
+              resources:
+                requests:
+                  cpu: 10m
+                  memory: 64Mi
+                limits:
+                  memory: 256Mi

--- a/kubernetes/apps/storage/minio/app/heal-cronjob.yaml
+++ b/kubernetes/apps/storage/minio/app/heal-cronjob.yaml
@@ -45,6 +45,7 @@ spec:
       # A full recursive heal scan can run long depending on object count;
       # generous relative to the current ~50Gi deployment.
       activeDeadlineSeconds: 7200
+      template:
         spec:
           restartPolicy: Never
           containers:

--- a/kubernetes/apps/storage/minio/app/heal-cronjob.yaml
+++ b/kubernetes/apps/storage/minio/app/heal-cronjob.yaml
@@ -45,9 +45,8 @@ spec:
       # A full recursive heal scan can run long depending on object count;
       # generous relative to the current ~50Gi deployment.
       activeDeadlineSeconds: 7200
-      template:
         spec:
-          restartPolicy: OnFailure
+          restartPolicy: Never
           containers:
             - name: mc
               image: quay.io/minio/mc:RELEASE.2025-08-13T08-35-41Z

--- a/kubernetes/apps/storage/minio/app/kustomization.yaml
+++ b/kubernetes/apps/storage/minio/app/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
   - ./bucket-bootstrap-job.yaml
   - ./bucket-quota-bootstrap-job.yaml
   - ./probe-bucket-metrics.yaml
+  - ./heal-cronjob.yaml
   - ./thanos-user-credentials.sops.yaml
   - ./thanos-user-bootstrap-job.yaml
   - ./loki-user-credentials.sops.yaml


### PR DESCRIPTION
## Summary
Addresses "no bitrot scrubbing" from the Minio safeguards review — standalone mode had nothing proactively checking stored objects for silent corruption; only a client actually reading a bad object would surface it.

- Weekly `CronJob` (`Sun 03:00`) running `mc admin heal --recursive local/` against the whole alias, covering both buckets in one pass.
- `mc admin heal` always exits 0 even when it finds objects it couldn't fully heal (verified against `mc`'s own source — `DisplayAndFollowHealStatus` always returns `nil`), so pass/fail is inferred from the output via a conservative keyword grep (`fail|corrupt|offline|error|unable to heal`) rather than trusting the exit code alone.
- `backoffLimit: 1`, `activeDeadlineSeconds: 7200`. Relies on the same `KubeJobFailed` alert already verified (in #286) to cover Job failures in the `storage` namespace — CronJob-spawned Jobs are ordinary Jobs, so no new PrometheusRule needed.

### On erasure coding in standalone mode
You asked whether EC is possible without going fully distributed — yes, in principle: MinIO's own erasure coding just needs ≥4 drives in an erasure set, which can live on a single node (single-node-multi-drive, "SNMD"). But in this specific chart (`minio/minio` v5.4.0), that topology is only reachable via `mode: distributed` with `replicas: 1` and `drivesPerNode: 4+` — I read the chart's `templates/deployment.yaml` directly and confirmed `mode: standalone` hardcodes exactly one mount path backed by one PVC; there's no multi-drive path in that template at all.

Deliberately **not implemented here** — it's a disruptive re-provision (different workload kind, new PVCs, data migration), not a config flip, and it would stack Minio's own EC parity (typically 50% overhead at 4 drives) on top of Longhorn's existing 2x replication under `longhorn-2-no-backup`. That's roughly 4x physical storage for redundancy that's largely already covered at the block layer — Longhorn already protects against a disk/node failure. What EC adds that Longhorn doesn't is object-level bitrot detection *and automatic repair from parity*; on the current single drive, this CronJob gives detection only, not repair. If that gap matters enough to justify the storage/complexity cost, it's worth its own migration plan rather than folding into this change.

## Test plan
- [x] `kubectl kustomize kubernetes/apps/storage/minio/app` builds cleanly
- [x] Embedded shell script passes `sh -n` syntax check
- [ ] After Flux reconciles: trigger manually (`kubectl -n storage create job --from=cronjob/minio-heal minio-heal-test`) and confirm it completes and logs a clean scan
- [ ] Confirm the CronJob's next scheduled run actually fires (`kubectl -n storage get cronjob minio-heal`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)