### PR TITLE
fix(longhorn): make *-no-backup classes actually skip backups

### DIFF
--- a/kubernetes/apps/storage/longhorn-system/app/storageclasses.yaml
+++ b/kubernetes/apps/storage/longhorn-system/app/storageclasses.yaml
@@ -6,6 +6,8 @@ metadata:
   name: longhorn-1
   annotations:
     storageclass.kubernetes.io/is-default-class: "false"
+    # params are immutable; let Flux recreate rather than fail the apply
+    kustomize.toolkit.fluxcd.io/force: "Enabled"
 provisioner: driver.longhorn.io
 allowVolumeExpansion: true
 reclaimPolicy: Delete
@@ -23,6 +25,8 @@ metadata:
   name: longhorn-2
   annotations:
     storageclass.kubernetes.io/is-default-class: "false"
+    # params are immutable; let Flux recreate rather than fail the apply
+    kustomize.toolkit.fluxcd.io/force: "Enabled"
 provisioner: driver.longhorn.io
 allowVolumeExpansion: true
 reclaimPolicy: Delete
@@ -33,13 +37,24 @@ parameters:
   replicaAutoBalance: best-effort
 
 ---
-# 3 replicas, no backups — same redundancy as default but exempt from recurring backup/snapshot jobs
+# 3 replicas, no backups — same redundancy as default, snapshots but no recurring backup.
+#
+# recurringJobSelector MUST name a real group. An empty "[]" does NOT opt out:
+# Longhorn "will automatically add a volume to the `default` group when the volume
+# has no recurring job", and `default` carries BOTH a 6-hourly snapshot job AND a
+# daily backup job — so "[]" silently opted these classes into the exact backups
+# their name disclaims. Naming the snapshot-only group is what actually excludes
+# them, because the volume then has a job and default is not auto-applied.
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: longhorn-no-backup
   annotations:
     storageclass.kubernetes.io/is-default-class: "false"
+    # StorageClass.parameters is immutable; without this a selector change fails to
+    # apply and wedges the whole longhorn Kustomization. Scoped per-resource rather
+    # than spec.force, which would also cover the Longhorn HelmRelease.
+    kustomize.toolkit.fluxcd.io/force: "Enabled"
 provisioner: driver.longhorn.io
 allowVolumeExpansion: true
 reclaimPolicy: Delete
@@ -48,7 +63,7 @@ parameters:
   numberOfReplicas: "3"
   dataLocality: best-effort
   replicaAutoBalance: best-effort
-  recurringJobSelector: "[]"
+  recurringJobSelector: '[{"name":"snapshot-only","isGroup":true}]'
 
 ---
 # 1 replica, no backups
@@ -58,6 +73,7 @@ metadata:
   name: longhorn-1-no-backup
   annotations:
     storageclass.kubernetes.io/is-default-class: "false"
+    kustomize.toolkit.fluxcd.io/force: "Enabled"
 provisioner: driver.longhorn.io
 allowVolumeExpansion: true
 reclaimPolicy: Delete
@@ -66,7 +82,7 @@ parameters:
   numberOfReplicas: "1"
   dataLocality: best-effort
   replicaAutoBalance: best-effort
-  recurringJobSelector: "[]"
+  recurringJobSelector: '[{"name":"snapshot-only","isGroup":true}]'
 
 ---
 # 2 replicas, no backups
@@ -76,6 +92,7 @@ metadata:
   name: longhorn-2-no-backup
   annotations:
     storageclass.kubernetes.io/is-default-class: "false"
+    kustomize.toolkit.fluxcd.io/force: "Enabled"
 provisioner: driver.longhorn.io
 allowVolumeExpansion: true
 reclaimPolicy: Delete
@@ -84,17 +101,21 @@ parameters:
   numberOfReplicas: "2"
   dataLocality: best-effort
   replicaAutoBalance: best-effort
-  recurringJobSelector: "[]"
+  recurringJobSelector: '[{"name":"snapshot-only","isGroup":true}]'
 
 ---
 # TSDB/write-heavy volumes (e.g., Prometheus) — daily snapshot only via longhorn-tsdb-snapshot-job.
-# Operator: reprovision or relabel Prometheus PVCs to use this class to stop 6-hourly snapshot amplification.
+# The Prometheus PVC was moved onto this class in #310; the daily/retain-2 cadence is
+# what keeps its snapshot chain from outrunning cleanup. Use this class (not the
+# *-no-backup ones, which snapshot 6-hourly) for any new continuously-written volume.
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: longhorn-tsdb
   annotations:
     storageclass.kubernetes.io/is-default-class: "false"
+    # params are immutable; let Flux recreate rather than fail the apply
+    kustomize.toolkit.fluxcd.io/force: "Enabled"
 provisioner: driver.longhorn.io
 allowVolumeExpansion: true
 reclaimPolicy: Delete


### PR DESCRIPTION
The root cause behind the snapshot-bloat incident that #310 fixed for Prometheus. This fixes it for every future volume.

## The bug

The three `*-no-backup` classes set `recurringJobSelector: "[]"`, intending to opt out of recurring jobs. **It does the exact opposite.**

Per [Longhorn's docs](https://longhorn.io/docs/1.10.0/snapshots-and-backups/scheduling-backups-and-snapshots/), Longhorn *"will automatically add a volume to the `default` group when the volume has no recurring job"* — and `default` carries **both**:

| Job | Task | Cron | Retain |
|---|---|---|---|
| `longhorn-default-snapshot-job` | snapshot | `15 */6 * * *` | 3 |
| `longhorn-default-backup-job` | **backup** | `45 2 * * *` | 3 |

An empty selector assigns no job → the volume has no job → **`default` is applied**. The classes were silently opted into precisely the backups their name disclaims. `"[]"` reads as "nothing"; Longhorn treats it as "unconfigured".

## Confirmed live, not theoretical

All **16** volumes carry `recurring-job-group.longhorn.io/default=enabled`. And:

```
$ kubectl get pvc -A  # volumes on *-no-backup classes
storage/minio   longhorn-2-no-backup   50Gi   last backup: 2026-07-15T02:46:51Z
```

`storage/minio` — 50Gi of Thanos blocks — **is backed up daily to real AWS S3**. The backup target secret has no `AWS_ENDPOINTS`, so `s3://hiro-longhorn-backups@us-east-1/` resolves to genuine AWS, not the in-cluster Minio. Backing an object store up to another object store is both unintended and billable.

*(Prometheus was the second victim; #310 moved it to `longhorn-tsdb`.)*

## The fix

Name a real group. `snapshot-only` already exists via `longhorn-snapshot-only-job` (6h snapshot, retain 3, **no backup**) — and has had **zero volumes on it**. Evidently built for these classes and never wired up, exactly like `longhorn-tsdb` sat unused until #310.

Naming a group is what actually excludes `default`, because the volume then *has* a job.

## Why the force annotation

`StorageClass.parameters` is **immutable** — verified:

```
$ kubectl patch storageclass longhorn-2-no-backup --dry-run=server ...
The StorageClass "longhorn-2-no-backup" is invalid: parameters: Invalid value: ...: field is immutable
```

Without help, Flux fails the patch and **wedges the entire longhorn Kustomization** (which also manages the Longhorn HelmRelease, backup target, and recurring jobs). `kustomize.toolkit.fluxcd.io/force: "Enabled"` makes the controller recreate them.

Applied **per-resource**, not `spec.force` on the Kustomization — Flux's docs call the annotation the *"safer alternative"*, and `spec.force` would also cover the HelmRelease. Recreating a StorageClass is safe: bound PVCs/PVs reference it by name only and are never reprovisioned.

Added to **all six** classes, since the immutability trap applies equally to the ones not changing here — leaving half the file trapped would just reset the same footgun for the next editor.

## Deliberately NOT changed

- **Snapshot cadence stays 6h/retain 3.** This fixes backup behaviour only. Worth being explicit: **snapshot rotation, not backups, is what drives snapshot-chain bloat** — each rotation coalesces the pruned snapshot's blocks forward instead of freeing them. So volumes on these classes still need the periodic `fstrim` in `docs/runbook-longhorn-volume-trim.md`. (`RecurringJob.spec.cron` is mutable, so retuning later is a trivial follow-up if the bloat becomes annoying.)
- **`default-jobs.yaml` untouched.**

## Follow-up required (not in this PR)

`recurringJobSelector` applies **only at provision time**. Existing volumes keep their `default` label, so **`storage/minio` will keep being backed up to S3 until it is relabelled**:

```sh
kubectl label volumes.longhorn.io -n storage <minio-vol> \
  recurring-job-group.longhorn.io/default- \
  recurring-job-group.longhorn.io/snapshot-only=enabled
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)