### PR TITLE
fix(thanos): grow compactor scratch PVC 30Gi -> 60Gi to clear catch-up backlog

### DIFF
--- a/kubernetes/apps/monitoring/thanos/app/pvc.yaml
+++ b/kubernetes/apps/monitoring/thanos/app/pvc.yaml
@@ -7,5 +7,12 @@ spec:
   accessModes: ["ReadWriteOnce"]
   resources:
     requests:
-      storage: 30Gi
+      # 30Gi (sized off steady-state ~13.4Gi usage) wasn't enough for the one-time
+      # catch-up backlog: 5 days without a successful compaction left a single group
+      # spanning 7 raw 2-day blocks, and Thanos's compactor needs ~2x the group's
+      # size locally (once to download the sources, once to build the merged
+      # output) -- observed ENOSPC at 29.79Gi actualSize. This is a one-time cost:
+      # steady-state compaction runs close to real-time in small increments once
+      # caught up, so no ongoing need for this much space is expected.
+      storage: 60Gi
   storageClassName: longhorn-scratch


### PR DESCRIPTION
Immediate follow-up to #314. That fix stopped the eviction loop (confirmed: 15+ min stable, 0 restarts, vs. 2,737 evictions previously) — but the compactor immediately hit a second, different wall on its own dedicated volume.

## What happened

5 days without a successful compaction (the exact loop #314 fixed) meant the compactor had a large one-time backlog: a single group spanning 7 raw 2-day blocks. Thanos needs roughly **2x a compaction group's size locally** — once to download the source blocks, once to build the merged output. 30Gi (sized off the ~13.4Gi steady-state usage measured before #314) wasn't enough:

```
preallocate: no space left on device
```

Confirmed at the volume: `actualSize=29.79Gi` of a 30Gi PVC.

## Why growing, not recreating

Unlike `storageClassName` (immutable, required the force-annotation dance in #310/#311), `spec.resources.requests.storage` is **not** an immutable PVC field — `allowVolumeExpansion: true` on `longhorn-scratch` makes this a live, additive, non-disruptive resize. Verified via server-side dry-run against the live PVC before committing this. No pod restart, no data loss, no force annotation needed.

## Why 60Gi, and why this shouldn't recur

This is sized for a one-time catch-up cost, not a new steady-state requirement. Once this backlog clears, ongoing compaction runs close to real-time in small increments and shouldn't approach this size again — the original 30Gi was a reasonable steady-state estimate; it just didn't anticipate the size of a 5-day-old backlog.

## Headroom check

cmp-03, where the volume's single replica already lives, has **129Gi free-to-schedule** — comfortably covering the extra 30Gi with room to spare.

🤖 Generated with [Claude Code](https://claude.com/claude-code)