### PR TITLE
feat(talos): declare Image Factory schematic inline, add util-linux-tools

### DIFF
--- a/talos/talconfig.yaml
+++ b/talos/talconfig.yaml
@@ -23,7 +23,25 @@ nodes:
     installDisk: "/dev/sda"
     machineSpec:
       secureboot: false
-    talosImageURL: factory.talos.dev/installer/10f9392d7091b30abf573524649756e5bc894f653af525836e9ab0297f301fc2
+    # Image Factory schematic, declared inline rather than as a hardcoded
+    # talosImageURL: talhelper submits this to the factory and derives the
+    # installer URL itself, so the 64-char schematic ID is never hand-copied.
+    # (It is a sha256 of the schematic body, so it changes whenever this list
+    # does — a typed ID silently drifts, and did: cmp-05 previously carried a
+    # 65-char ID the factory 404'd on.)
+    #
+    # iscsi-tools + util-linux-tools are both Longhorn requirements — the
+    # latter provides the `fstrim` binary Longhorn nsenters into for
+    # filesystem-trim / space reclamation. qemu-guest-agent is the Proxmox
+    # guest integration.
+    schematic: &schematic
+      customization:
+        systemExtensions:
+          officialExtensions:
+            - siderolabs/iscsi-tools
+            - siderolabs/nfs-utils
+            - siderolabs/qemu-guest-agent
+            - siderolabs/util-linux-tools
     controlPlane: true
     networkInterfaces:
       - deviceSelector:
@@ -48,7 +66,7 @@ nodes:
     installDisk: "/dev/sda"
     machineSpec:
       secureboot: false
-    talosImageURL: factory.talos.dev/installer/10f9392d7091b30abf573524649756e5bc894f653af525836e9ab0297f301fc2
+    schematic: *schematic
     controlPlane: true
     networkInterfaces:
       - deviceSelector:
@@ -73,7 +91,7 @@ nodes:
     installDisk: "/dev/sda"
     machineSpec:
       secureboot: false
-    talosImageURL: factory.talos.dev/installer/10f9392d7091b30abf573524649756e5bc894f653af525836e9ab0297f301fc2
+    schematic: *schematic
     controlPlane: true
     networkInterfaces:
       - deviceSelector:
@@ -98,7 +116,7 @@ nodes:
     installDisk: "/dev/sda"
     machineSpec:
       secureboot: false
-    talosImageURL: factory.talos.dev/installer/10f9392d7091b30abf573524649756e5bc894f653af525836e9ab0297f301fc2
+    schematic: *schematic
     controlPlane: true
     networkInterfaces:
       - deviceSelector:
@@ -123,7 +141,7 @@ nodes:
     installDisk: "/dev/sda"
     machineSpec:
       secureboot: false
-    talosImageURL: factory.talos.dev/installer/188d1f7a5c4f1d3aba7df787c448c1d3d008ed29cfb34af53fa0df4336a56040b
+    schematic: *schematic
     controlPlane: true
     networkInterfaces:
       - deviceSelector:

--- a/talos/talconfig.yaml
+++ b/talos/talconfig.yaml
@@ -31,7 +31,7 @@ nodes:
     # 65-char ID the factory 404'd on.)
     #
     # iscsi-tools + util-linux-tools are both Longhorn requirements — the
-    # latter provides the `fstrim` binary Longhorn nsenters into for
+    # latter provides the `fstrim` binary that Longhorn runs via `nsenter` for
     # filesystem-trim / space reclamation. qemu-guest-agent is the Proxmox
     # guest integration.
     schematic: &schematic


### PR DESCRIPTION
Closes the config half of #285. **Sequence: 2 of 4.** Merge after #354. A node roll follows this merge and gates PR 3.

## Why

Longhorn's `filesystem-trim` fails on Talos with `nsenter: failed to execute fstrim: No such file or directory: exit status 127` — Talos ships no `util-linux`. Without trim, freed blocks are never unmapped and volume `actualSize` ratchets toward the provisioned size regardless of retention.

Measured 2026-07-28 (real FS usage vs Longhorn `actualSize`):

| Volume | Real used | actualSize |
|---|---|---|
| thanos-compactor-data | 0.4 MB | 11.9 GiB |
| prometheus-db | 3.8 GB | 31.8 GiB |
| storage-loki-0 | 0.11 GB | 8.4 GiB |
| minio | 26.8 GB | 94.8 GiB |

## What

Replaces five hardcoded `talosImageURL` values with a single anchored talhelper `schematic:` block. talhelper submits the schematic to the Image Factory and derives the installer URL itself, so the 64-char ID — a sha256 of the schematic body — is never hand-typed and cannot drift from the extension list.

Extension list is **additive**; `nfs-utils` and `qemu-guest-agent` are retained deliberately (the latter is the Proxmox guest integration):

```yaml
- siderolabs/iscsi-tools
- siderolabs/nfs-utils
- siderolabs/qemu-guest-agent
- siderolabs/util-linux-tools
```

Registered image: `factory.talos.dev/installer/c23d16533980fd972f96a79cc22130404615c16de18f43da4a40d801d4fe8d6a:v1.13.7`

## Also fixes

`hiro-cmp-05` carried a **65-character** schematic ID that the factory 404s (`schematic not found`). No node carries its own ID any more, so this is corrected as a side effect.

## Not verified locally

`talhelper` isn't available in the authoring environment, so `task talos:generate-config` has not been run. Do that before any upgrade — `upgrade-node` reads the generated `clusterconfig/`, not `talconfig.yaml`.

## Rollout notes

All five nodes are `controlPlane: true`; there are no workers. Talos wipes EPHEMERAL on upgrade by default and **etcd member data lives there** — with cmp-05 cordoned that leaves 4 members against a quorum of 3. Recommend `--preserve`. Longhorn replica data is unaffected either way; it lives on the `/dev/sdb` UserVolume.

🤖 Generated with [Claude Code](https://claude.com/claude-code)