### PR TITLE
fix(alloy): tail pod logs from files instead of the Kubernetes API

### DIFF
--- a/kubernetes/apps/monitoring/alloy/app/configmap.yaml
+++ b/kubernetes/apps/monitoring/alloy/app/configmap.yaml
@@ -19,8 +19,71 @@ data:
       }
     }
 
-    loki.source.kubernetes "pods" {
-      targets    = discovery.kubernetes.pods.targets
+    // File-based tailing of /var/log/pods with on-disk positions.
+    // Replaces loki.source.kubernetes (API tailer) which kept its read
+    // position only in memory and, on every send failure, re-tailed from the
+    // earliest container-runtime-retained line. For low-volume long-lived pods
+    // that line is >7d old, so Loki (reject_old_samples_max_age: 168h) rejected
+    // it, the send failed, and it re-read the same old region forever.
+    discovery.relabel "pods" {
+      targets = discovery.kubernetes.pods.targets
+
+      // Preserve the label schema the old loki.source.kubernetes emitted so
+      // existing Grafana queries keep working: instance="<ns>/<pod>:<container>".
+      rule {
+        source_labels = ["__meta_kubernetes_namespace", "__meta_kubernetes_pod_name"]
+        separator     = "/"
+        target_label  = "instance"
+      }
+      rule {
+        source_labels = ["instance", "__meta_kubernetes_pod_container_name"]
+        separator     = ":"
+        target_label  = "instance"
+      }
+      rule {
+        action       = "replace"
+        target_label = "job"
+        replacement  = "loki.source.kubernetes.pods"
+      }
+
+      // /var/log/pods/<ns>_<pod>_<uid>/<container>/*.log
+      rule {
+        source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
+        separator     = "/"
+        action        = "replace"
+        replacement   = "/var/log/pods/*$1/*.log"
+        target_label  = "__path__"
+      }
+
+      // Container runtime, used to gate CRI parsing below; dropped before write.
+      rule {
+        source_labels = ["__meta_kubernetes_pod_container_id"]
+        regex         = "^(\\S+):\\/\\/.+$"
+        replacement   = "$1"
+        target_label  = "tmp_container_runtime"
+      }
+    }
+
+    local.file_match "pods" {
+      path_targets = discovery.relabel.pods.output
+    }
+
+    loki.source.file "pods" {
+      targets    = local.file_match.pods.targets
+      forward_to = [loki.process.pods.receiver]
+    }
+
+    loki.process "pods" {
+      // Recover the real log timestamp + stream from the CRI-format line.
+      stage.match {
+        selector = "{tmp_container_runtime=\"containerd\"}"
+        stage.cri {}
+      }
+      // Drop helper labels so streams match the previous schema exactly
+      // (filename is added automatically by loki.source.file).
+      stage.label_drop {
+        values = ["tmp_container_runtime", "filename"]
+      }
       forward_to = [loki.write.default.receiver]
     }
 

--- a/kubernetes/apps/monitoring/alloy/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/alloy/app/helmrelease.yaml
@@ -28,6 +28,10 @@ spec:
         create: false
         name: alloy-config
         key: config.alloy
+      # Mount host /var/log (read-only) so loki.source.file can tail
+      # /var/log/pods/*/*/*.log.
+      mounts:
+        varlog: true
       extraEnv:
         - name: NODE_NAME
           valueFrom:


### PR DESCRIPTION
## Problem

Alloy was flooding its logs with Loki `400 Bad Request` errors and **dropping log data**:

> `has timestamp too old: 2026-07-19T14:59:59Z, oldest acceptable timestamp is: ...`

Loki's `reject_old_samples_max_age: 168h` (7d) rejected the batches. The affected streams were quiet, long-lived pods (kube-scheduler, controller-manager, cilium, csi daemons) — those pods had **no current logs in Loki at all**, while high-volume pods ingested fine.

## Root cause

`loki.source.kubernetes` tails pod logs via the Kubernetes API and keeps its read position **only in memory**. On any send failure it re-tails from the earliest container-runtime-retained line. For low-volume long-lived pods that line is >7d old → Loki rejects it → send fails → it re-reads the same old region → repeat. A self-sustaining loop that never advanced to current logs.

Confirmation: the newly-added node's Alloy pod (fresh, no old container logs) had **zero** such errors; rejected timestamps sat exactly on the sliding 7d boundary.

## Fix

Switch to the file-based pipeline (Grafana's recommended DaemonSet pattern):

`discovery.kubernetes` → `discovery.relabel` → `local.file_match` (`/var/log/pods/*/*/*.log`) → `loki.source.file` → `loki.process` (CRI parse) → `loki.write`

- `loki.source.file` persists read positions to disk and does **not** rewind on send errors — the loop is gone.
- `alloy.mounts.varlog: true` mounts host `/var/log` so the container can read `/var/log/pods`.
- Label schema preserved (`instance="<ns>/<pod>:<container>"`, `job="loki.source.kubernetes.pods"`); `filename`/helper labels dropped — **existing Grafana queries/dashboards unaffected**.

## Reviewer notes

- **One-time burst on rollout**: first read starts at each file's head, so the >7d tail is rejected once, then steady state. Self-limits.
- **Positions on emptyDir** (chart default `storagePath`): survive container restarts; wiped on pod delete/reschedule → one bounded re-read burst per pod, not a loop. Can back with hostPath later if desired.
- Verify after reconcile: `timestamp too old` errors stop; `{instance=~"kube-system/kube-scheduler-hiro-cmp-04.*"}` shows fresh entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)