### PR TITLE
fix(audacity): adopt HelmRelease into GitOps management

### DIFF
--- a/kubernetes/apps/default/audacity/app/helmrelease.yaml
+++ b/kubernetes/apps/default/audacity/app/helmrelease.yaml
@@ -1,0 +1,82 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app audacity
+spec:
+  interval: 1h
+  chartRef:
+    kind: OCIRepository
+    name: audacity
+  install:
+    remediation:
+      retries: -1
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  values:
+    controllers:
+      main:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            image:
+              repository: lscr.io/linuxserver/audacity
+              tag: latest@sha256:96d893786e030c9c4b869b17110abef3fd8f17e602136995e42af020168998d8
+            env:
+              TZ: ${TIMEZONE}
+              PUID: "1001"
+              PGID: "1001"
+              DOCKER_MODS: linuxserver/mods:universal-package-install
+              INSTALL_PACKAGES: ffmpeg
+            resources:
+              requests:
+                cpu: 25m
+                memory: 256Mi
+              limits:
+                memory: 2Gi
+
+    defaultPodOptions:
+      securityContext:
+        fsGroup: 1001
+        fsGroupChangePolicy: OnRootMismatch
+        supplementalGroups:
+          - 1001
+
+    service:
+      app:
+        controller: main
+        ports:
+          http:
+            port: 3000
+
+    route:
+      app:
+        annotations:
+          gethomepage.dev/enabled: "true"
+          gethomepage.dev/icon: https://audacityteam.org/favicon.ico
+          gethomepage.dev/title: Audacity
+          gethomepage.dev/description: "Audio editor"
+          gethomepage.dev/group: "Media"
+        hostnames:
+          - audacity.${SECRET_DOMAIN}
+        parentRefs:
+          - name: envoy-internal
+            namespace: network
+            sectionName: https
+        rules:
+          - backendRefs:
+              - identifier: app
+                port: 3000
+
+    persistence:
+      config:
+        existingClaim: audacity-config
+        globalMounts:
+          - path: /config
+
+      tmp:
+        type: emptyDir

--- a/kubernetes/apps/default/audacity/app/kustomization.yaml
+++ b/kubernetes/apps/default/audacity/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml
+  - ./pvc.yaml

--- a/kubernetes/apps/default/audacity/app/ocirepository.yaml
+++ b/kubernetes/apps/default/audacity/app/ocirepository.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: audacity
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/default/audacity/app/pvc.yaml
+++ b/kubernetes/apps/default/audacity/app/pvc.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: audacity-config
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi
+  storageClassName: longhorn

--- a/kubernetes/apps/default/audacity/ks.yaml
+++ b/kubernetes/apps/default/audacity/ks.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: audacity
+spec:
+  interval: 1h
+  path: ./kubernetes/apps/default/audacity/app
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: default
+  wait: false

--- a/kubernetes/apps/default/kustomization.yaml
+++ b/kubernetes/apps/default/kustomization.yaml
@@ -27,3 +27,4 @@ resources:
   - ./changedetection/ks.yaml
   - ./guacamole/ks.yaml
   - ./freecad/ks.yaml
+  - ./audacity/ks.yaml


### PR DESCRIPTION
## Summary
- `audacity` was deployed straight to the cluster (kubectl/helm) on 2026-05-22 and never existed in this repo.
- Its `HelmRelease.spec.chartRef` pointed at OCIRepository name `app-template`, which no app in this cluster owns — convention here is one dedicated OCIRepository per app (see `freecad`, `echo`, etc). That's the source of the reconcile error:
  ```
  OCIRepository.source.toolkit.fluxcd.io "app-template" not found
  ```
- Adds `kubernetes/apps/default/audacity/` following the standard app-template pattern: own `ks.yaml`, `ocirepository.yaml` (named `audacity`), `helmrelease.yaml` (`chartRef.name: audacity`), and `pvc.yaml` binding the existing `audacity-config` PVC (5Gi, already bound, not recreated).
- HelmRelease values mirror what's currently live in-cluster (image + digest, PUID/PGID 1001, `DOCKER_MODS`/`INSTALL_PACKAGES` for ffmpeg, homepage annotations); hostname swapped from the literal domain to `${SECRET_DOMAIN}` per repo convention.
- Registered in `kubernetes/apps/default/kustomization.yaml`.

## Test plan
- [x] YAML syntax validated (`yaml.safe_load_all` on all new/changed files)
- [ ] Flux Local CI diff on this PR — should show Flux adopting the existing Deployment/Service/HTTPRoute/PVC without drift, and the `app-template` OCIRepository error going away next reconcile
- [ ] After merge, confirm `flux -n default reconcile kustomization audacity` succeeds and `kubectl get helmrelease audacity -n default` goes Ready

🤖 Generated with [Claude Code](https://claude.com/claude-code)