### PR TITLE
feat(loki): move PVC to longhorn-tsdb

### DIFF
--- a/kubernetes/apps/monitoring/loki/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/loki/app/helmrelease.yaml
@@ -115,7 +115,7 @@ spec:
         #
         # longhorn-tsdb, moved off `longhorn` (2026-07-28): aligns Loki's RPO with
         # Prometheus, which is the right shape for it -- chunks and index ship to
-        # MinIO continuously (30m idle / 2h max chunk age, 5m index resync), so
+        # MinIO continuously, so
         # the local volume is a buffer, not the durable copy. The class name is
         # accurate despite the workload not being metrics: Loki's own schema is
         # `store: tsdb` with a tsdb_shipper index.

--- a/kubernetes/apps/monitoring/loki/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/loki/app/helmrelease.yaml
@@ -109,10 +109,9 @@ spec:
         # StatefulSet volumeClaimTemplates are IMMUTABLE. Editing this value does
         # not move an existing PVC -- the rebuilt StatefulSet just adopts the old
         # one. Changing it requires deleting the PVC so it reprovisions, and that
-        # must be preceded by an explicit `POST /flush` against the ingester plus
-        # confirmation that the observability-loki bucket stopped growing (see
-        # ingester.wal.flush_on_shutdown above -- graceful shutdown alone is
-        # best-effort, not a guarantee).
+        # must be preceded by an explicit `POST /flush` plus confirmation that the
+        # observability-loki bucket stopped growing — graceful shutdown alone is
+        # best-effort, not a guarantee.
         #
         # longhorn-tsdb, moved off `longhorn` (2026-07-28): aligns Loki's RPO with
         # Prometheus, which is the right shape for it -- chunks and index ship to

--- a/kubernetes/apps/monitoring/loki/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/loki/app/helmrelease.yaml
@@ -106,10 +106,28 @@ spec:
     singleBinary:
       replicas: 1
       persistence:
-        # StatefulSet volumeClaimTemplates are immutable; keep this stable after first deploy.
-        # To suppress Longhorn recurring backups/snapshots, disable the volume's default
-        # recurring-job label instead of changing storageClass in-place.
-        storageClass: longhorn
+        # StatefulSet volumeClaimTemplates are IMMUTABLE. Editing this value does
+        # not move an existing PVC -- the rebuilt StatefulSet just adopts the old
+        # one. Changing it requires deleting the PVC so it reprovisions, and that
+        # must be preceded by an explicit `POST /flush` against the ingester plus
+        # confirmation that the observability-loki bucket stopped growing (see
+        # ingester.wal.flush_on_shutdown above -- graceful shutdown alone is
+        # best-effort, not a guarantee).
+        #
+        # longhorn-tsdb, moved off `longhorn` (2026-07-28): aligns Loki's RPO with
+        # Prometheus, which is the right shape for it -- chunks and index ship to
+        # MinIO continuously (30m idle / 2h max chunk age, 5m index resync), so
+        # the local volume is a buffer, not the durable copy. The class name is
+        # accurate despite the workload not being metrics: Loki's own schema is
+        # `store: tsdb` with a tsdb_shipper index.
+        #
+        # Consequences, accepted deliberately: 3 replicas -> 2; daily AWS S3
+        # backups via the `default` recurring-job group are LOST (the tsdb group
+        # has no backup job); 6-hourly snapshots become daily/retain-2; and
+        # filesystem-trim will collapse the snapshot chain, so there are windows
+        # with no local restore point. All fine given a few hours of log loss is
+        # tolerable here and older data lives in MinIO.
+        storageClass: longhorn-tsdb
         size: 10Gi
       resources:
         requests:

--- a/kubernetes/apps/storage/longhorn-system/app/storageclasses.yaml
+++ b/kubernetes/apps/storage/longhorn-system/app/storageclasses.yaml
@@ -113,7 +113,7 @@ parameters:
 #
 # The name describes the access pattern, not strictly the payload: high block
 # churn, local volume as buffer rather than system of record, no Longhorn backup
-# because the real copy is already in S3/MinIO. It happens to stay literally
+# because the real copy is already in MinIO (S3-compatible object storage). It happens to stay literally
 # accurate for Loki too, whose schema is `store: tsdb`. A policy-shaped rename
 # (longhorn-derived or similar) was considered on 2026-07-28 and deliberately
 # deferred — revisit if a third non-metrics workload lands here.

--- a/kubernetes/apps/storage/longhorn-system/app/storageclasses.yaml
+++ b/kubernetes/apps/storage/longhorn-system/app/storageclasses.yaml
@@ -104,10 +104,19 @@ parameters:
   recurringJobSelector: '[{"name":"snapshot-only","isGroup":true}]'
 
 ---
-# TSDB/write-heavy volumes (e.g., Prometheus) — daily snapshot only via longhorn-tsdb-snapshot-job.
-# The Prometheus PVC was moved onto this class in #310; the daily/retain-2 cadence is
-# what keeps its snapshot chain from outrunning cleanup. Use this class (not the
-# *-no-backup ones, which snapshot 6-hourly) for any new continuously-written volume.
+# Continuously-written volumes whose durable copy lives in object storage —
+# Prometheus (Thanos/MinIO) and Loki (MinIO). Daily snapshot only, via
+# longhorn-tsdb-snapshot-job. The Prometheus PVC moved here in #310; the
+# daily/retain-2 cadence is what keeps its snapshot chain from outrunning
+# cleanup. Use this class (not the *-no-backup ones, which snapshot 6-hourly)
+# for any new continuously-written volume.
+#
+# The name describes the access pattern, not strictly the payload: high block
+# churn, local volume as buffer rather than system of record, no Longhorn backup
+# because the real copy is already in S3/MinIO. It happens to stay literally
+# accurate for Loki too, whose schema is `store: tsdb`. A policy-shaped rename
+# (longhorn-derived or similar) was considered on 2026-07-28 and deliberately
+# deferred — revisit if a third non-metrics workload lands here.
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:


### PR DESCRIPTION
**Sequence: 4 of 4.** Merge after #356. Touches `storageclasses.yaml`, so rebase if #356 lands first and Git complains.

## Why

Aligns Loki's RPO with Prometheus. The local volume is a buffer, not the system of record — chunks ship to MinIO at 30m idle / 2h max chunk age, index resyncs every 5m. It was carrying **7.8 GiB of Longhorn allocation against 0.11 GB of real data** while sitting on the `default` group's 3 replicas, 6-hourly snapshots and daily S3 backups.

## Accepted consequences

| | before (`longhorn`) | after (`longhorn-tsdb`) |
|---|---|---|
| Replicas | 3 | 2 |
| Snapshots | 6-hourly, retain 3 | daily 04:15, retain 2 |
| AWS S3 backups | daily | **none** |
| Trim | none | daily 03:00, collapses the chain |

The backup loss is the notable one: afterwards Loki's local volume has no off-cluster copy, and recovery is entirely "re-read from MinIO". Accepted — a few hours of log loss is tolerable here.

## Class name kept

A policy-shaped rename (`longhorn-derived`) was considered and deferred. `longhorn-tsdb` stays literally accurate: Loki's own schema is `store: tsdb` with a `tsdb_shipper` index. The class comment now describes the access pattern it selects for — high churn, local volume as buffer, durable copy in object storage — rather than naming only Prometheus.

## This PR does not move the volume

StatefulSet `volumeClaimTemplates` are immutable; the rebuilt StatefulSet adopts the existing PVC on the old class. Same trap that made #265's Prometheus resize a no-op. The PVC must be deleted by hand to reprovision.

> [!IMPORTANT]
> Flush first, or lose up to 2h of chunks that exist only in the WAL.
>
> The Loki image is distroless — no shell, no `curl`, no `wget` — so `kubectl exec` cannot reach the endpoint. Port-forward instead:
> ```sh
> kubectl -n monitoring port-forward loki-0 3100:3100
> ```
> then, from another shell:
> ```sh
> curl -sS -XPOST http://localhost:3100/flush -w '\nHTTP %{http_code}\n'
> ```
> `204` means *accepted*, not *complete* — the flush is async. Wait for `loki_ingester_memory_chunks` to reach 0 before going further:
> ```sh
> curl -sS http://localhost:3100/metrics | grep loki_ingester_memory_chunks
> ```
> Confirm the `observability-loki` bucket stopped growing, then scale the StatefulSet to 0, delete the PVC, and scale back up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
