### PR TITLE
fix(ci): repair broken quoting in image-scan image extraction

### DIFF
--- a/.github/workflows/image-scan.yaml
+++ b/.github/workflows/image-scan.yaml
@@ -42,7 +42,7 @@ jobs:
         run: |
           grep -E '^\s*image:\s*' rendered.yaml \
             | awk -F': ' '{print $2}' \
-            | sed -E 's/^["'"'"'"']//; s/["'"'"'"']$//' \
+            | sed -E 's/^["'\'']//; s/["'\'']$//' \
             | sort -u > images.txt
           echo "Found $(wc -l < images.txt) unique image references"
 


### PR DESCRIPTION
## The bug

The `sed` in the **Extract referenced container images** step of `.github/workflows/image-scan.yaml` builds the character class `["']`, but has one `"'"` too many in the single-quote escape sequence, leaving an unbalanced double quote. Bash cannot parse the line at all.

```diff
-            | sed -E 's/^["'"'"'"']//; s/["'"'"'"']$//' \
+            | sed -E 's/^["'\'']//; s/["'\'']$//' \
```

## Impact

**The Image Vulnerability Scan has been dead for weeks.** 4 of the last 5 runs failed on exactly this:

```
/home/runner/work/_temp/….sh: line 5: unexpected EOF while looking for matching `"'
##[error]Process completed with exit code 2
```

| Run | Result |
|---|---|
| 2026-07-27 | failure |
| 2026-07-26 | success |
| 2026-07-20 | failure |
| 2026-07-13 | failure |
| 2026-07-12 | failure |

It went unnoticed because the workflow is weekly and report-only: a failure produces no PR comment, and an empty step summary looks much like a clean scan. No Trivy results have actually been produced in that window.

## Verification

Extracted the step from the workflow with a YAML parser (so the real bytes are tested, not a retyped copy) and ran it under bash against a fixture covering double-quoted, single-quoted, and bare image references:

```
Found        4 unique image references
docker.io/foo/bar:1.2
ghcr.io/baz/qux:3.4
ghcr.io/dup/same:9.9
registry.k8s.io/plain:5.6
```

5 input lines → 4 unique. Both quote styles strip, bare refs pass through untouched, and a ref appearing both quoted and unquoted collapses to one entry — confirming the strip happens before `sort -u`, which is the point of the expression.

## Provenance

Found by `shellcheck` via `actionlint` (SC1072/SC1073/SC1078/SC1079) while linting an unrelated branch. The only other actionlint finding in the repo is SC2094 in `e2e.yaml`, which is a false positive (`sops --filename-override` names a path it does not read) in a workflow gated to `onedr0p/cluster-template` that never runs here — left alone deliberately.

This is the sole occurrence of the malformed idiom repo-wide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)