### PR TITLE
docs(agents): note node CPU asymmetry + stateful I/O placement

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -413,7 +413,7 @@ grep -r "kind: OCIRepository" kubernetes/apps/<group>/
 | Item | Value |
 |---|---|
 | Kubernetes distribution | Talos Linux |
-| Nodes | 4 (Proxmox VMs: 192.168.25.21–24) |
+| Nodes | 4 (Proxmox VMs: 192.168.25.21–24). **CPU-asymmetric**: `hiro-cmp-01`/`-02` have 3 CPU, `hiro-cmp-03`/`-04` have 2 CPU (memory uniform ~11.8Gi). Steer heavy stateful I/O workloads (e.g. Prometheus) to the 3-CPU nodes — on the 2-CPU nodes the Longhorn instance-manager + kernel I/O path dominates CPU, so high CPU there is usually I/O, not compute. |
 | GitOps engine | Flux CD (flux-operator + flux-instance) |
 | CNI | Cilium |
 | Ingress | Envoy Gateway (Gateway API): `envoy-external`, `envoy-internal` |


### PR DESCRIPTION
## What

Adds the node **CPU asymmetry** to the cluster-details table in the agent instructions — it wasn't recorded anywhere in the repo:

- `hiro-cmp-01` / `-02` → **3 CPU**
- `hiro-cmp-03` / `-04` → **2 CPU**
- memory uniform (~11.8Gi)

Plus the operational lesson from the recent cmp-04 saturation incident: steer heavy stateful I/O workloads (e.g. Prometheus) to the 3-CPU nodes, because on the 2-CPU nodes the Longhorn instance-manager + kernel I/O path dominates CPU — so high CPU there is usually I/O, not compute.

## Why

During the cmp-04 (98% CPU) diagnosis, the asymmetry was the key fact that explained the hotspot, and it's the fact that guided the Prometheus soft-affinity fix (#333). Knowing it up front would have shortcut the whole investigation, and it'll guide every future placement decision. Docs-only, no manifest impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)