### PR TITLE
feat(freecad): add FreeCAD webtop to default namespace

### DIFF
--- a/kubernetes/apps/default/freecad/app/helmrelease.yaml
+++ b/kubernetes/apps/default/freecad/app/helmrelease.yaml
@@ -1,0 +1,115 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app freecad
+spec:
+  interval: 1h
+  timeout: 15m
+  chartRef:
+    kind: OCIRepository
+    name: freecad
+  install:
+    remediation:
+      retries: -1
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  values:
+    controllers:
+      main:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            image:
+              repository: docker.io/linuxserver/freecad
+              tag: 1.1.3
+            env:
+              TZ: ${TIMEZONE}
+              PUID: "1000"
+              PGID: "1000"
+            probes:
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /
+                    port: 3000
+                  initialDelaySeconds: 30
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 3
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /
+                    port: 3000
+                  initialDelaySeconds: 10
+                  periodSeconds: 10
+                  timeoutSeconds: 5
+                  failureThreshold: 3
+              startup:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /
+                    port: 3000
+                  initialDelaySeconds: 10
+                  periodSeconds: 10
+                  timeoutSeconds: 5
+                  failureThreshold: 30
+            resources:
+              requests:
+                cpu: 100m
+                memory: 512Mi
+              limits:
+                memory: 4Gi
+
+    service:
+      app:
+        controller: main
+        ports:
+          http:
+            port: 3000
+
+    route:
+      app:
+        annotations:
+          gethomepage.dev/enabled: "true"
+          gethomepage.dev/icon: https://freecad.${SECRET_DOMAIN}/favicon.ico
+          gethomepage.dev/title: FreeCAD
+          gethomepage.dev/description: "FreeCAD 3D CAD Modeler"
+          gethomepage.dev/group: "Design"
+        hostnames:
+          - freecad.${SECRET_DOMAIN}
+        parentRefs:
+          - name: envoy-internal
+            namespace: network
+            sectionName: https
+        rules:
+          - backendRefs:
+              - identifier: app
+                port: 3000
+
+    persistence:
+      config:
+        existingClaim: freecad-config
+        globalMounts:
+          - path: /config
+
+      tmp:
+        type: emptyDir
+
+      shm:
+        type: emptyDir
+        medium: Memory
+        sizeLimit: 1Gi
+        globalMounts:
+          - path: /dev/shm

--- a/kubernetes/apps/default/freecad/app/kustomization.yaml
+++ b/kubernetes/apps/default/freecad/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml
+  - ./pvc.yaml

--- a/kubernetes/apps/default/freecad/app/ocirepository.yaml
+++ b/kubernetes/apps/default/freecad/app/ocirepository.yaml
@@ -9,5 +9,5 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: 5.1.3
+    tag: 5.0.1
   url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/default/freecad/app/ocirepository.yaml
+++ b/kubernetes/apps/default/freecad/app/ocirepository.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: freecad
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.1.3
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/default/freecad/app/pvc.yaml
+++ b/kubernetes/apps/default/freecad/app/pvc.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: freecad-config
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 500Mi
+  storageClassName: longhorn

--- a/kubernetes/apps/default/freecad/ks.yaml
+++ b/kubernetes/apps/default/freecad/ks.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: freecad
+spec:
+  interval: 1h
+  path: ./kubernetes/apps/default/freecad/app
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: default
+  wait: false

--- a/kubernetes/apps/default/kustomization.yaml
+++ b/kubernetes/apps/default/kustomization.yaml
@@ -26,3 +26,4 @@ resources:
   - ./tika-ner/ks.yaml
   - ./changedetection/ks.yaml
   - ./guacamole/ks.yaml
+  - ./freecad/ks.yaml


### PR DESCRIPTION
## Summary
- Adds `linuxserver/freecad` (KasmVNC webtop, tag 1.1.3) via bjw-s app-template, mirroring the existing `obsidian` app pattern
- Internal-only route (`envoy-internal`), homepage entry under new "Design" group
- `/config` PVC on `longhorn`, 500Mi — small footprint by design, easy to grow later via Longhorn resize
- Resources: 100m/512Mi request, 4Gi memory limit (no cpu limit, per cluster convention); 1Gi shm emptyDir per linuxserver docs

## Test plan
- [x] Reviewed against working `obsidian` app for structural/naming consistency (chartRef/OCIRepository name match, PVC existingClaim match, `./`-prefixed kustomization resources)
- [x] `/code-review high` — 8-angle pass, no findings
- [ ] Flux Local CI diff on this PR (kustomize/kubeconform not available in this worktree — no local `task build`/`task validate` run)
- [ ] Confirm pod comes up healthy and FreeCAD loads at `freecad.${SECRET_DOMAIN}` after merge