### PR TITLE
fix(minio): stop bootstrap Jobs from permanently failing Kustomization health

### DIFF
--- a/kubernetes/apps/storage/minio/app/bucket-bootstrap-job.yaml
+++ b/kubernetes/apps/storage/minio/app/bucket-bootstrap-job.yaml
@@ -26,6 +26,14 @@ metadata:
     # Remove this job from Flux management after first successful run
     # by deleting it: kubectl -n storage delete job minio-bucket-bootstrap
     kustomize.toolkit.fluxcd.io/prune: "false"
+    # ssa: IfNotPresent tells kustomize-controller to skip applying this
+    # resource once it already exists in the cluster. Without this, every
+    # reconcile does a fresh dry-run apply against the completed Job, which
+    # fails with "field is immutable" (spec.template can't change, and the
+    # live object's controller-added labels, e.g. batch.kubernetes.io/controller-uid,
+    # never match a fresh dry-run projection) — leaving this Kustomization
+    # permanently Ready=False after the Job's first successful run.
+    kustomize.toolkit.fluxcd.io/ssa: IfNotPresent
 spec:
   backoffLimit: 2
   activeDeadlineSeconds: 3600

--- a/kubernetes/apps/storage/minio/app/bucket-quota-bootstrap-job.yaml
+++ b/kubernetes/apps/storage/minio/app/bucket-quota-bootstrap-job.yaml
@@ -43,6 +43,15 @@ metadata:
     # push to Git, then manually clean up the completed Job:
     #   kubectl -n storage delete job minio-bucket-quota-bootstrap
     kustomize.toolkit.fluxcd.io/prune: "false"
+    # ssa: IfNotPresent tells kustomize-controller to skip applying this
+    # resource once it already exists in the cluster. Without this, every
+    # reconcile does a fresh dry-run apply against the completed Job, which
+    # fails with "field is immutable" (spec.template can't change, and the
+    # live object's controller-added labels, e.g. batch.kubernetes.io/controller-uid,
+    # never match a fresh dry-run projection) — leaving this Kustomization
+    # permanently Ready=False after the Job's first successful run. See
+    # docs/incident-thanos-compactor-disk-pressure.md.
+    kustomize.toolkit.fluxcd.io/ssa: IfNotPresent
 spec:
   backoffLimit: 2
   activeDeadlineSeconds: 3600

--- a/kubernetes/apps/storage/minio/app/loki-user-bootstrap-job.yaml
+++ b/kubernetes/apps/storage/minio/app/loki-user-bootstrap-job.yaml
@@ -24,6 +24,14 @@ metadata:
     # Deleting the Job while it is still listed will cause Flux to recreate it
     # on the next reconcile.
     kustomize.toolkit.fluxcd.io/prune: "false"
+    # ssa: IfNotPresent tells kustomize-controller to skip applying this
+    # resource once it already exists in the cluster. Without this, every
+    # reconcile does a fresh dry-run apply against the completed Job, which
+    # fails with "field is immutable" (spec.template can't change, and the
+    # live object's controller-added labels, e.g. batch.kubernetes.io/controller-uid,
+    # never match a fresh dry-run projection) — leaving this Kustomization
+    # permanently Ready=False after the Job's first successful run.
+    kustomize.toolkit.fluxcd.io/ssa: IfNotPresent
 spec:
   template:
     spec:


### PR DESCRIPTION
## Summary
- The `storage/minio` Flux Kustomization has been permanently `Ready=False` after the first successful run of any of its three one-shot bootstrap Jobs (`minio-bucket-bootstrap`, `minio-bucket-quota-bootstrap`, `loki-user-bootstrap`). Kustomize-controller does a fresh dry-run apply of every resource on every reconcile, and a Job's `spec.template` is immutable — the live object's controller-added labels (e.g. `batch.kubernetes.io/controller-uid`) never match the dry-run's projection, so the dry-run fails with `field is immutable` indefinitely. This is a permanent false-alarm health status, not an actual problem (the Jobs are `Complete`, and Minio/HelmRelease/PVC are all fine).
- Add `kustomize.toolkit.fluxcd.io/ssa: IfNotPresent` to all three bootstrap Jobs. This is Flux's documented mechanism for resources that should be created once and then left alone — kustomize-controller skips applying (and dry-running) a resource entirely once it already exists in the cluster.
- Discovered/worked around today (manually deleting the quota-bootstrap Job before each reconcile) during the unrelated `docs/incident-thanos-compactor-disk-pressure.md` incident, but the bug predates that incident by 8+ days and affects all three sibling Jobs identically.

## Test plan
- [x] YAML validated (`yaml.safe_load_all`) for all three edited files
- [ ] `kustomize build kubernetes/apps/storage/minio/app` (blocked in this worktree — no `kustomize`/`task`/`mise` binary available)
- [ ] Flux Local CI workflow on this PR
- [ ] After merge: force two consecutive Flux reconciles of `storage/minio` and confirm `kubectl -n storage get kustomization minio` stays `Ready=True` both times

🤖 Generated with [Claude Code](https://claude.com/claude-code)