### PR TITLE
fix(minio): apply ssa: IfNotPresent to thanos-user-bootstrap Job too

### DIFF
--- a/kubernetes/apps/storage/minio/app/thanos-user-bootstrap-job.yaml
+++ b/kubernetes/apps/storage/minio/app/thanos-user-bootstrap-job.yaml
@@ -35,6 +35,16 @@ metadata:
     # because Flux will recreate it on the next reconcile while it remains in
     # the resources list.
     kustomize.toolkit.fluxcd.io/prune: "false"
+    # ssa: IfNotPresent tells kustomize-controller to skip applying this
+    # resource once it already exists in the cluster. Without this, a
+    # reconcile can do a fresh dry-run apply against the completed Job, which
+    # fails with "field is immutable" (spec.template can't change, and the
+    # live object's controller-added labels, e.g. batch.kubernetes.io/controller-uid,
+    # never match a fresh dry-run projection) — leaving this Kustomization
+    # Ready=False after the Job's first successful run. Same fix applied to
+    # this Job's three siblings (bucket-bootstrap, bucket-quota-bootstrap,
+    # loki-user-bootstrap) after the failure was observed on those.
+    kustomize.toolkit.fluxcd.io/ssa: IfNotPresent
 spec:
   backoffLimit: 2
   activeDeadlineSeconds: 3600


### PR DESCRIPTION
## Summary
- Follow-up to #324. While verifying that fix live, I found a fourth bootstrap Job in the same app — \`thanos-user-bootstrap-job.yaml\` — that wasn't named in the original report but is cut from the identical one-shot \`mc\` bootstrap template and has the same missing annotation and the same controller-injected \`spec.template.metadata.labels\` shape as the three Jobs already fixed.
- It hasn't been observed failing a reconcile yet (kustomize-controller logged it as `"unchanged"` rather than `"skipped"` during my verification pass), but nothing about it is structurally different from the three that did fail, so it carries the same latent risk. Applying the same `kustomize.toolkit.fluxcd.io/ssa: IfNotPresent` annotation for consistency.

## Test plan
- [x] YAML validated
- [ ] Flux Local CI workflow on this PR
- [ ] After merge: force a reconcile of `storage/minio` and confirm `Job/storage/thanos-user-bootstrap` shows `"skipped"` (or at minimum `Ready=True` holds) in kustomize-controller's server-side-apply log

🤖 Generated with [Claude Code](https://claude.com/claude-code)