### PR TITLE
feat(thanos): move compactor scratch off node-local /var to Longhorn

### DIFF
--- a/kubernetes/apps/monitoring/thanos/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/thanos/app/helmrelease.yaml
@@ -237,8 +237,13 @@ spec:
                 readOnly: true
 
       compactor-data:
-        type: emptyDir
-        sizeLimit: 20Gi
+        # emptyDir competed with the node's container images/logs for Talos's
+        # shared ~48Gi /var partition, and had no ephemeral-storage floor, so
+        # it was evicted first under any DiskPressure -- 2,737 evictions,
+        # zero successful compactions in 24h. See pvc.yaml (longhorn-scratch:
+        # single replica, no snapshots, no backups -- functionally scratch,
+        # just off node-local disk).
+        existingClaim: thanos-compactor-data
         advancedMounts:
           compactor:
             app:

--- a/kubernetes/apps/monitoring/thanos/app/kustomization.yaml
+++ b/kubernetes/apps/monitoring/thanos/app/kustomization.yaml
@@ -5,3 +5,4 @@ kind: Kustomization
 resources:
   - ./ocirepository.yaml
   - ./helmrelease.yaml
+  - ./pvc.yaml

--- a/kubernetes/apps/monitoring/thanos/app/pvc.yaml
+++ b/kubernetes/apps/monitoring/thanos/app/pvc.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: thanos-compactor-data
+spec:
+  accessModes: ["ReadWriteOnce"]
+  resources:
+    requests:
+      storage: 30Gi
+  storageClassName: longhorn-scratch

--- a/kubernetes/apps/storage/longhorn-system/app/storageclasses.yaml
+++ b/kubernetes/apps/storage/longhorn-system/app/storageclasses.yaml
@@ -125,3 +125,36 @@ parameters:
   dataLocality: best-effort
   replicaAutoBalance: best-effort
   recurringJobSelector: '[{"name":"tsdb","isGroup":true}]'
+
+---
+# Disposable working scratch — rewritten/discarded every run, worth zero snapshots
+# or backups (unlike snapshot-only/tsdb, which still take periodic snapshots for
+# rollback). Single replica: no redundancy value in scratch data, and no reason to
+# pay 2x write cost for it — on node loss the consumer just redownloads/recomputes.
+#
+# recurringJobSelector names a group ("scratch") that has NO RecurringJob targeting
+# it. This is deliberate, not an oversight: per #311, the CSI driver sets the
+# recurring-job-group label purely from this selector at provision time — it does
+# not check whether a job exists for the name. That label's mere presence is what
+# excludes the volume from Longhorn's `default` group (6-hourly snapshot + daily
+# backup) fallback. Since nothing ever targets "scratch", no job ever fires: no
+# snapshots are taken, so there is no chain to bloat — closer in behaviour to
+# emptyDir than to any other class here. Do NOT add a RecurringJob for this group;
+# that would defeat the point.
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: longhorn-scratch
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "false"
+    # params are immutable; let Flux recreate rather than fail the apply
+    kustomize.toolkit.fluxcd.io/force: "Enabled"
+provisioner: driver.longhorn.io
+allowVolumeExpansion: true
+reclaimPolicy: Delete
+volumeBindingMode: Immediate
+parameters:
+  numberOfReplicas: "1"
+  dataLocality: best-effort
+  replicaAutoBalance: best-effort
+  recurringJobSelector: '[{"name":"scratch","isGroup":true}]'


### PR DESCRIPTION
Fixes the compactor eviction loop directly, rather than out-tuning kubelet's eviction ordering (#313 addresses `/var` tightness fleet-wide but doesn't reserve headroom for this workload specifically).

## The bug

`compactor-data` was an `emptyDir` (`sizeLimit: 20Gi`, **no `ephemeral-storage` resource request**) competing with container images, logs, and every other pod on the node for Talos's shared ~48Gi `/var` partition. With no reserved floor, kubelet evicts it first under any `DiskPressure`.

Measured: **2,737 evictions since 2026-07-13, zero successful compactions logged in the prior 24 hours.** It downloads blocks, tips the node into pressure, gets killed, restarts from scratch, repeats.

## The fix

Move `/data` to a Longhorn PVC — off `/var` entirely.

**New `longhorn-scratch` StorageClass:**
- `numberOfReplicas: "1"` — no redundancy value in disposable working data. On node loss the compactor just redownloads from the object store on its next run; that's cheaper than paying 2x write cost for HA on data that's thrown away every run.
- `recurringJobSelector` names a **`scratch`** group with **deliberately zero backing `RecurringJob`**.

## Why zero-job, not `snapshot-only`/`tsdb`

Per the mechanism established in #311: the CSI driver sets the `recurring-job-group.longhorn.io/<name>` label purely from the StorageClass selector **at provision time** — it does not check whether any `RecurringJob` actually targets that name. That label's mere *presence* is what excludes the volume from Longhorn's `default`-group fallback (6-hourly snapshot + daily backup).

So naming a group nothing targets gets the same "excluded from default" protection as `snapshot-only`, but with a real difference: **since nothing ever targets `scratch`, no job ever fires** — no snapshots taken, no chain, no bloat, ever. `snapshot-only` still snapshots every 6h (appropriate for volumes you'd want to roll back). This data is rewritten/discarded every compaction run — there's nothing worth rolling back. This is functionally the closest thing to `emptyDir`'s behavior on the specific axis that mattered when `emptyDir` was originally chosen for this exact reason, just off contended node-local disk.

## Sizing

30Gi against measured **13.4Gi** live usage (previously capped at 20Gi). Longhorn supports **online expansion** later if needed — unlike `/var`, which requires the disk-repartition dance covered in #313's discussion.

No node pinning. cmp-02 (32.2Gi free-to-schedule) and cmp-03 (159Gi) both have headroom for a single 30Gi replica; Longhorn's scheduler picks a viable node on its own.

## Scope

`storegateway-data`'s `emptyDir` is untouched — this only reshapes the compactor's own working directory. Verified via `grep` that no other `persistence` block in the file changed.

## After merge

Flux reconciles the HelmRelease; the compactor Deployment picks up the new volume on its next pod recreation (no manual PVC dance needed — unlike the Prometheus StatefulSet cutover in #310, this is a Deployment with a directly-referenced PVC, not a `volumeClaimTemplate`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)