### PR TITLE
feat(minio): add request rate/latency/traffic panels to dashboard

### DIFF
--- a/kubernetes/apps/monitoring/kube-prometheus-stack/app/grafana-dashboard-minio.yaml
+++ b/kubernetes/apps/monitoring/kube-prometheus-stack/app/grafana-dashboard-minio.yaml
@@ -143,6 +143,68 @@ data:
               }
             ]
           }
+        },
+        {
+          "id": 6,
+          "type": "timeseries",
+          "title": "S3 Request Rate",
+          "gridPos": {"h": 8, "w": 8, "x": 0, "y": 12},
+          "targets": [
+            {"expr": "sum(rate(minio_s3_requests_total[5m]))", "legendFormat": "requests/s"}
+          ],
+          "fieldConfig": {
+            "defaults": {"min": 0, "unit": "reqps", "custom": {"lineWidth": 2, "fillOpacity": 10}},
+            "overrides": []
+          }
+        },
+        {
+          "id": 7,
+          "type": "timeseries",
+          "title": "S3 Request Latency (p99 TTFB)",
+          "gridPos": {"h": 8, "w": 8, "x": 8, "y": 12},
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.99, sum by (le) (minio_s3_requests_ttfb_seconds_distribution))",
+              "legendFormat": "p99"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {"min": 0, "unit": "s", "custom": {"lineWidth": 2, "fillOpacity": 10}},
+            "overrides": []
+          }
+        },
+        {
+          "id": 8,
+          "type": "timeseries",
+          "title": "S3 Traffic",
+          "gridPos": {"h": 8, "w": 8, "x": 16, "y": 12},
+          "targets": [
+            {"expr": "rate(minio_s3_traffic_received_bytes[5m])", "legendFormat": "received"},
+            {"expr": "rate(minio_s3_traffic_sent_bytes[5m])", "legendFormat": "sent"}
+          ],
+          "fieldConfig": {
+            "defaults": {"min": 0, "unit": "Bps", "custom": {"lineWidth": 2, "fillOpacity": 10}},
+            "overrides": []
+          }
+        },
+        {
+          "id": 9,
+          "type": "timeseries",
+          "title": "S3 Errors by Type",
+          "gridPos": {"h": 8, "w": 24, "x": 0, "y": 20},
+          "targets": [
+            {"expr": "sum(rate(minio_s3_requests_4xx_errors_total[5m]))", "legendFormat": "4xx"},
+            {"expr": "sum(rate(minio_s3_requests_5xx_errors_total[5m]))", "legendFormat": "5xx"}
+          ],
+          "fieldConfig": {
+            "defaults": {"min": 0, "unit": "reqps", "custom": {"lineWidth": 2, "fillOpacity": 10}},
+            "overrides": [
+              {
+                "matcher": {"id": "byName", "options": "5xx"},
+                "properties": [{"id": "color", "value": {"mode": "fixed", "fixedColor": "red"}}]
+              }
+            ]
+          }
         }
       ],
       "schemaVersion": 39,


### PR DESCRIPTION
## Summary
Follow-up on "no dashboard... request latency" from the Minio safeguards review. A `grafana-dashboard-minio.yaml` already exists (from the bucket-quota work) but only covered capacity/quota headroom — no visibility into request latency or throughput, which was the other half of the original gap.

Added 4 panels to the existing dashboard:
- **S3 Request Rate** — `sum(rate(minio_s3_requests_total[5m]))`
- **S3 Request Latency (p99 TTFB)** — `histogram_quantile` over `minio_s3_requests_ttfb_seconds_distribution`. Worth flagging: this is Minio's non-standard histogram export (`le`-labeled gauge series rather than a proper `_bucket`/`_sum`/`_count` counter triplet — verified against Minio's source), so it's queried without a `rate()` wrapper, unlike a normal Prometheus histogram. `histogram_quantile` doesn't care about the metric name suffix, only the `le` label, so this should compute correctly, but it's worth a visual sanity check once real traffic is flowing through it.
- **S3 Traffic** — received/sent byte rates.
- **S3 Errors by Type** — 4xx/5xx rate, visually complementing the existing `MinioS3ServerErrorsHigh` alert (which only covers 5xx).

### Why extend instead of import Minio's official dashboard
Went with extending the existing hand-built dashboard rather than importing Minio's official community dashboard (e.g. the one on grafana.com). That dashboard is sized for multi-node/replicated/KMS-enabled deployments — most of its panels (internode traffic, replication lag, KMS, LDAP, per-node breakdowns) would just be empty on this single-node deployment, and it'd be a much larger JSON blob to maintain. Every other dashboard in this repo (n8n, longhorn, hosts, opnsense) is a small curated set of panels tied to what's actually monitored/alerted on — this keeps that pattern.

## Test plan
- [x] Dashboard JSON parses (`json.loads` round-trip)
- [x] `kubectl kustomize kubernetes/apps/monitoring/kube-prometheus-stack/app` builds cleanly
- [ ] After Flux reconciles: open the "Minio Overview" dashboard in Grafana and confirm the new panels render with real data, especially the TTFB latency panel given the non-standard histogram export

🤖 Generated with [Claude Code](https://claude.com/claude-code)