### PR TITLE
fix(thanos): shrink compactor scratch PVC 60Gi -> 30Gi

### DIFF
--- a/kubernetes/apps/monitoring/thanos/app/pvc.yaml
+++ b/kubernetes/apps/monitoring/thanos/app/pvc.yaml
@@ -7,12 +7,17 @@ spec:
   accessModes: ["ReadWriteOnce"]
   resources:
     requests:
-      # 30Gi (sized off steady-state ~13.4Gi usage) wasn't enough for the one-time
-      # catch-up backlog: 5 days without a successful compaction left a single group
-      # spanning 7 raw 2-day blocks, and Thanos's compactor needs ~2x the group's
-      # size locally (once to download the sources, once to build the merged
-      # output) -- observed ENOSPC at 29.79Gi actualSize. This is a one-time cost:
-      # steady-state compaction runs close to real-time in small increments once
-      # caught up, so no ongoing need for this much space is expected.
-      storage: 60Gi
+      # Sized for steady-state compaction (~13.4Gi observed live usage), ~2x
+      # headroom. Thanos's compactor needs roughly 2x a compaction group's size
+      # locally at peak: it downloads the source blocks and builds the merged
+      # output alongside them before uploading and deleting the sources.
+      #
+      # History: was temporarily grown (60Gi, then 120Gi) to absorb a one-time
+      # catch-up backlog -- a 5-day gap without a successful compaction produced
+      # a single group spanning 7 raw 2-day blocks, which ENOSPC'd the original
+      # 30Gi at 29.79Gi actualSize. That backlog is fully processed (fs drained
+      # to near-empty), so this returns to a steady-state size. If a large
+      # multi-day backlog ever recurs (e.g. the compactor is halted for days),
+      # grow this again temporarily; steady-state does not need more.
+      storage: 30Gi
   storageClassName: longhorn-scratch


### PR DESCRIPTION
## What
Shrink `thanos-compactor-data` scratch PVC 60Gi → 30Gi.

## Why
The one-time catch-up backlog that required the temporary grow is fully processed. The compactor volume drained to near-empty (932K live) while Longhorn held **84.6G** of untrimmed + snapshot bloat for it. Return to steady-state size (~13.4Gi observed, ~2x headroom for a compaction group's ~2x peak).

## How
Longhorn has no in-place shrink, so the PVC was deleted and is reprovisioned empty from this manifest. Scratch data, no backup — the compactor re-downloads its working set on next run. Replicas were on cmp-05/cmp-03, so this also frees StorageScheduled reservation there.

## Restore sequence (on merge)
Compactor is currently scaled to 0 with the PVC deleted. On merge, Flux recreates the PVC at 30Gi and the HelmRelease scales the compactor back to 1, binding the fresh volume.

🤖 Generated with [Claude Code](https://claude.com/claude-code)