### PR TITLE
fix(monitoring): drop apiserver etcd client histogram (~12.7% of TSDB)

### DIFF
--- a/kubernetes/apps/monitoring/kube-prometheus-stack/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/kube-prometheus-stack/app/helmrelease.yaml
@@ -40,6 +40,13 @@ spec:
         metricRelabelings:
           # etcd request histograms are extremely high-cardinality for a homelab.
           # The _count and _sum variants are retained for rate/avg queries.
+          #
+          # NOTE: this rule only covers etcd's own scrape job, which currently has
+          # no targets — the chart's kube-etcd Service has zero endpoints on Talos,
+          # so nothing matches this today. It is kept so the rule is already correct
+          # if etcd scraping is ever wired up. The series that actually exist come
+          # from the apiserver's etcd *client* instrumentation — see kubeApiServer
+          # below. Do not assume this rule is what bounds etcd histogram cardinality.
           - action: drop
             sourceLabels: [__name__]
             regex: etcd_request_duration_seconds_bucket
@@ -53,6 +60,19 @@ spec:
           - action: drop
             sourceLabels: [__name__]
             regex: apiserver_request_body_size_bytes_bucket|apiserver_watch_list_duration_seconds_bucket|apiserver_watch_cache_read_wait_seconds_bucket|apiserver_response_sizes_bucket|apiserver_watch_events_sizes_bucket
+          # The kube-apiserver exports its own etcd client histogram under
+          # job="apiserver" — distinct from etcd's server-side metrics above. It
+          # carries `group` and `resource` labels, so its cardinality scales with
+          # every installed CRD: 24 le x 6 operation x 4 apiservers x ~65
+          # group/resource pairs = ~37.7k series, ~12.7% of the whole TSDB.
+          #
+          # Nothing reads it: no PrometheusRule references it, and the repo's own
+          # "etcd Range (Read) Latency p99" panel (grafana-dashboard-apiserver-watch-cache)
+          # filters job=~".*etcd.*", which these series do not match. _count/_sum
+          # are retained, so rate/avg queries still work.
+          - action: drop
+            sourceLabels: [__name__]
+            regex: etcd_request_duration_seconds_bucket
 
     alertmanager:
       alertmanagerSpec:


### PR DESCRIPTION
## Problem

`kubeEtcd.serviceMonitor.metricRelabelings` already carried a drop rule for `etcd_request_duration_seconds_bucket`, with a comment explaining that etcd request histograms are too high-cardinality for a homelab. **That rule has never matched a single series.**

The chart's `kube-prometheus-stack-kube-etcd` Service has **zero endpoints** on Talos, so that scrape job has no targets and produces no series at all:

```
$ kubectl get endpoints -n kube-system kube-prometheus-stack-kube-etcd
NAME                              ENDPOINTS   AGE
kube-prometheus-stack-kube-etcd   <none>      4d21h
```

Meanwhile the 37,752 series that *do* exist come from a different scrape job entirely — the kube-apiserver's own etcd **client** instrumentation:

```
$ count by (job) (etcd_request_duration_seconds_bucket)
apiserver    37752 series
```

Those series carry `group` and `resource` labels, so their cardinality scales with every installed CRD:

> 24 `le` × 6 `operation` × 4 apiservers × ~65 `group`/`resource` pairs ≈ **37.7k series**

That is **~12.7% of the entire 297,726-series TSDB**, retained by a rule written to delete it, attached to the wrong ServiceMonitor.

## Change

Add `etcd_request_duration_seconds_bucket` to the `kubeApiServer` drop list, where the series actually live.

The `kubeEtcd` rule is **left in place** so it is already correct if etcd scraping is ever wired up, with a comment recording why it is inert today and pointing at the apiserver rule.

## Verification that nothing consumes it

- **No PrometheusRule** references `etcd_request_duration_seconds_bucket`.
- The repo's own `etcd Range (Read) Latency p99` panel (`grafana-dashboard-apiserver-watch-cache`) filters `job=~".*etcd.*"` — which these `job="apiserver"` series **do not match**. That panel reads from the absent etcd job and **is already blank today**; this change does not alter it.
- `_count` / `_sum` are retained (1,573 series each), so `rate`/avg queries still work. Only the `_bucket` quantile series are dropped.
- The `kubeApiServer` drop mechanism is proven working — the other metrics in that list are confirmed absent from `job="apiserver"`.

## Impact

Storage scales roughly linearly with series count. Removing ~12.7% of series reduces:

- object-store growth across **all** Thanos resolution tiers (raw, 5m, 1h)
- local Prometheus TSDB size
- write amplification into the `kube-prometheus-stack-prometheus` Longhorn volume

This is context for the current alert storm: that volume's engine controller is the top CPU consumer on `hiro-cmp-04`, and the `kube-apiserver-burnrate.rules` group is failing evaluation with `context deadline exceeded`.

## Notes

- `apiserver_response_sizes_bucket` still shows 56 series, but from `job="metrics-server"` (a separate ServiceMonitor), not the apiserver. Negligible; not addressed here.
- **Separate latent issue, not fixed here:** etcd monitoring is silently dead (Service has no endpoints). Wiring it up is Talos-level work. Worth noting that if it is ever fixed, the `kubeEtcd` drop rule and the `etcd Range (Read) Latency p99` panel are mutually exclusive by design — one deletes what the other reads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)