### PR TITLE
perf(monitoring): steer Prometheus to 3-CPU nodes + slow apiserver scrape

### DIFF
--- a/kubernetes/apps/monitoring/kube-prometheus-stack/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/kube-prometheus-stack/app/helmrelease.yaml
@@ -53,6 +53,15 @@ spec:
 
     kubeApiServer:
       serviceMonitor:
+        # Scrape the apiserver at 60s instead of the 30s global default. The
+        # apiserver is ~43% of total sample ingestion (its large histograms),
+        # so halving its scrape rate is the single biggest reduction in TSDB
+        # write I/O — which was saturating the (2-CPU) node running Prometheus.
+        # All apiserver-derived rules use [5m]+ windows and are unaffected; the
+        # one exception is the stock KubeAggregatedAPIErrors alert (a [1m]
+        # window), which is disabled by this change — an accepted trade for a
+        # homelab. Everything else stays at the 30s global interval.
+        interval: 60s
         metricRelabelings:
           # Drop high-cardinality apiserver histograms not needed for basic homelab dashboards.
           #
@@ -128,6 +137,19 @@ spec:
         # Alertmanager or the Thanos storegateway, to avoid CPU contention
         # (see monitoring/thanos helmrelease.yaml for the matching rule).
         affinity:
+          # Soft preference for the 3-CPU nodes (cmp-01/cmp-02). Prometheus is
+          # the heaviest stateful I/O workload here; keeping it off the 2-CPU
+          # nodes (cmp-03/cmp-04) avoids saturating them. Preference, not a
+          # hard requirement — it still schedules elsewhere if these are full.
+          # Matched by hostname since the nodes carry no CPU-tier label.
+          nodeAffinity:
+            preferredDuringSchedulingIgnoredDuringExecution:
+              - weight: 100
+                preference:
+                  matchExpressions:
+                    - key: kubernetes.io/hostname
+                      operator: In
+                      values: ["hiro-cmp-01", "hiro-cmp-02"]
           podAntiAffinity:
             preferredDuringSchedulingIgnoredDuringExecution:
               - weight: 100


### PR DESCRIPTION
## Problem

`hiro-cmp-04` (a **2-CPU** node) was pinned at **~98% CPU** while the **3-CPU** `cmp-02` sat at **~17%**. Diagnosis showed the load is I/O, not compute:

| CPU mode on cmp-04 | cores |
|---|---|
| system (kernel storage I/O) | 751m |
| user (instance-manager ~590m + Prometheus + apps) | 623m |
| softirq (block + network) | 312m |
| idle | **9m** |

Nothing was malfunctioning — no rebuilds, no failing backups, no snapshot bloat, healthy volumes. The **Prometheus pod had landed on the small node** and was driving the TSDB write I/O. Ingestion is **7.2k samples/s**, of which the **apiserver is ~43%** (its large histograms).

## Changes

**1. Soft nodeAffinity → prefer the 3-CPU nodes (cmp-01/cmp-02) for Prometheus.**
Preference, not a hard pin (still schedules elsewhere if those are full). Matched by hostname (nodes carry no CPU-tier label). Interplay with the existing anti-affinity (off alertmanager@cmp-01, storegateway@cmp-03) means **cmp-02 scores highest** — the idle 3-CPU node. Takes effect on Prometheus's next reschedule, which this HelmRelease change itself triggers.

**2. apiserver ServiceMonitor `interval: 30s → 60s`.**
Single biggest cut to TSDB write I/O (and block-upload volume to MinIO). Everything else stays at the 30s global.

### Scrape-interval tradeoff (why apiserver-only, why safe)
- Checked all 199 rule range-windows: apiserver-derived rules use `[5m]`+ and are unaffected.
- The **one** casualty is the stock `KubeAggregatedAPIErrors` alert (`[1m]` window) — disabled by a 60s scrape. Accepted trade for a homelab.
- Retention (3d/10GB, ~4.3GB actual) is already lean — left unchanged.

## Validation
- `kubectl kustomize` renders clean.
- Flux Local diff is the real gate — please confirm the rendered `prometheusSpec.affinity` and the apiserver ServiceMonitor interval before merge.

## Follow-up (not in this PR)
Longer-term scaling pressure will come from **series cardinality** (327k head series today), not scrape interval — worth watching `prometheus_tsdb_head_series` as apps are added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)