### PR TITLE
feat(minio): expose the console on the internal gateway

### DIFF
--- a/kubernetes/apps/storage/minio/app/httproute-console.yaml
+++ b/kubernetes/apps/storage/minio/app/httproute-console.yaml
@@ -1,0 +1,24 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/gateway.networking.k8s.io/httproute_v1.json
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: minio-console
+  annotations:
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/icon: minio
+    gethomepage.dev/title: Minio
+    gethomepage.dev/description: "Object storage console"
+    gethomepage.dev/group: "Monitoring"
+spec:
+  hostnames:
+    - minio.${SECRET_DOMAIN}
+  parentRefs:
+    - name: envoy-internal
+      namespace: network
+      sectionName: https
+  rules:
+    - backendRefs:
+        - name: minio-console
+          namespace: storage
+          port: 9001

--- a/kubernetes/apps/storage/minio/app/kustomization.yaml
+++ b/kubernetes/apps/storage/minio/app/kustomization.yaml
@@ -4,6 +4,7 @@ kind: Kustomization
 resources:
   - ./helmrepository.yaml
   - ./helmrelease.yaml
+  - ./httproute-console.yaml
   - ./minio-root-credentials.sops.yaml
   - ./bucket-bootstrap-job.yaml
   - ./bucket-quota-bootstrap-job.yaml


### PR DESCRIPTION
## Summary
`consoleService` was already `ClusterIP` but had no route in front of it, so the Minio web console was only reachable via `kubectl port-forward`. Added an `HTTPRoute` on `envoy-internal` — confirmed via `network/envoy-gateway/app/envoy.yaml` that this Gateway is the LAN-only one (`external-dns...hostname: internal.${SECRET_DOMAIN}`), distinct from `envoy-external`.

- `minio.${SECRET_DOMAIN}` → `minio-console` Service, port 9001
- Same pattern as the existing Grafana and Longhorn dashboard routes (`envoy-internal`, `sectionName: https`), homepage annotations included for consistency with Grafana/Thanos

### Worth knowing
Auth is unchanged — still just the single root credential, no MFA. This just makes the existing login page reachable without a port-forward instead of adding any new capability. That's the same trust boundary this repo already accepts for the Longhorn dashboard (routed the same way, and unauthenticated by default unlike Minio's console). Not flagging this to block the change, just so it's an explicit choice rather than an implicit one.

## Test plan
- [x] `kubectl kustomize kubernetes/apps/storage/minio/app` builds cleanly
- [ ] After Flux reconciles: confirm `https://minio.<domain>` resolves and the console login page loads
- [ ] Confirm it does NOT resolve on `envoy-external` (LAN-only as intended)

🤖 Generated with [Claude Code](https://claude.com/claude-code)