### PR TITLE
feat(thanos): cut raw retention 30d -> 7d to fit Minio volume

### DIFF
--- a/kubernetes/apps/monitoring/thanos/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/thanos/app/helmrelease.yaml
@@ -144,7 +144,17 @@ spec:
               - --objstore.config-file=/etc/thanos/objstore.yml
               - --http-address=0.0.0.0:10902
               - --wait
-              - --retention.resolution-raw=30d
+              # Retention per resolution tier. These coexist — downsampling writes an
+              # additional copy, it does not replace raw — so total ≈ sum of all three.
+              #
+              # raw cut 30d -> 7d: at the observed post-cardinality growth the raw tier
+              # dominated the ~50Gi Minio volume, pushing it past 85%. Raw below the
+              # local Prometheus retention (3d) is redundant anyway — the sidecar serves
+              # that window off local disk — so raw only earns its keep for the 3d..7d
+              # zoom-into-old-data case. 5m keeps min/max/avg (peaks preserved, rate()
+              # works) for 90d; 1h covers a full year. Cutting raw immediately deletes
+              # the accumulated 8d..30d of raw blocks whose 5m/1h copies already exist.
+              - --retention.resolution-raw=7d
               - --retention.resolution-5m=90d
               - --retention.resolution-1h=1y
             probes:


### PR DESCRIPTION
Closes out the MinIO capacity problem. The last real lever, and it reclaims space immediately.

## Why now

The `observability-thanos` bucket grew to fill the 50Gi Minio volume past **85%** (`LonghornVolumeUsageHigh`). **Trimming no longer helps** — a fresh `fstrim` reclaimed ~0Gi because the volume now holds **~35.6Gi of real data** vs only **~8Gi of reclaimable snapshot overhead** (mostly a 39.7Gi root snapshot that will rotate out naturally). The data itself is the constraint, so the fix has to reduce data, not defragment it.

## The change

`--retention.resolution-raw`: **30d → 7d**. 5m stays 90d, 1h stays 1y.

The three tiers **coexist** — downsampling writes an *additional* copy, it does not replace raw — so total ≈ sum of all three, and raw (30s samples) is the largest tier by far.

## Why 7d loses nothing that matters

- **Raw below 3d is already redundant** — local Prometheus retains 3d and the Thanos sidecar serves that window off local disk. Raw only earns its keep for the **3d..7d** "zoom into old data" case, which for a homelab rarely happens beyond a week.
- **Immediate reclaim, no signal lost.** Oldest raw block is 2026-07-02 (~15d). Cutting to 7d deletes the accumulated **8d..30d** of raw blocks — but their **5m and 1h downsampled copies already exist** in the bucket. You lose only sub-5-minute resolution on data older than a week, not the data.
- **5m preserves what you'd actually query:** min/max (peaks are *not* smoothed away), avg, and a working `rate()`/`histogram_quantile` for 90d. 1h covers a full year.

## Compounds with the cardinality work

The real fix was upstream: #308/#309 cut series −26.7%, which dropped `observability-thanos` growth from **4.89 → 0.89 Gi/day (−82%)**. That already turned MinIO from a ~4-day emergency into ~2 weeks of headroom. This PR brings the volume **comfortably under** its ceiling rather than merely delaying it — raw settles at ~7Gi instead of ~30Gi.

## Safety

- GitOps only, no cutover, no PVC touch. The compactor applies the new retention on its next cycle and deletes the now-expired raw blocks.
- Deletes **only old raw blocks whose downsampled copies exist** — not 5m, not 1h, nothing inside the local Prometheus window.
- Note: raw blocks older than 7d are permanently deleted once this runs. That data stays queryable at 5m/1h; only sub-5m detail on the 7d..30d window is unrecoverable.

## Compactor behaviour to expect

`thanos-compactor` runs retention on its `--wait` loop; expect the deletions (and the `actualSize` drop) within a compaction cycle or two, not instantly. Longhorn reclaim of the freed blocks follows its own snapshot rotation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)