### PR TITLE
feat(longhorn): reclaim volume space with scoped filesystem-trim

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -189,7 +189,7 @@ Apps surfaced on the Homepage dashboard carry `gethomepage.dev/*` annotations (`
 ## Storage
 
 - **Longhorn** is the only storage provisioner. Volumes are backed by dedicated disks on each node (Talos `UserVolumeConfig` in `talos/patches/global/machine-volumes.yaml`).
-- Backups target an S3-compatible endpoint (MinIO) — backup configuration lives in `kubernetes/apps/storage/longhorn-system/`.
+- Backups target **AWS S3** (`s3://hiro-longhorn-backups@us-east-1/`), not the in-cluster MinIO — backup configuration lives in `kubernetes/apps/storage/longhorn-system/default-backup-target.yaml`. MinIO is an application object store (Thanos, Loki), not the Longhorn backupstore; do not conflate the two when reasoning about what survives a cluster loss.
 - **Several storage classes exist** (defined in `kubernetes/apps/storage/longhorn-system/app/storageclasses.yaml`). Choose by redundancy and backup needs:
 
   | Class | Replicas | Recurring backups | Use for |
@@ -421,7 +421,8 @@ grep -r "kind: OCIRepository" kubernetes/apps/<group>/
 | DNS (internal) | k8s_gateway |
 | TLS | cert-manager, `letsencrypt-production` ClusterIssuer, wildcard cert in `network` ns |
 | Storage | Longhorn (multiple classes: replica count × backup policy) |
-| Object storage | MinIO (`storage` ns) — Thanos, Loki, Longhorn backups |
+| Object storage | MinIO (`storage` ns) — Thanos, Loki. **Not** the Longhorn backup target |
+| Longhorn backups | AWS S3, `s3://hiro-longhorn-backups@us-east-1/` |
 | Secrets | SOPS + age |
 | Dependency updates | Renovate (Saturdays, conventional commits) |
 | CI validation | flux-local (test + diff) |

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -189,7 +189,7 @@ Apps surfaced on the Homepage dashboard carry `gethomepage.dev/*` annotations (`
 ## Storage
 
 - **Longhorn** is the only storage provisioner. Volumes are backed by dedicated disks on each node (Talos `UserVolumeConfig` in `talos/patches/global/machine-volumes.yaml`).
-- Backups target **AWS S3** (`s3://hiro-longhorn-backups@us-east-1/`), not the in-cluster MinIO — backup configuration lives in `kubernetes/apps/storage/longhorn-system/default-backup-target.yaml`. MinIO is an application object store (Thanos, Loki), not the Longhorn backupstore; do not conflate the two when reasoning about what survives a cluster loss.
+- Backups target **AWS S3** (`s3://hiro-longhorn-backups@us-east-1/`), not the in-cluster MinIO — backup configuration lives in `kubernetes/apps/storage/longhorn-system/app/default-backup-target.yaml`. MinIO is an application object store (Thanos, Loki), not the Longhorn backupstore; do not conflate the two when reasoning about what survives a cluster loss.
 - **Several storage classes exist** (defined in `kubernetes/apps/storage/longhorn-system/app/storageclasses.yaml`). Choose by redundancy and backup needs:
 
   | Class | Replicas | Recurring backups | Use for |

--- a/kubernetes/apps/storage/longhorn-system/app/default-jobs.yaml
+++ b/kubernetes/apps/storage/longhorn-system/app/default-jobs.yaml
@@ -88,8 +88,8 @@ spec:
 # per job. Where a group's class has chain removal enabled, the trim is
 # scheduled BEFORE that group's next snapshot (not after), so the volume is left
 # bare for the shortest possible window: tsdb trims 03:00 against a 04:15
-# snapshot, snapshot-only trims 03:00 Sunday against a 05:00 snapshot. All are
-# clear of the 02:45 backup window.
+# snapshot; snapshot-only trims 03:00 Sunday against a 05:00 snapshot. Trims start
+# after the 02:45 default-group backup, but may overlap if the backup runs long.
 apiVersion: longhorn.io/v1beta2
 kind: RecurringJob
 metadata:

--- a/kubernetes/apps/storage/longhorn-system/app/default-jobs.yaml
+++ b/kubernetes/apps/storage/longhorn-system/app/default-jobs.yaml
@@ -57,3 +57,64 @@ spec:
   - tsdb
   retain: 2
   concurrency: 1
+
+---
+
+# filesystem-trim jobs. Longhorn never unmaps blocks freed by the guest
+# filesystem on its own, so volume actualSize ratchets toward the provisioned
+# size no matter what the application retains -- measured 2026-07-28:
+# thanos-compactor-data held 11.9GiB for 0.4MB of data, prometheus-db 31.8GiB
+# for 3.8GB. These jobs run `fstrim` against the guest filesystem to give the
+# space back. Paired with removeSnapshotsDuringFilesystemTrim in helmrelease.yaml,
+# which lets the reclaim reach bytes pinned behind snapshots.
+#
+# REQUIRES the siderolabs/util-linux-tools Talos extension (see #285) -- Talos
+# ships no `fstrim` binary, and without it Longhorn fails these with exit 127.
+#
+# Trim is I/O heavy and these nodes are 2-3 CPU, so: concurrency 1, one group
+# per job, staggered clear of the snapshot (:15 past every 6h, 4:15) and backup
+# (2:45) windows.
+apiVersion: longhorn.io/v1beta2
+kind: RecurringJob
+metadata:
+  name: longhorn-tsdb-trim-job
+  namespace: storage
+spec:
+  cron: "30 5 * * *" # every day at 5:30 AM, after the 4:15 tsdb snapshot
+  task: "filesystem-trim"
+  groups:
+  - tsdb
+  concurrency: 1
+
+---
+
+# The "scratch" group intentionally has no *snapshot* job (see storageclasses.yaml).
+# A trim job is the deliberate exception: it takes no snapshot, so it creates no
+# chain to bloat -- it only returns space these throwaway volumes have already
+# stopped using. Do not read this as license to add snapshot/backup jobs here.
+apiVersion: longhorn.io/v1beta2
+kind: RecurringJob
+metadata:
+  name: longhorn-scratch-trim-job
+  namespace: storage
+spec:
+  cron: "30 3 * * *" # every day at 3:30 AM
+  task: "filesystem-trim"
+  groups:
+  - scratch
+  concurrency: 1
+
+---
+
+apiVersion: longhorn.io/v1beta2
+kind: RecurringJob
+metadata:
+  name: longhorn-general-trim-job
+  namespace: storage
+spec:
+  cron: "30 6 * * 0" # weekly, Sunday 6:30 AM
+  task: "filesystem-trim"
+  groups:
+  - default
+  - snapshot-only
+  concurrency: 1

--- a/kubernetes/apps/storage/longhorn-system/app/default-jobs.yaml
+++ b/kubernetes/apps/storage/longhorn-system/app/default-jobs.yaml
@@ -28,17 +28,23 @@ spec:
 
 ---
 
+# Currently only MinIO. Dialled back from 6-hourly/retain-3 to daily/retain-2:
+# the 6h cadence was buying logical-recovery granularity nobody uses while
+# pinning tens of GiB (one snapshot alone held 96.9GiB against 26.8GB of live
+# data). Runs at 05:00, two hours after longhorn-snapshot-only-trim-job, so the
+# weekly trim's chain removal is followed by a fresh restore point rather than
+# leaving the volume bare until the next day.
 apiVersion: longhorn.io/v1beta2
 kind: RecurringJob
 metadata:
   name: longhorn-snapshot-only-job
   namespace: storage
 spec:
-  cron: "15 */6 * * *" # every 6 hours at minute 15
+  cron: "0 5 * * *" # every day at 5:00 AM
   task: "snapshot"
   groups:
   - snapshot-only
-  retain: 3
+  retain: 2
   concurrency: 2
 
 ---
@@ -65,22 +71,32 @@ spec:
 # size no matter what the application retains -- measured 2026-07-28:
 # thanos-compactor-data held 11.9GiB for 0.4MB of data, prometheus-db 31.8GiB
 # for 3.8GB. These jobs run `fstrim` against the guest filesystem to give the
-# space back. Paired with removeSnapshotsDuringFilesystemTrim in helmrelease.yaml,
-# which lets the reclaim reach bytes pinned behind snapshots.
+# space back.
+#
+# How far a trim reaches depends on the volume's unmapMarkSnapChainRemoved,
+# which is set per StorageClass (see storageclasses.yaml), NOT here:
+#   enabled  (tsdb, scratch, *-no-backup) -- also reclaims bytes pinned behind
+#            snapshots, at the cost of collapsing the whole snapshot chain.
+#   ignored  (longhorn, longhorn-1/-2)    -- inherits the global `false`, so the
+#            trim can only reclaim unreferenced blocks and never removes a
+#            snapshot. Safe on any volume.
 #
 # REQUIRES the siderolabs/util-linux-tools Talos extension (see #285) -- Talos
 # ships no `fstrim` binary, and without it Longhorn fails these with exit 127.
 #
 # Trim is I/O heavy and these nodes are 2-3 CPU, so: concurrency 1, one group
-# per job, staggered clear of the snapshot (:15 past every 6h, 4:15) and backup
-# (2:45) windows.
+# per job. Where a group's class has chain removal enabled, the trim is
+# scheduled BEFORE that group's next snapshot (not after), so the volume is left
+# bare for the shortest possible window: tsdb trims 03:00 against a 04:15
+# snapshot, snapshot-only trims 03:00 Sunday against a 05:00 snapshot. All are
+# clear of the 02:45 backup window.
 apiVersion: longhorn.io/v1beta2
 kind: RecurringJob
 metadata:
   name: longhorn-tsdb-trim-job
   namespace: storage
 spec:
-  cron: "30 5 * * *" # every day at 5:30 AM, after the 4:15 tsdb snapshot
+  cron: "0 3 * * *" # every day at 3:00 AM — 75min BEFORE the 4:15 tsdb snapshot
   task: "filesystem-trim"
   groups:
   - tsdb
@@ -98,7 +114,7 @@ metadata:
   name: longhorn-scratch-trim-job
   namespace: storage
 spec:
-  cron: "30 3 * * *" # every day at 3:30 AM
+  cron: "30 1 * * *" # every day at 1:30 AM
   task: "filesystem-trim"
   groups:
   - scratch
@@ -106,6 +122,31 @@ spec:
 
 ---
 
+# snapshot-only (MinIO) is the one group where trim runs against a class with
+# unmapMarkSnapChainRemoved=enabled AND a meaningful restore point, so the
+# ordering matters: chain removal here at 03:00, fresh snapshot at 05:00 from
+# longhorn-snapshot-only-job. The 2h separation is padding, not synchronisation
+# -- Longhorn has no post-trim hook, so a trim that overruns simply reclaims
+# less that week. It cannot corrupt anything or skip the snapshot.
+apiVersion: longhorn.io/v1beta2
+kind: RecurringJob
+metadata:
+  name: longhorn-snapshot-only-trim-job
+  namespace: storage
+spec:
+  cron: "0 3 * * 0" # weekly, Sunday 3:00 AM — 2h before the daily snapshot
+  task: "filesystem-trim"
+  groups:
+  - snapshot-only
+  concurrency: 1
+
+---
+
+# Trim-only, by decision (2026-07-28): the `default` group's 15 volumes keep
+# their full 6-hourly snapshot chain and daily AWS S3 backups. This job can only
+# reclaim unreferenced blocks -- the class sets no unmapMarkSnapChainRemoved, so
+# it inherits the global `false` and cannot remove a snapshot. Revisit enabling
+# chain removal here once there is measured bloat to justify it.
 apiVersion: longhorn.io/v1beta2
 kind: RecurringJob
 metadata:
@@ -116,5 +157,4 @@ spec:
   task: "filesystem-trim"
   groups:
   - default
-  - snapshot-only
   concurrency: 1

--- a/kubernetes/apps/storage/longhorn-system/app/helmrelease.yaml
+++ b/kubernetes/apps/storage/longhorn-system/app/helmrelease.yaml
@@ -35,6 +35,25 @@ spec:
       guaranteedReplicaManagerCPU: "10"
       nodeDownPodDeletionPolicy: delete-both-statefulset-and-deployment-pod
       orphanAutoDeletion: true
+      # Let filesystem-trim reclaim space that sits behind snapshots. Without
+      # this, trim only unmaps blocks in the live head volume and anything
+      # already captured by a snapshot stays allocated forever -- which is how
+      # prometheus-db reached 31.8GiB actualSize against 3.8GB of real data.
+      #
+      # Trade-off, deliberate: during a trim Longhorn marks the latest snapshot
+      # and its ancestors removed (stopping at any snapshot with multiple
+      # children), so rollback points are collapsed. Acceptable here -- the
+      # `default` group still ships daily backups to Minio, and the volumes that
+      # actually bloat (Prometheus TSDB, Thanos/Loki scratch) hold data that is
+      # either reproducible or already durable in object storage.
+      #
+      # Set globally rather than per-class on purpose: the per-volume
+      # `unmapMarkSnapChainRemoved` field is only stamped from a StorageClass
+      # parameter at provision time, so a class-level setting would not reach
+      # any volume that already exists (same trap as the recurring-job labels,
+      # see storageclasses.yaml). Every current volume is `ignored`, i.e.
+      # "follow the global setting", so this takes effect immediately.
+      removeSnapshotsDuringFilesystemTrim: true
       replicaAutoBalance: best-effort
       storageMinimalAvailablePercentage: "1"
       storageReservedPercentageForDefaultDisk: "5"

--- a/kubernetes/apps/storage/longhorn-system/app/helmrelease.yaml
+++ b/kubernetes/apps/storage/longhorn-system/app/helmrelease.yaml
@@ -35,25 +35,27 @@ spec:
       guaranteedReplicaManagerCPU: "10"
       nodeDownPodDeletionPolicy: delete-both-statefulset-and-deployment-pod
       orphanAutoDeletion: true
-      # Let filesystem-trim reclaim space that sits behind snapshots. Without
-      # this, trim only unmaps blocks in the live head volume and anything
-      # already captured by a snapshot stays allocated forever -- which is how
-      # prometheus-db reached 31.8GiB actualSize against 3.8GB of real data.
+      # Deliberately FALSE (also the Longhorn default; stated explicitly to
+      # record the decision). This is the global fallback for volumes whose
+      # `unmapMarkSnapChainRemoved` is `ignored`, i.e. all of them today.
       #
-      # Trade-off, deliberate: during a trim Longhorn marks the latest snapshot
-      # and its ancestors removed (stopping at any snapshot with multiple
-      # children), so rollback points are collapsed. Acceptable here -- the
-      # `default` group still ships daily backups to Minio, and the volumes that
-      # actually bloat (Prometheus TSDB, Thanos/Loki scratch) hold data that is
-      # either reproducible or already durable in object storage.
+      # Two separable knobs, do not conflate them:
+      #   - a filesystem-trim RecurringJob (see default-jobs.yaml) is always
+      #     safe: it can only unmap blocks nothing references, and can never
+      #     touch a snapshot.
+      #   - snapshot-chain removal is destructive: during a trim Longhorn marks
+      #     the latest snapshot AND ALL ITS ANCESTORS removed, stopping only at
+      #     a snapshot with multiple children. Recurring jobs produce a linear
+      #     chain, so in practice the volume is left with ZERO restore points
+      #     until its next scheduled snapshot.
       #
-      # Set globally rather than per-class on purpose: the per-volume
-      # `unmapMarkSnapChainRemoved` field is only stamped from a StorageClass
-      # parameter at provision time, so a class-level setting would not reach
-      # any volume that already exists (same trap as the recurring-job labels,
-      # see storageclasses.yaml). Every current volume is `ignored`, i.e.
-      # "follow the global setting", so this takes effect immediately.
-      removeSnapshotsDuringFilesystemTrim: true
+      # Turning that on cluster-wide would strip the chain from all 15 volumes
+      # in the `default` group to reclaim space that has only actually been
+      # measured on four. Enabled per-class instead (see storageclasses.yaml),
+      # for volumes whose contents are reproducible or already durable
+      # elsewhere. Revisit for `default` once the trim-only jobs have run and
+      # there is evidence of bloat there.
+      removeSnapshotsDuringFilesystemTrim: false
       replicaAutoBalance: best-effort
       storageMinimalAvailablePercentage: "1"
       storageReservedPercentageForDefaultDisk: "5"

--- a/kubernetes/apps/storage/longhorn-system/app/helmrelease.yaml
+++ b/kubernetes/apps/storage/longhorn-system/app/helmrelease.yaml
@@ -37,7 +37,7 @@ spec:
       orphanAutoDeletion: true
       # Deliberately FALSE (also the Longhorn default; stated explicitly to
       # record the decision). This is the global fallback for volumes whose
-      # `unmapMarkSnapChainRemoved` is `ignored`, i.e. all of them today.
+      # `unmapMarkSnapChainRemoved` is `ignored` (e.g. existing volumes until manually patched).
       #
       # Two separable knobs, do not conflate them:
       #   - a filesystem-trim RecurringJob (see default-jobs.yaml) is always

--- a/kubernetes/apps/storage/longhorn-system/app/storageclasses.yaml
+++ b/kubernetes/apps/storage/longhorn-system/app/storageclasses.yaml
@@ -63,6 +63,9 @@ parameters:
   numberOfReplicas: "3"
   dataLocality: best-effort
   replicaAutoBalance: best-effort
+  # Reproducible/bulk data — let filesystem-trim reclaim space pinned behind
+  # snapshots. See default-jobs.yaml and helmrelease.yaml for the trade-off.
+  unmapMarkSnapChainRemoved: "enabled"
   recurringJobSelector: '[{"name":"snapshot-only","isGroup":true}]'
 
 ---
@@ -82,6 +85,9 @@ parameters:
   numberOfReplicas: "1"
   dataLocality: best-effort
   replicaAutoBalance: best-effort
+  # Reproducible/bulk data — let filesystem-trim reclaim space pinned behind
+  # snapshots. See default-jobs.yaml and helmrelease.yaml for the trade-off.
+  unmapMarkSnapChainRemoved: "enabled"
   recurringJobSelector: '[{"name":"snapshot-only","isGroup":true}]'
 
 ---
@@ -101,6 +107,9 @@ parameters:
   numberOfReplicas: "2"
   dataLocality: best-effort
   replicaAutoBalance: best-effort
+  # Reproducible/bulk data — let filesystem-trim reclaim space pinned behind
+  # snapshots. See default-jobs.yaml and helmrelease.yaml for the trade-off.
+  unmapMarkSnapChainRemoved: "enabled"
   recurringJobSelector: '[{"name":"snapshot-only","isGroup":true}]'
 
 ---
@@ -124,6 +133,10 @@ parameters:
   numberOfReplicas: "2"
   dataLocality: best-effort
   replicaAutoBalance: best-effort
+  # TSDB churn is exactly the case snapshot-pinned blocks hurt most; the durable
+  # copy lives in object storage, so collapsing local restore points on trim is
+  # an accepted trade. See default-jobs.yaml.
+  unmapMarkSnapChainRemoved: "enabled"
   recurringJobSelector: '[{"name":"tsdb","isGroup":true}]'
 
 ---
@@ -163,4 +176,6 @@ parameters:
   numberOfReplicas: "1"
   dataLocality: best-effort
   replicaAutoBalance: best-effort
+  # Nothing here is worth a restore point in the first place.
+  unmapMarkSnapChainRemoved: "enabled"
   recurringJobSelector: '[{"name":"scratch","isGroup":true}]'

--- a/kubernetes/apps/storage/longhorn-system/app/storageclasses.yaml
+++ b/kubernetes/apps/storage/longhorn-system/app/storageclasses.yaml
@@ -132,15 +132,21 @@ parameters:
 # rollback). Single replica: no redundancy value in scratch data, and no reason to
 # pay 2x write cost for it — on node loss the consumer just redownloads/recomputes.
 #
-# recurringJobSelector names a group ("scratch") that has NO RecurringJob targeting
-# it. This is deliberate, not an oversight: per #311, the CSI driver sets the
-# recurring-job-group label purely from this selector at provision time — it does
-# not check whether a job exists for the name. That label's mere presence is what
-# excludes the volume from Longhorn's `default` group (6-hourly snapshot + daily
-# backup) fallback. Since nothing ever targets "scratch", no job ever fires: no
-# snapshots are taken, so there is no chain to bloat — closer in behaviour to
-# emptyDir than to any other class here. Do NOT add a RecurringJob for this group;
-# that would defeat the point.
+# recurringJobSelector names a group ("scratch") with no snapshot or backup
+# RecurringJob targeting it. This is deliberate, not an oversight: per #311, the
+# CSI driver sets the recurring-job-group label purely from this selector at
+# provision time — it does not check whether a job exists for the name. That
+# label's mere presence is what excludes the volume from Longhorn's `default`
+# group (6-hourly snapshot + daily backup) fallback. No chain is ever created, so
+# none can bloat — closer in behaviour to emptyDir than to any other class here.
+# Do NOT add a snapshot or backup RecurringJob for this group; that would defeat
+# the point.
+#
+# The one job that DOES target "scratch" is longhorn-scratch-trim-job
+# (task: filesystem-trim, see default-jobs.yaml). Trim takes no snapshot — it only
+# unmaps blocks the volume has already stopped using — so it reclaims space
+# without reintroducing a chain. thanos-compactor-data was holding 11.9GiB of
+# allocation against 0.4MB of live data before that job existed.
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:


### PR DESCRIPTION
Closes the reclamation half of #285. **Sequence: 3 of 4.**

> [!WARNING]
> **Do not merge until #355 is merged AND every node reports `util-linux-tools` in `talosctl get extensions`.** Without `fstrim` on the host these jobs fire nightly and fail with exit 127.

## The two knobs, deliberately separated

- A `filesystem-trim` RecurringJob is **always safe** — it unmaps only unreferenced blocks and can never touch a snapshot.
- Snapshot-chain removal is **destructive**: Longhorn marks the latest snapshot *and all its ancestors* removed, stopping only at a snapshot with multiple children. Recurring jobs produce a linear chain, so the volume is left with **zero** restore points until its next snapshot — not one fewer.

Global `removeSnapshotsDuringFilesystemTrim` stays **false**, stated explicitly to record the decision. Chain removal is enabled per StorageClass via `unmapMarkSnapChainRemoved` on `longhorn-tsdb`, `longhorn-scratch` and the three `*-no-backup` classes, whose contents are reproducible or already durable in object storage.

**The `default` group's 15 volumes get trim-only** and keep their full 6-hourly chain and daily backups. Enabling chain removal there would strip 15 volumes to reclaim space measured on four. Revisit with evidence.

## Schedule

Trim runs **before** each group's next snapshot, not after, so the window with no restore point is as short as possible:

| Group | Trim | Next snapshot | Bare window |
|---|---|---|---|
| snapshot-only (minio) | Sun 03:00 weekly | 05:00 daily | 2h |
| tsdb (prometheus) | 03:00 daily | 04:15 daily | 1h15 |
| scratch (compactor) | 01:30 daily | none by design | n/a |
| default (15 vols) | Sun 06:30 weekly | 6-hourly | none — trim-only |

The gap is padding, not synchronisation — Longhorn has no post-trim hook, so a trim that overruns simply reclaims less that week.

MinIO's snapshot cadence also drops from 6-hourly/retain-3 to daily/retain-2; the finer granularity was pinning tens of GiB (one snapshot alone held 96.9 GiB against 26.8 GB of live data) for recovery points that go unused.

## Manual step after merge

`unmapMarkSnapChainRemoved` is stamped from the StorageClass **at provision time only**, so existing volumes stay `ignored`. Patch them once, before the first trim fires:

```sh
kubectl -n storage patch volumes.longhorn.io \ pvc-e70f015b-e7e5-488c-af2c-497d79a736ff \ pvc-0f7daeb2-7d32-4b42-b145-15be40d4609b \ pvc-e7b3d058-c535-4cdc-ae3f-0dce0f82d102 \ --type=merge -p '{"spec":{"unmapMarkSnapChainRemoved":"enabled"}}'
```

(prometheus-db, thanos-compactor-data, minio. Same trap as the recurring-job-group labels in #311.)

## Doc correction included

The Longhorn backup target is **AWS S3** (`s3://hiro-longhorn-backups@us-east-1/`), not the in-cluster MinIO. `.github/copilot-instructions.md` claimed otherwise in two places; both fixed. MinIO is an application object store — conflating the two overstates what a MinIO loss costs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)