### PR TITLE
perf(requests): right-size over-provisioned CPU requests

### DIFF
--- a/kubernetes/apps/default/hermes-ai-agent/app/helmrelease.yaml
+++ b/kubernetes/apps/default/hermes-ai-agent/app/helmrelease.yaml
@@ -76,7 +76,9 @@ spec:
                   failureThreshold: 60
             resources:
               requests:
-                cpu: 250m
+                # Idles ~3m; 50m keeps burst headroom without over-reserving
+                # scheduling capacity (limits below still allow bursting).
+                cpu: 50m
                 memory: 512Mi
               limits:
                 cpu: 2000m

--- a/kubernetes/apps/default/n8n/app/helmrelease.yaml
+++ b/kubernetes/apps/default/n8n/app/helmrelease.yaml
@@ -47,7 +47,9 @@ spec:
               N8N_LOG_OUTPUT: console
             resources:
               requests:
-                cpu: 250m
+                # Idles ~6m; 50m keeps burst headroom without over-reserving
+                # scheduling capacity (limits below still allow bursting).
+                cpu: 50m
                 memory: 512Mi
               limits:
                 cpu: 2000m

--- a/kubernetes/apps/flux-system/flux-instance/app/helmrelease.yaml
+++ b/kubernetes/apps/flux-system/flux-instance/app/helmrelease.yaml
@@ -58,6 +58,26 @@ spec:
             target:
               kind: Deployment
               name: (kustomize-controller|helm-controller|source-controller)
+          - # Right-size CPU requests. Controllers idle at 1-3m but the
+            # flux-operator defaults reserve 50-100m each; only the CPU
+            # request is lowered (no CPU limit is set, so bursting during
+            # reconciliation is unaffected).
+            patch: |
+              apiVersion: apps/v1
+              kind: Deployment
+              metadata:
+                name: all
+              spec:
+                template:
+                  spec:
+                    containers:
+                      - name: manager
+                        resources:
+                          requests:
+                            cpu: 25m
+            target:
+              kind: Deployment
+              name: (kustomize-controller|helm-controller|source-controller|notification-controller)
           - # Enable in-memory kustomize builds
             patch: |
               - op: add

--- a/kubernetes/apps/serverless/knative-operator/app/helmrelease.yaml
+++ b/kubernetes/apps/serverless/knative-operator/app/helmrelease.yaml
@@ -46,3 +46,22 @@ spec:
             patch: |
               - op: remove
                 path: /data/_example
+          # Right-size operator CPU requests. Both deployments idle at ~1-3m
+          # but the chart reserves 100m each; only the CPU request is lowered
+          # (memory request and limits are untouched, bursting unaffected).
+          - target:
+              kind: Deployment
+              name: knative-operator
+              namespace: knative-serving
+            patch: |
+              - op: replace
+                path: /spec/template/spec/containers/0/resources/requests/cpu
+                value: 25m
+          - target:
+              kind: Deployment
+              name: operator-webhook
+              namespace: knative-serving
+            patch: |
+              - op: replace
+                path: /spec/template/spec/containers/0/resources/requests/cpu
+                value: 25m

--- a/kubernetes/apps/serverless/knative-serving/app/knativeserving.yaml
+++ b/kubernetes/apps/serverless/knative-serving/app/knativeserving.yaml
@@ -7,6 +7,48 @@ metadata:
 spec:
   # Keep control-plane and APIs on the latest 1.21 patch stream.
   version: "1.21"
+  # Right-size control-plane CPU requests. The upstream defaults reserve
+  # 300m (activator) / 100m (others), but these components idle at 1-2m on
+  # this cluster and were the bulk of a scheduling-headroom warning on one
+  # node. Memory requests and all limits are preserved, so bursting is
+  # unchanged — only the CPU reservation shrinks.
+  workloads:
+    - name: activator
+      resources:
+        - container: activator
+          requests:
+            cpu: 50m
+            memory: 60Mi
+          limits:
+            cpu: "1"
+            memory: 600Mi
+    - name: autoscaler
+      resources:
+        - container: autoscaler
+          requests:
+            cpu: 25m
+            memory: 100Mi
+          limits:
+            cpu: "1"
+            memory: 1000Mi
+    - name: controller
+      resources:
+        - container: controller
+          requests:
+            cpu: 25m
+            memory: 100Mi
+          limits:
+            cpu: "1"
+            memory: 1000Mi
+    - name: webhook
+      resources:
+        - container: webhook
+          requests:
+            cpu: 25m
+            memory: 100Mi
+          limits:
+            cpu: 500m
+            memory: 500Mi
   ingress:
     istio:
       enabled: false


### PR DESCRIPTION
## Problem

`hiro-cmp-01` sat at **~96% CPU requests** (2833m / 2950m allocatable), firing `NodeCpuRequestsHigh` and leaving no scheduling headroom — yet actual CPU usage there was only **~49%**. The reservation, not real load, was the constraint. (The related `NodeCpuRequestsCritical`/`NodeMemoryRequests*` alerts were separately resolved — they were inflated by a large batch of evicted pods that the request-sum query counts regardless of phase.)

Investigation showed many workloads reserving **30–300×** their idle CPU usage:

| Workload | Was | Idle usage | Now |
|---|---|---|---|
| knative activator | 300m | 1m | 50m |
| n8n | 250m | 6m | 50m |
| hermes-ai-agent | 250m | 3m | 50m |
| knative autoscaler/controller/webhook | 100m each | 1–2m | 25m |
| knative-operator + operator-webhook | 100m each | 1–3m | 25m |
| flux source/kustomize/helm/notification | 50–100m | 1–3m | 25m |

## Change

Trim CPU **requests** only. **Memory requests and all limits are preserved**, so every workload can still burst exactly as before — only the scheduling reservation shrinks. Mechanisms per app:

- `default/n8n`, `default/hermes-ai-agent` — HelmRelease values.
- `knative-serving` — `KnativeServing spec.workloads` resource overrides (memory + limits carried over explicitly).
- `knative-operator` — `postRenderers` kustomize JSON-patch on the two operator deployments.
- `flux-instance` — new `kustomize.patches` entry (the controllers set no CPU limit, so bursts during reconciliation are unaffected).

Frees ~1.3 CPU of reservation concentrated on cmp-01, dropping it well under the 85% warning threshold.

## Validation

- `kubectl kustomize` renders clean for all five app directories.
- Flux Local diff on this PR is the real gate — please confirm the rendered request values before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)