### PR TITLE
feat(monitoring): reformat Telegram alerts with emoji status/severity glyphs

### DIFF
--- a/kubernetes/apps/monitoring/kube-prometheus-stack/app/alertmanagerconfig.yaml
+++ b/kubernetes/apps/monitoring/kube-prometheus-stack/app/alertmanagerconfig.yaml
@@ -20,3 +20,14 @@ spec:
             key: bot-token
           chatID: 8854064758
           sendResolved: true
+          parseMode: HTML
+          message: |-
+            {{ if gt (len .Alerts.Firing) 0 }}🔥 <b>FIRING</b>{{ else }}✅ <b>RESOLVED</b>{{ end }} ({{ .Alerts.Firing | len }} firing, {{ .Alerts.Resolved | len }} resolved)
+            {{ range .Alerts.Firing }}
+            {{ if eq .Labels.severity "critical" }}🔴{{ else }}🟠{{ end }} <b>{{ .Labels.alertname }}</b> [{{ .Labels.severity }}]
+            {{ if .Labels.node }}node: <code>{{ .Labels.node }}</code>{{ end }}{{ if .Labels.namespace }} ns: <code>{{ .Labels.namespace }}</code>{{ end }}{{ if .Labels.pod }} pod: <code>{{ .Labels.pod }}</code>{{ end }}{{ if .Labels.instance }} instance: <code>{{ .Labels.instance }}</code>{{ end }}
+            {{ .Annotations.description }}
+            since {{ .StartsAt.Format "15:04 MST" }}
+            {{ end }}{{ range .Alerts.Resolved }}
+            ✅ <b>{{ .Labels.alertname }}</b> resolved{{ if .Labels.node }} — <code>{{ .Labels.node }}</code>{{ end }}{{ if .Labels.pod }} — <code>{{ .Labels.pod }}</code>{{ end }}{{ if .Labels.instance }} — <code>{{ .Labels.instance }}</code>{{ end }} (was {{ .Labels.severity }}, {{ .StartsAt.Format "15:04" }}–{{ .EndsAt.Format "15:04 MST" }})
+            {{ end }}

--- a/kubernetes/apps/monitoring/kube-prometheus-stack/app/prometheusrule-envoy.yaml
+++ b/kubernetes/apps/monitoring/kube-prometheus-stack/app/prometheusrule-envoy.yaml
@@ -28,4 +28,4 @@ spec:
             service: envoy
           annotations:
             summary: Envoy pod restarts detected
-            description: One or more Envoy pods in the network namespace have restarted within the last 30 minutes.
+            description: One or more Envoy pods in the network namespace have restarted within the last 30 minutes. Restart count now {{ $$value | humanize }}.

--- a/kubernetes/apps/monitoring/kube-prometheus-stack/app/prometheusrule-minio.yaml
+++ b/kubernetes/apps/monitoring/kube-prometheus-stack/app/prometheusrule-minio.yaml
@@ -40,7 +40,7 @@ spec:
             severity: warning
           annotations:
             summary: Minio container is restarting frequently
-            description: Minio container has restarted more than 2 times in the last 15 minutes.
+            description: Minio container has restarted more than 2 times in the last 15 minutes. Restart count now {{ $$value | humanize }}.
 
         - alert: MinioDriveOffline
           # Standalone mode runs a single drive, so any offline drive means the
@@ -51,7 +51,7 @@ spec:
             severity: critical
           annotations:
             summary: Minio has an offline drive
-            description: Minio has reported at least one offline drive for more than 5 minutes. Thanos block uploads and Loki writes may be failing.
+            description: Minio has reported at least one offline drive for more than 5 minutes. Thanos block uploads and Loki writes may be failing. Offline drive count now {{ $$value | humanize }}.
 
         - alert: MinioS3ServerErrorsHigh
           # Only 5xx (server-side faults) are alerted by default. 4xx is
@@ -65,7 +65,7 @@ spec:
             severity: warning
           annotations:
             summary: Minio is returning S3 server errors
-            description: Minio has served 5xx errors to S3 clients (Thanos sidecar/compactor/store-gateway) over the last 10 minutes.
+            description: Minio has served 5xx errors to S3 clients (Thanos sidecar/compactor/store-gateway) over the last 10 minutes. Error rate now {{ $$value | printf "%.2f" }}/s.
 
         - alert: MinioBucketQuotaApproaching
           # `and minio_bucket_quota_total_bytes > 0` guards against divide-by-zero
@@ -78,7 +78,7 @@ spec:
             severity: warning
           annotations:
             summary: Minio bucket is approaching its quota
-            description: Bucket {{ $$labels.bucket }} has been above 70% of its configured quota for 30 minutes. Growing the PVC or raising the quota is worth planning now, before writes start failing.
+            description: Bucket {{ $$labels.bucket }} has been above 70% of its configured quota for 30 minutes. Growing the PVC or raising the quota is worth planning now, before writes start failing. Current usage now {{ $$value | humanizePercentage }}.
 
         - alert: MinioBucketQuotaCritical
           expr: |
@@ -89,4 +89,4 @@ spec:
             severity: critical
           annotations:
             summary: Minio bucket is nearly at its quota
-            description: Bucket {{ $$labels.bucket }} has been above 90% of its configured quota for 15 minutes. Writes to this bucket (Thanos block uploads or Loki chunks) will start failing once the quota is hit.
+            description: Bucket {{ $$labels.bucket }} has been above 90% of its configured quota for 15 minutes. Writes to this bucket (Thanos block uploads or Loki chunks) will start failing once the quota is hit. Current usage now {{ $$value | humanizePercentage }}.

--- a/kubernetes/apps/monitoring/kube-prometheus-stack/app/prometheusrule-n8n.yaml
+++ b/kubernetes/apps/monitoring/kube-prometheus-stack/app/prometheusrule-n8n.yaml
@@ -28,7 +28,7 @@ spec:
             severity: warning
           annotations:
             summary: n8n container is restarting frequently
-            description: n8n app container has restarted more than 2 times in the last 15 minutes.
+            description: n8n app container has restarted more than 2 times in the last 15 minutes. Restart count now {{ $$value | humanize }}.
 
         - alert: N8nWorkflowErrorRateHigh
           expr: |
@@ -44,7 +44,7 @@ spec:
             severity: warning
           annotations:
             summary: n8n workflow error ratio is elevated
-            description: n8n workflow errors are above 5% over the last 10 minutes.
+            description: n8n workflow errors are above 5% over the last 10 minutes. Current error rate now {{ $$value | humanizePercentage }}.
 
         - alert: N8nWorkflowErrorRateCritical
           expr: |
@@ -60,7 +60,7 @@ spec:
             severity: critical
           annotations:
             summary: n8n workflow error ratio is critical
-            description: n8n workflow errors are above 20% over the last 10 minutes.
+            description: n8n workflow errors are above 20% over the last 10 minutes. Current error rate now {{ $$value | humanizePercentage }}.
 
         - alert: N8nNoRecentWorkflowExecutions
           expr: |

--- a/kubernetes/apps/monitoring/kube-prometheus-stack/app/prometheusrule-opnsense.yaml
+++ b/kubernetes/apps/monitoring/kube-prometheus-stack/app/prometheusrule-opnsense.yaml
@@ -28,7 +28,7 @@ spec:
             service: opnsense
           annotations:
             summary: OPNsense scrape is slow
-            description: Prometheus scrape duration for {{ $$labels.instance }} is above 10 seconds over the last 10 minutes.
+            description: Prometheus scrape duration for {{ $$labels.instance }} is above 10 seconds over the last 10 minutes. Currently {{ $$value | printf "%.1f" }}s.
 
         - alert: OpnSenseHighCpuUsage
           expr: 100 * (1 - avg by (instance) (rate(cpu_usage_idle{job="opnsense-telegraf", cpu=~"cpu[0-9]+"}[5m]))) > 90
@@ -38,7 +38,7 @@ spec:
             service: opnsense
           annotations:
             summary: OPNsense CPU usage is high
-            description: CPU usage on {{ $$labels.instance }} has stayed above 90% for more than 15 minutes.
+            description: CPU usage on {{ $$labels.instance }} has stayed above 90% for more than 15 minutes. Currently {{ $$value | printf "%.1f" }}%.
 
         - alert: OpnSenseHighCpuUsageCritical
           expr: 100 * (1 - avg by (instance) (rate(cpu_usage_idle{job="opnsense-telegraf", cpu=~"cpu[0-9]+"}[5m]))) > 95
@@ -48,7 +48,7 @@ spec:
             service: opnsense
           annotations:
             summary: OPNsense CPU usage is critically high
-            description: CPU usage on {{ $$labels.instance }} has stayed above 95% for more than 10 minutes.
+            description: CPU usage on {{ $$labels.instance }} has stayed above 95% for more than 10 minutes. Currently {{ $$value | printf "%.1f" }}%.
 
         - alert: OpnSenseMemoryPressure
           expr: mem_used_percent{job="opnsense-telegraf"} > 90
@@ -58,7 +58,7 @@ spec:
             service: opnsense
           annotations:
             summary: OPNsense memory pressure is high
-            description: Memory usage on {{ $$labels.instance }} has stayed above 90% for more than 15 minutes.
+            description: Memory usage on {{ $$labels.instance }} has stayed above 90% for more than 15 minutes. Currently {{ $$value | printf "%.1f" }}%.
 
         - alert: OpnSenseMemoryPressureCritical
           expr: mem_used_percent{job="opnsense-telegraf"} > 95
@@ -68,7 +68,7 @@ spec:
             service: opnsense
           annotations:
             summary: OPNsense memory pressure is critically high
-            description: Memory usage on {{ $$labels.instance }} has stayed above 95% for more than 10 minutes.
+            description: Memory usage on {{ $$labels.instance }} has stayed above 95% for more than 10 minutes. Currently {{ $$value | printf "%.1f" }}%.
 
         - alert: OpnSenseDiskPressure
           expr: max by (instance) (disk_used_percent{job="opnsense-telegraf", path="/"}) > 90
@@ -78,7 +78,7 @@ spec:
             service: opnsense
           annotations:
             summary: OPNsense root disk usage is high
-            description: Root filesystem usage on {{ $$labels.instance }} has stayed above 90% for more than 15 minutes.
+            description: Root filesystem usage on {{ $$labels.instance }} has stayed above 90% for more than 15 minutes. Currently {{ $$value | printf "%.1f" }}%.
 
         - alert: OpnSenseDiskPressureCritical
           expr: max by (instance) (disk_used_percent{job="opnsense-telegraf", path="/"}) > 95
@@ -88,7 +88,7 @@ spec:
             service: opnsense
           annotations:
             summary: OPNsense root disk usage is critically high
-            description: Root filesystem usage on {{ $$labels.instance }} has stayed above 95% for more than 10 minutes.
+            description: Root filesystem usage on {{ $$labels.instance }} has stayed above 95% for more than 10 minutes. Currently {{ $$value | printf "%.1f" }}%.
 
         - alert: OpnSenseInterfaceErrorsHigh
           expr: sum by (instance, interface) (rate(net_err_in{job="opnsense-telegraf"}[5m]) + rate(net_err_out{job="opnsense-telegraf"}[5m])) > 10
@@ -98,7 +98,7 @@ spec:
             service: opnsense
           annotations:
             summary: OPNsense interface errors are elevated
-            description: Interface {{ $$labels.interface }} on {{ $$labels.instance }} has sustained error activity above baseline.
+            description: Interface {{ $$labels.interface }} on {{ $$labels.instance }} has sustained error activity above baseline. Rate now {{ $$value | printf "%.2f" }}/s.
 
         - alert: OpnSenseInterfaceDropsHigh
           expr: sum by (instance, interface) (rate(net_drop_in{job="opnsense-telegraf"}[5m]) + rate(net_drop_out{job="opnsense-telegraf"}[5m])) > 5
@@ -108,7 +108,7 @@ spec:
             service: opnsense
           annotations:
             summary: OPNsense interface packet drops are elevated
-            description: Interface {{ $$labels.interface }} on {{ $$labels.instance }} has sustained packet drops above baseline.
+            description: Interface {{ $$labels.interface }} on {{ $$labels.instance }} has sustained packet drops above baseline. Rate now {{ $$value | printf "%.2f" }}/s.
 
         - alert: OpnSenseInterfaceThroughputNearPeak
           expr: |
@@ -138,7 +138,7 @@ spec:
             service: opnsense
           annotations:
             summary: OPNsense interface throughput is near peak baseline
-            description: Interface {{ $$labels.interface }} on {{ $$labels.instance }} is above 90% of its 7-day peak throughput for more than 15 minutes.
+            description: Interface {{ $$labels.interface }} on {{ $$labels.instance }} is above 90% of its 7-day peak throughput for more than 15 minutes. Currently {{ $$value | humanizePercentage }} of peak.
 
         - alert: OpnSenseStateTablePressure
           expr: 100 * max by (instance) (pf_state_table_used{job="opnsense-telegraf"}) / clamp_min(max by (instance) (pf_state_table_limit{job="opnsense-telegraf"}), 1) > 85
@@ -148,7 +148,7 @@ spec:
             service: opnsense
           annotations:
             summary: OPNsense firewall state table usage is high
-            description: Firewall state table usage on {{ $$labels.instance }} is above 85% for more than 15 minutes.
+            description: Firewall state table usage on {{ $$labels.instance }} is above 85% for more than 15 minutes. Currently {{ $$value | printf "%.1f" }}%.
 
         - alert: OpnSenseGatewayPacketLossHigh
           expr: avg_over_time(ping_loss_percent{job="opnsense-telegraf"}[10m]) > 5
@@ -158,7 +158,7 @@ spec:
             service: opnsense
           annotations:
             summary: OPNsense gateway packet loss is high
-            description: Packet loss observed by {{ $$labels.instance }} for target {{ $$labels.target }} is above 5%.
+            description: Packet loss observed by {{ $$labels.instance }} for target {{ $$labels.target }} is above 5%. Currently {{ $$value | printf "%.1f" }}%.
 
         - alert: OpnSenseGatewayLatencyHigh
           expr: avg_over_time(ping_response_time_ms{job="opnsense-telegraf"}[10m]) > 150
@@ -168,4 +168,4 @@ spec:
             service: opnsense
           annotations:
             summary: OPNsense gateway latency is high
-            description: Gateway latency observed by {{ $$labels.instance }} for target {{ $$labels.target }} is above 150ms.
+            description: Gateway latency observed by {{ $$labels.instance }} for target {{ $$labels.target }} is above 150ms. Currently {{ $$value | printf "%.0f" }}ms.

--- a/kubernetes/apps/monitoring/kube-prometheus-stack/app/prometheusrule-pod-limit-pressure.yaml
+++ b/kubernetes/apps/monitoring/kube-prometheus-stack/app/prometheusrule-pod-limit-pressure.yaml
@@ -25,7 +25,7 @@ spec:
             severity: warning
           annotations:
             summary: Pod container CPU usage is near its configured limit
-            description: Container {{ $$labels.container }} in pod {{ $$labels.namespace }}/{{ $$labels.pod }} has used more than 85% of its CPU limit for 15 minutes.
+            description: Container {{ $$labels.container }} in pod {{ $$labels.namespace }}/{{ $$labels.pod }} has used more than 85% of its CPU limit for 15 minutes. Currently {{ $$value | humanizePercentage }}.
 
         - alert: PodCpuLimitPressureCritical
           expr: |
@@ -42,7 +42,7 @@ spec:
             severity: critical
           annotations:
             summary: Pod container CPU usage is critically close to its configured limit
-            description: Container {{ $$labels.container }} in pod {{ $$labels.namespace }}/{{ $$labels.pod }} has used more than 95% of its CPU limit for 10 minutes.
+            description: Container {{ $$labels.container }} in pod {{ $$labels.namespace }}/{{ $$labels.pod }} has used more than 95% of its CPU limit for 10 minutes. Currently {{ $$value | humanizePercentage }}.
 
         - alert: PodMemoryLimitPressureHigh
           expr: |
@@ -57,7 +57,7 @@ spec:
             severity: warning
           annotations:
             summary: Pod container memory usage is near its configured limit
-            description: Container {{ $$labels.container }} in pod {{ $$labels.namespace }}/{{ $$labels.pod }} has used more than 90% of its memory limit for 15 minutes.
+            description: Container {{ $$labels.container }} in pod {{ $$labels.namespace }}/{{ $$labels.pod }} has used more than 90% of its memory limit for 15 minutes. Currently {{ $$value | humanizePercentage }}.
 
         - alert: PodMemoryLimitPressureCritical
           expr: |
@@ -72,4 +72,4 @@ spec:
             severity: critical
           annotations:
             summary: Pod container memory usage is critically close to its configured limit
-            description: Container {{ $$labels.container }} in pod {{ $$labels.namespace }}/{{ $$labels.pod }} has used more than 98% of its memory limit for 10 minutes.
+            description: Container {{ $$labels.container }} in pod {{ $$labels.namespace }}/{{ $$labels.pod }} has used more than 98% of its memory limit for 10 minutes. Currently {{ $$value | humanizePercentage }}.

--- a/kubernetes/apps/monitoring/kube-prometheus-stack/app/prometheusrule-storage-and-hosts.yaml
+++ b/kubernetes/apps/monitoring/kube-prometheus-stack/app/prometheusrule-storage-and-hosts.yaml
@@ -44,7 +44,7 @@ spec:
             severity: warning
           annotations:
             summary: Longhorn volume usage is high
-            description: Longhorn volume {{ $$labels.pvc }} in namespace {{ $$labels.pvc_namespace }} is above 85% used.
+            description: Longhorn volume {{ $$labels.pvc }} in namespace {{ $$labels.pvc_namespace }} is above 85% used. Currently {{ $$value | printf "%.1f" }}%.
 
         - alert: LonghornNodeStoragePressure
           expr: 100 * max by (node) (longhorn_node_storage_usage_bytes) / clamp_min(max by (node) (longhorn_node_storage_capacity_bytes) - max by (node) (longhorn_node_storage_reservation_bytes), 1) > 85
@@ -53,7 +53,7 @@ spec:
             severity: warning
           annotations:
             summary: Longhorn node storage pressure is high
-            description: Longhorn node {{ $$labels.node }} is above 85% of usable storage capacity.
+            description: Longhorn node {{ $$labels.node }} is above 85% of usable storage capacity. Currently {{ $$value | printf "%.1f" }}%.
 
         - alert: LonghornInstanceManagerUnschedulable
           expr: max_over_time(kube_pod_status_unschedulable{namespace="storage", pod=~"instance-manager-.*"}[10m]) > 0
@@ -81,7 +81,7 @@ spec:
             severity: warning
           annotations:
             summary: Node CPU requests are high
-            description: Node {{ $$labels.node }} has CPU requests above 85% of allocatable for more than 10 minutes, which can block scheduling for critical pods.
+            description: Node {{ $$labels.node }} has CPU requests above 85% of allocatable for more than 10 minutes, which can block scheduling for critical pods. Currently {{ $$value | printf "%.1f" }}%.
 
         - alert: NodeCpuRequestsCritical
           expr: |
@@ -100,7 +100,7 @@ spec:
             severity: critical
           annotations:
             summary: Node CPU requests are critically high
-            description: Node {{ $$labels.node }} has CPU requests above 95% of allocatable for more than 5 minutes. Critical pods like Longhorn instance-manager will fail to schedule.
+            description: Node {{ $$labels.node }} has CPU requests above 95% of allocatable for more than 5 minutes. Critical pods like Longhorn instance-manager will fail to schedule. Currently {{ $$value | printf "%.1f" }}%.
 
         - alert: NodeMemoryRequestsHigh
           expr: |
@@ -119,7 +119,7 @@ spec:
             severity: warning
           annotations:
             summary: Node memory requests are high
-            description: Node {{ $$labels.node }} has memory requests above 85% of allocatable for more than 10 minutes, reducing scheduling headroom for new workloads.
+            description: Node {{ $$labels.node }} has memory requests above 85% of allocatable for more than 10 minutes, reducing scheduling headroom for new workloads. Currently {{ $$value | printf "%.1f" }}%.
 
         - alert: NodeMemoryRequestsCritical
           expr: |
@@ -138,7 +138,7 @@ spec:
             severity: critical
           annotations:
             summary: Node memory requests are critically high
-            description: Node {{ $$labels.node }} has memory requests above 95% of allocatable for more than 5 minutes. New pods requiring memory guarantees will fail to schedule.
+            description: Node {{ $$labels.node }} has memory requests above 95% of allocatable for more than 5 minutes. New pods requiring memory guarantees will fail to schedule. Currently {{ $$value | printf "%.1f" }}%.
 
         - alert: LonghornBackupFailuresDetected
           # Fires only when the count of failed backups is actively increasing,
@@ -150,7 +150,7 @@ spec:
             severity: warning
           annotations:
             summary: Longhorn backup failures detected
-            description: New backup failures have appeared for Longhorn volume {{ $$labels.volume }} in the last 20 minutes.
+            description: New backup failures have appeared for Longhorn volume {{ $$labels.volume }} in the last 20 minutes. Failure count now {{ $$value | humanize }}.
 
     - name: node-exporter.rules
       rules:
@@ -170,7 +170,7 @@ spec:
             severity: warning
           annotations:
             summary: Host CPU usage is high
-            description: Host {{ $$labels.instance }} has sustained CPU usage above 90% for more than 15 minutes.
+            description: Host {{ $$labels.instance }} has sustained CPU usage above 90% for more than 15 minutes. Currently {{ $$value | printf "%.1f" }}%.
 
         - alert: HostMemoryPressure
           expr: 100 * (1 - (node_memory_MemAvailable_bytes{job="node-exporter"} / node_memory_MemTotal_bytes{job="node-exporter"})) > 90
@@ -179,7 +179,7 @@ spec:
             severity: warning
           annotations:
             summary: Host memory pressure is high
-            description: Host {{ $$labels.instance }} has sustained memory usage above 90% for more than 15 minutes.
+            description: Host {{ $$labels.instance }} has sustained memory usage above 90% for more than 15 minutes. Currently {{ $$value | printf "%.1f" }}%.
 
         - alert: HostRootFilesystemPressure
           expr: 100 * (1 - (node_filesystem_avail_bytes{job="node-exporter", mountpoint="/", fstype!~"tmpfs|overlay"} / node_filesystem_size_bytes{job="node-exporter", mountpoint="/", fstype!~"tmpfs|overlay"})) > 90
@@ -188,4 +188,4 @@ spec:
             severity: warning
           annotations:
             summary: Host root filesystem usage is high
-            description: Host {{ $$labels.instance }} root filesystem has been above 90% used for more than 15 minutes.
+            description: Host {{ $$labels.instance }} root filesystem has been above 90% used for more than 15 minutes. Currently {{ $$value | printf "%.1f" }}%.


### PR DESCRIPTION
## Summary

- Telegram alert template rewritten (`alertmanagerconfig.yaml`) for at-a-glance scanning: 🔥/✅ status header with firing/resolved counts, 🔴/🟠 severity glyph per alert, bold alertname, monospace node/namespace/pod/instance, compact one-liner for resolved alerts.
- Switched `parseMode` to `HTML` instead of `MarkdownV2` — MarkdownV2 requires escaping ~17 special characters (`.`, `-`, `(`, `)`, `!`, etc.) that show up routinely in free-text descriptions, IPs, and percentages; one unescaped char silently drops the whole Telegram message. HTML only needs `< > &`, none of which appear in this repo's alert labels/text.
- Added `{{ $value }}` to descriptions across `prometheusrule-envoy.yaml`, `prometheusrule-minio.yaml`, `prometheusrule-n8n.yaml`, `prometheusrule-opnsense.yaml`, `prometheusrule-pod-limit-pressure.yaml`, `prometheusrule-storage-and-hosts.yaml` so the new template can show the live metric that tripped the alert. Skipped for `up == 0` / pod-readiness alerts where the value is always 0/1 and adds no information.
- Alert duration shown as a fixed `since HH:MM` start timestamp rather than a computed elapsed duration — avoided Alertmanager template funcs (`since`, `humanizeDuration`) that couldn't be verified against a live instance from this environment.

## Why

Default Alertmanager Telegram formatting was long, unstyled plain text with no firing/resolved distinction at a glance, and long alert groups could exceed what Telegram previews show.

## Test plan

- [x] YAML syntax validated with `python3 -c "yaml.safe_load_all(...)"` on all 7 changed files
- [x] Go template brace/`if`/`range`/`end` balance checked (11 opens = 11 ends) since `go`/`kustomize`/`task` weren't available in this sandbox
- [ ] `kustomize build kubernetes/apps/monitoring/kube-prometheus-stack/app`
- [ ] `task build path=monitoring/kube-prometheus-stack`
- [ ] `task validate`
- [ ] Flux Local CI diff on this PR
- [ ] Trigger a real alert (or `amtool alert add`) and confirm the Telegram message renders as expected on a phone