### PR TITLE
fix(longhorn): raise storage over-provisioning to 150%

### DIFF
--- a/kubernetes/apps/storage/longhorn-system/app/helmrelease.yaml
+++ b/kubernetes/apps/storage/longhorn-system/app/helmrelease.yaml
@@ -58,6 +58,28 @@ spec:
       removeSnapshotsDuringFilesystemTrim: false
       replicaAutoBalance: best-effort
       storageMinimalAvailablePercentage: "1"
+      # Raised from Longhorn's default of 100. Longhorn schedules against a
+      # replica's *allocated* size, never its used bytes, and this cluster is
+      # heavily thin-provisioned -- measured actual vs scheduled per disk when
+      # this was changed: cmp-01 10/42Gi, cmp-02 22/79Gi, cmp-03 57/210Gi,
+      # cmp-04 14/45Gi, cmp-05 35/160Gi. At 100% the scheduler was rejecting
+      # placements the disks had ample real room for.
+      #
+      # Trigger: thanos-compactor-data (30Gi, longhorn-scratch, dataLocality
+      # best-effort) could not place its local replica alongside its pod on
+      # cmp-02 -- 79Gi already scheduled against a 99Gi ceiling left 20Gi of
+      # headroom for a 30Gi replica. The volume sat permanently at
+      # Scheduled=False/LocalReplicaSchedulingFailure with its only replica
+      # running remotely on cmp-05, so every compaction read/write crossed the
+      # network. 150% lifts cmp-02's ceiling to 148Gi and the replica fits.
+      #
+      # 150 and not 200: this keeps a real ceiling rather than removing one.
+      # Over-provisioning is a bet that volumes do not all fill at once, and at
+      # least one here can genuinely reach its full allocation (the compactor
+      # ENOSPC'd at 29.79Gi during a backlog -- see thanos/app/pvc.yaml).
+      # storageMinimalAvailablePercentage above is the backstop: Longhorn still
+      # refuses to schedule onto a disk that is actually near-full.
+      storageOverProvisioningPercentage: "150"
       storageReservedPercentageForDefaultDisk: "5"
     ingress:
       enabled: false


### PR DESCRIPTION
## Problem

`monitoring/thanos-compactor-data` (PV `pvc-0f7daeb2-7d32-4b42-b145-15be40d4609b`) has been sitting at:

```
Scheduled=False  reason=LocalReplicaSchedulingFailure  msg=insufficient storage
```

The volume's data path is fine — `attached`, `robustness: healthy`, engine RW, filesystem 444K used of 29.4G. The defect is placement.

The PVC is 30Gi on `longhorn-scratch` (`numberOfReplicas: 1`, `dataLocality: best-effort`). The compactor pod runs on **cmp-02**; best-effort locality therefore spawns a shadow replica pinned with `hardNodeAffinity: hiro-cmp-02`, which cannot be scheduled and is stuck `stopped` at `rebuildRetryCount: 5`. The one live replica runs on **cmp-05**, so every compaction read/write crosses the network.

## Root cause

Longhorn schedules against a replica's **allocated** size, never its used bytes. cmp-02's disk: `storageMaximum` 99Gi, `storageReserved` 0, over-provisioning 100% → a hard 99Gi ceiling. 79Gi was already scheduled (30Gi of it the Prometheus TSDB), leaving 20Gi of headroom for a 30Gi replica. Short by 10Gi, permanently.

Actual vs scheduled per disk at time of change — the cluster is heavily thin-provisioned and the 100% default was rejecting placements the disks had real room for:

| node | actual used | scheduled | max |
|---|---|---|---|
| cmp-01 | 10Gi | 42Gi | 99Gi |
| cmp-02 | 22Gi | 79Gi | 99Gi |
| cmp-03 | 57Gi | 210Gi | 299Gi |
| cmp-04 | 14Gi | 45Gi | 99Gi |
| cmp-05 | 35Gi | 160Gi | 299Gi |

## Change

Sets `storageOverProvisioningPercentage: "150"` explicitly in the Longhorn `defaultSettings` (previously inheriting the upstream default of 100). The chart renders this into the `longhorn-default-setting` ConfigMap; longhorn-manager v1.12.0 reconciles the Setting CR from it live, so no manager restart is needed.

cmp-02's ceiling becomes 148Gi; 79 + 30 = 109Gi fits.

## Why 150 and not 200

This keeps a real ceiling rather than removing one. Over-provisioning is a bet that volumes don't all fill at once, and at least one here genuinely can reach full allocation — the compactor ENOSPC'd at 29.79Gi during a backlog (see `kubernetes/apps/monitoring/thanos/app/pvc.yaml`). `storageMinimalAvailablePercentage: "1"` remains the backstop: Longhorn still refuses to schedule onto a disk that is actually near-full, and replicas are sparse so allocation doesn't consume real space up front.

## Expected effect after merge

Longhorn places the local replica on cmp-02, the `Scheduled=False` condition clears, and the cmp-05 replica is dropped once the (444K) rebuild completes. Compaction I/O becomes node-local.

## Not addressed here

cmp-05 is a control-plane node reporting **4.1GiB RAM** against ~11.8Gi on every other node, currently uncordoned, and holds the cluster's only single-replica volume. Deliberately left alone in this PR — tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)