### PR TITLE
feat(talos): tighten kubelet image GC thresholds for small /var partitions

### DIFF
--- a/talos/patches/global/machine-kubelet.yaml
+++ b/talos/patches/global/machine-kubelet.yaml
@@ -2,6 +2,18 @@ machine:
   kubelet:
     extraConfig:
       serializeImagePulls: false
+      # Stock Kubernetes defaults (high=85/low=80) are sized for nodes with
+      # hundreds of GB of disk. Talos's EPHEMERAL partition (/var, hosts both
+      # imagefs and the node's general ephemeral storage) is ~48Gi on every
+      # node here, and images alone were observed using 23-56% of it. At
+      # stock thresholds, GC doesn't trigger until images hit ~40.6Gi and
+      # only cleans down to ~38.2Gi -- leaving ~9.5Gi free against kubelet's
+      # own nodefs.available<10% (~4.8Gi) eviction threshold. Any burst on
+      # top of that (e.g. a pod's emptyDir scratch use) tips the node into
+      # DiskPressure. Tightened so GC keeps a wider, earlier margin:
+      # triggers at ~35.8Gi, cleans to ~28.7Gi, leaving ~19Gi of headroom.
+      imageGCHighThresholdPercent: 75
+      imageGCLowThresholdPercent: 60
     nodeIP:
       validSubnets:
         - 192.168.25.0/24


### PR DESCRIPTION
Fleet-wide mitigation for the `thanos-compactor` eviction loop (2,737 evictions since 2026-07-13, `DiskPressure` on cmp-01) and general `/var` tightness. Complements, doesn't replace, addressing the compactor's own `emptyDir` footprint separately.

## The mismatch

Talos's `EPHEMERAL` partition (`/var` — imagefs + general ephemeral storage) is **~48Gi on every node**. Kubelet's stock `imageGCHighThresholdPercent=85` / `imageGCLowThresholdPercent=80` are sized for nodes with hundreds of GB, not 48Gi.

At stock thresholds: GC doesn't trigger until images hit **~40.6Gi**, and only cleans down to **~38.2Gi** — leaving **~9.5Gi** free against kubelet's own `nodefs.available<10%` (**~4.8Gi**) eviction threshold. Any burst on top of that margin — like the compactor's 20Gi `emptyDir` scratch volume — tips a node into `DiskPressure`.

## Measured, not assumed

Cross-referenced each node's `kubelet stats/summary` and `Node.status.images` against running pods' `imageID` to determine actual in-use vs unused images, per node:

| node | imagefs used | % of /var | confirmed-unused (visible slice) |
|---|---|---|---|
| cmp-01 | 13.3Gi | 28% | 0 |
| cmp-02 | 26.6Gi | **56%** | **3.89Gi** |
| cmp-03 | 10.8Gi | 23% | 0 |
| cmp-04 | 16.0Gi | 34% | 1.40Gi |

Caveat carried through honestly: `Node.status.images` caps at the 50 largest images, and three of four nodes hit that cap — roughly two-thirds of each node's image bytes aren't individually visible via this API. The confirmed-unused figures above are a **floor**, not the full reclaimable total.

The visible unused bytes are a mix of: genuinely orphaned digests referenced nowhere (`grafana@121a7a`, cached on 2 nodes, used by neither), and images left behind when a pod was rescheduled to a different node. Both are equally reclaimable on the node they're sitting on — that's the relevant scope for local disk pressure, regardless of whether the digest is in use elsewhere in the cluster.

## The change

`imageGCHighThresholdPercent`: 85 → **75** (~35.8Gi trigger)
`imageGCLowThresholdPercent`: 80 → **60** (~28.7Gi target)

Wider gap between high/low than stock (15pp → 15pp is actually the same gap, but at a much lower absolute ceiling) so GC doesn't thrash by immediately re-triggering. Leaves **~19Gi of steady-state headroom** — comfortably above every node's current imagefs usage, and wide enough to absorb a 20Gi scratch burst without approaching the eviction line.

## Blast radius

`machine.kubelet.extraConfig` applies via a **kubelet service restart** (`talosctl patch machineconfig`, automatic mode) — not a full node reboot, and not the disk-repartition path `VolumeConfig`/`EPHEMERAL` sizing changes require. **Running pods are not evicted by this change.**

## What this PR does NOT do

**Merging alone does not apply anything.** Talos machine config isn't Flux-reconciled — per the repo's own conventions, rollout requires `task talos:apply-node IP=<ip>` per node, which needs `talosctl` and direct cluster access. That's a separate, explicit step after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)