### PR TITLE
feat(hermes): gemini-primary routing, claude OAuth, GitOps secret migration

### DIFF
--- a/kubernetes/apps/default/hermes-ai-agent/README.md
+++ b/kubernetes/apps/default/hermes-ai-agent/README.md
@@ -137,7 +137,7 @@ kubectl -n default exec deploy/hermes-ai-agent -c app -- sh -c \
 ```sh
 sops kubernetes/apps/default/hermes-ai-agent/app/secret.sops.yaml
 # edit the value, save (re-encrypts in place), then:
-git commit && push   # Flux reconciles; reloader restarts the pod
+git commit && git push   # Flux reconciles; reloader restarts the pod
 ```
 
 `CLAUDE_CODE_OAUTH_TOKEN` is intentionally **empty** until you paste the output of

--- a/kubernetes/apps/default/hermes-ai-agent/README.md
+++ b/kubernetes/apps/default/hermes-ai-agent/README.md
@@ -1,64 +1,163 @@
 # Hermes AI Agent Runbook
 
-This app runs Hermes gateway mode in the `default` namespace.
+Hermes runs in `gateway` mode in the `default` namespace (bjw-s `app-template`).
+Telegram is the interaction surface; Gemini is the primary model provider.
 
-## Current deployment
+## Deployment facts
 
-- HelmRelease: `kubernetes/apps/default/hermes-ai-agent/app/helmrelease.yaml`
-- Secret (SOPS): `kubernetes/apps/default/hermes-ai-agent/app/secret.sops.yaml`
-- Persistent data path in pod: `/opt/data`
-- Service/API port: `8642`
-- Dashboard exposure is disabled in-cluster until auth-backed Hermes dashboard settings are added
+- HelmRelease: `app/helmrelease.yaml` (image `nousresearch/hermes-agent`)
+- Secret (SOPS): `app/secret.sops.yaml` — **single source of truth for all Hermes credentials**, injected as container env via `envFrom: secretRef`
+- Persistent data: Longhorn PVC `hermes-ai-agent-data` (`longhorn` class, 3 replicas + backups) mounted at `/opt/data`
+- `HERMES_HOME=/opt/data` (pinned in the HelmRelease) — holds `config.yaml`, `.env`, `auth.json`, `state.db` (FTS5 memory), `skills/`, `cron/`, `sessions/`
+- API/health port: `8642`; exposed **internal-only** via `envoy-internal` at `hermes.${SECRET_DOMAIN}`
 
-## Rotate API key
+## Configuration model (important — read before changing anything)
 
-1. Decrypt and edit the secret:
+Hermes keeps its behavioral config as **mutable runtime state in `/opt/data/config.yaml`**,
+which the CLI rewrites (see the many `config.yaml.bak-*`). There is **no env var** for
+default model / provider / fallback, and `hermes model` / `hermes fallback add` are
+**interactive-only**. So config is split across two planes:
 
-   ```bash
-   sops kubernetes/apps/default/hermes-ai-agent/app/secret.sops.yaml
-   ```
+| Plane | What | Where | Reproducible? |
+|---|---|---|---|
+| Credentials | all API keys / tokens | `secret.sops.yaml` → env | ✅ Git |
+| Behavioral | model default, fallback, curator, approvals | `/opt/data/config.yaml` (PVC) | ⚠️ runbook below + `hermes backup` |
 
-2. Update `stringData.API_SERVER_KEY` with a strong value.
+Keys flow **Git Secret → env → Hermes** (process env). `/opt/data/.env` is legacy and
+should not duplicate managed keys once migration is verified (see "Post-merge").
 
-3. Save and re-apply:
+## Provider routing
 
-   ```bash
-   task apply path=default/hermes-ai-agent
-   flux -n default reconcile helmrelease hermes-ai-agent --with-source
-   ```
+- **Primary / default: Gemini** — `model.provider=gemini`, `model.default=gemini-2.5-flash`.
+  Uses `GOOGLE_API_KEY` (Google AI Pro / AI Studio). This is what unattended cron uses.
+- **Fallback: Claude** — resilience only; `fallback_providers` fires on Gemini
+  rate-limit/overload/connection errors, **not** on task difficulty.
+- **Claude selectively for hard tasks** — manual `/model claude-sonnet-4-6` in Telegram,
+  or per-cron `-m claude-sonnet-4-6`. Not automatic by design.
 
-4. Verify rollout:
+### ⚠️ Claude subscription-OAuth is a LIVE POLICY RISK
 
-   ```bash
-   kubectl -n default get hr hermes-ai-agent
-   kubectl -n default get deploy,pod -l app.kubernetes.io/instance=hermes-ai-agent
-   ```
+Claude via `CLAUDE_CODE_OAUTH_TOKEN` routes through the Pro subscription instead of
+pay-per-token. Anthropic flipped this policy repeatedly through 2026 (banned Apr →
+reinstated May with an Agent-SDK credit → credit split paused mid-June). Treat it as
+unstable. **The dependency is isolated to one secret key.**
 
-## First-time interactive setup
+**Reversibility (one step):** if OAuth breaks, blank `CLAUDE_CODE_OAUTH_TOKEN` in the
+secret — Claude falls back to `ANTHROPIC_API_KEY` (raw pay-per-token, already stored).
+Nothing else changes. Do **not** design cron/mission-critical work around OAuth; point
+those at Gemini.
 
-1. Open an interactive shell in the running pod:
+## Locked-down posture (skills & autonomy)
 
-   ```bash
-   kubectl -n default exec -it deploy/hermes-ai-agent -- /bin/sh
-   ```
+- `approvals.mode: manual`, `approvals.cron_mode: deny` — tool actions require approval; cron can't self-approve.
+- `HERMES_WRITE_SAFE_ROOT=/opt/data/workspace` — the agent's `write_file`/`patch` tool is
+  fenced to a scratch dir; it cannot clobber its own config/skills/DB. Result filing to
+  Obsidian/Todoist goes via their REST APIs (network), not disk, so dispatch still works.
+- **Curator paused** (`hermes curator pause`) — the background skill-maintenance task is
+  off. It only ever prunes/archives agent-created skills (never deletes, archives are
+  recoverable, built-in/hub skills untouched), but locked-down keeps it manual.
+- `skills.write_approval: true` + `skills.guard_agent_created: true` + `skills.inline_shell: false`
+  — skill writes/execution are gated; skills can't run inline shell.
+- **Self-generated skills are drafts.** Review before any unattended (cron) use:
+  `hermes skills list`, inspect under `/opt/data/skills/<name>/`, then enable/pin.
 
-2. Run setup commands as needed:
+## Security (residual risks & follow-ups)
 
-   ```bash
-   hermes setup
-   hermes gateway setup
-   ```
+Hermes logs this on start: *"API server is network-accessible (0.0.0.0) AND the terminal
+backend is 'local' (unsandboxed). Agent work dispatched through this endpoint runs as the
+host user with full terminal/file access."* Current mitigations and open items:
 
-3. Exit and verify logs:
+- ✅ `API_SERVER_KEY` required; ✅ ClusterIP + `envoy-internal` only (not public);
+  ✅ approvals `manual` + cron `deny`; ✅ `inline_shell: false`; ✅ write-safe-root fenced.
+- ⚠️ **`terminal.backend: local` is unsandboxed.** An approved shell tool runs as the
+  container user. Sandboxing (`terminal.backend: docker`) needs a docker/podman daemon in
+  the pod (DinD sidecar or socket) — an infra decision, not a config toggle. Deferred.
+- ⚠️ **No NetworkPolicy on `:8642`.** Any in-cluster pod can reach the API (still needs the
+  key). Cilium supports a policy to restrict ingress to the gateway/n8n only — optional
+  hardening, add a `networkpolicy.yaml` if desired.
+- Optional: `hermes config set approvals.destructive_slash_confirm true`.
 
-   ```bash
-   kubectl -n default logs -l app.kubernetes.io/instance=hermes-ai-agent -c app --tail=200
-   ```
+## Hermes ↔ n8n division of labor
 
-## Quick health checks
+Principle: **n8n moves and guards data; Hermes decides and composes.** Keep n8n — it
+already runs the Readwise pipeline, webhook glue, schedules, and Todoist/Obsidian wiring.
 
-```bash
+- **n8n = deterministic plane** — triggers (webhooks, Readwise/RSS polling, Todoist watch)
+  and side-effect writes (Obsidian REST, Todoist updates, git-vault commits).
+- **Hermes = reasoning plane** — multi-step research/summarize/classify/draft, cross-session
+  memory, Telegram command surface, agent-native cron for judgment tasks.
+
+**Seam = a webhook contract both directions:**
+- n8n → `POST https://hermes.${SECRET_DOMAIN}/…` (auth: `API_SERVER_KEY`) to request reasoning.
+- Hermes → n8n webhook to request a deterministic side effect (the final Obsidian/Todoist write).
+
+Async-dispatch: intent dropped (Telegram msg / Readwise tag) → catcher normalizes →
+Hermes reasons (Gemini primary) → result delivered via n8n write (formatting/idempotency)
+or direct REST for low-stakes notes. Don't rebuild the Readwise pipeline in Hermes; don't
+put LLM reasoning in n8n Function nodes.
+
+---
+
+## Runbook
+
+### One-time bootstrap (reproduces behavioral config on a fresh PVC)
+
+Run inside the pod (`kubectl -n default exec -it deploy/hermes-ai-agent -c app -- sh`).
+`hermes backup` first; every step is reversible via backup / `config.yaml.bak-*`.
+
+```sh
+hermes backup
+hermes config set model.provider gemini
+hermes config set model.default gemini-2.5-flash
+hermes config set skills.write_approval true       # skill writes need approval
+hermes config set skills.guard_agent_created true  # guard agent-created skills
+hermes curator pause
+# Fallback must be added interactively (writes full provider metadata):
+hermes fallback add        # pick: anthropic / claude-sonnet-4-6
+hermes fallback list       # verify
+```
+
+### Post-merge (after the Secret lands via Flux and the pod restarts)
+
+Provider keys now arrive as env from the Secret. Collapse the dual source so Git is
+authoritative:
+
+```sh
+# 1. Confirm env injection worked (names only):
+kubectl -n default exec deploy/hermes-ai-agent -c app -- sh -c \
+  'for v in GOOGLE_API_KEY ANTHROPIC_API_KEY CLAUDE_CODE_OAUTH_TOKEN TELEGRAM_BOT_TOKEN; do \
+   eval x=\$$v; [ -n "$x" ] && echo "$v set" || echo "$v EMPTY"; done'
+
+# 2. Once verified, blank the provider keys in /opt/data/.env so env (Git) is the only
+#    source. (.env.bak-* are kept automatically.) Leave non-managed keys alone.
+```
+
+### Fill / rotate a credential
+
+```sh
+sops kubernetes/apps/default/hermes-ai-agent/app/secret.sops.yaml
+# edit the value, save (re-encrypts in place), then:
+git commit && push   # Flux reconciles; reloader restarts the pod
+```
+
+`CLAUDE_CODE_OAUTH_TOKEN` is intentionally **empty** until you paste the output of
+`claude setup-token` (run locally).
+
+### Health checks
+
+```sh
 kubectl -n default get pod -l app.kubernetes.io/instance=hermes-ai-agent
-kubectl -n default describe pod -l app.kubernetes.io/instance=hermes-ai-agent | rg -n "Ready|Liveness|Readiness|Startup|Warning|BackOff"
-kubectl -n default get httproute | rg "hermes|hermes-ai-agent"
+kubectl -n default exec deploy/hermes-ai-agent -c app -- hermes config get model
+kubectl -n default exec deploy/hermes-ai-agent -c app -- hermes doctor
+kubectl -n default logs -l app.kubernetes.io/instance=hermes-ai-agent -c app --tail=200
+```
+
+### Restart to reload config.yaml
+
+The gateway runs as an s6-supervised service inside the container, so `hermes gateway
+restart` (systemd/launchd) does not apply. Force a config reload by deleting the pod (the
+ReplicaSet recreates it; Flux stays authoritative):
+
+```sh
+kubectl -n default delete pod -l app.kubernetes.io/instance=hermes-ai-agent
 ```

--- a/kubernetes/apps/default/hermes-ai-agent/app/helmrelease.yaml
+++ b/kubernetes/apps/default/hermes-ai-agent/app/helmrelease.yaml
@@ -40,6 +40,18 @@ spec:
               TZ: ${TIMEZONE}
               API_SERVER_ENABLED: true
               API_SERVER_HOST: 0.0.0.0
+              # Pin the Hermes data/config dir onto the persistent volume.
+              # Holds config.yaml, .env, auth.json, state.db (FTS5 memory),
+              # skills/, cron/, sessions/. Matches the image default today;
+              # pinned so an upstream image change can't silently move it off
+              # the PVC and drop memory/skills on restart.
+              HERMES_HOME: /opt/data
+              # Locked-down posture: confine the agent's write_file/patch tool
+              # to a scratch dir so it can't clobber its own config/skills/DB or
+              # anything else under /opt/data. Result filing to Obsidian/Todoist
+              # goes via their REST APIs (network), not disk, so this doesn't
+              # block dispatch. Widen to /opt/data to relax.
+              HERMES_WRITE_SAFE_ROOT: /opt/data/workspace
             probes:
               liveness:
                 enabled: true

--- a/kubernetes/apps/default/hermes-ai-agent/app/secret.sops.yaml
+++ b/kubernetes/apps/default/hermes-ai-agent/app/secret.sops.yaml
@@ -10,7 +10,7 @@
 #     falls back to ANTHROPIC_API_KEY (raw pay-per-token). No other change needed.
 #
 # Fill/rotate:  sops kubernetes/apps/default/hermes-ai-agent/app/secret.sops.yaml
-# CLAUDE_CODE_OAUTH_TOKEN is intentionally EMPTY until you paste your setup-token.
+# Set CLAUDE_CODE_OAUTH_TOKEN with the output of `claude setup-token` to enable OAuth (or blank it to fall back to ANTHROPIC_API_KEY).
 apiVersion: v1
 kind: Secret
 metadata:

--- a/kubernetes/apps/default/hermes-ai-agent/app/secret.sops.yaml
+++ b/kubernetes/apps/default/hermes-ai-agent/app/secret.sops.yaml
@@ -1,5 +1,16 @@
-# Fill these values, then re-encrypt in place if changed:
-# sops --encrypt --in-place kubernetes/apps/default/hermes-ai-agent/app/secret.sops.yaml
+# Hermes AI Agent — provider + platform secrets (SOPS/age encrypted).
+# Single source of truth for Hermes credentials (migrated from /opt/data/.env).
+# Injected as container env via HelmRelease `envFrom: secretRef`.
+#
+# PROVIDER ROUTING (see README):
+#   Primary  : Gemini  -> GOOGLE_API_KEY  (Google AI Pro / AI Studio key)
+#   Fallback : Claude  -> CLAUDE_CODE_OAUTH_TOKEN  (Pro subscription OAuth via `claude setup-token`)
+#     *** LIVE POLICY RISK ***: Anthropic flipped subscription-OAuth for programmatic
+#     use repeatedly in 2026. REVERSIBILITY: blank CLAUDE_CODE_OAUTH_TOKEN and Claude
+#     falls back to ANTHROPIC_API_KEY (raw pay-per-token). No other change needed.
+#
+# Fill/rotate:  sops kubernetes/apps/default/hermes-ai-agent/app/secret.sops.yaml
+# CLAUDE_CODE_OAUTH_TOKEN is intentionally EMPTY until you paste your setup-token.
 apiVersion: v1
 kind: Secret
 metadata:
@@ -9,21 +20,29 @@ metadata:
     app.kubernetes.io/name: hermes-ai-agent
 type: Opaque
 stringData:
-  #ENC[AES256_GCM,data:j7nVolfz5Z+NiuHOElIHQL3JHchhRaWbOIJqnnTZX4aMsZ0W+7h/SkL6+qCyi9YybodZfUkBik3qXON+s4LzFNCFaC2CkTZ0SUI=,iv:OsqmVBOeVFhIGsWN8odFO4iTjE2UtDc6RVbRS1M46YI=,tag:kgcaUS/A5WPA2zbZeePjgg==,type:comment]
-  API_SERVER_KEY: ENC[AES256_GCM,data:H4rX1ca1lliv8QAvCuZCnZMhlRJaZhh6JP1OIEIAx2OO5cgxgOzEg6ZRFZoxVpKW39cqPRraP0K4Aa4DSqqtug==,iv:NAT1WwhwHnVnaT1z95BIP7ltMpNxy7XUNoqYZjOrjuY=,tag:vM1gq/RDrjSF+vgZ0CU1uQ==,type:str]
+  API_SERVER_KEY: ENC[AES256_GCM,data:+6Rp/0kis3a+f2WOkYADaBbXhh4NDmwrlRqaNMP3+5/fhf7If6HCQVR7j3LohWop/7lgyUF+ZY/d4s8b7WF4Sw==,iv:I2bgyT2rSQjqFowSq+0I5GK6yB9upr9yGQBjdpks+JE=,tag:bOtnajxFjgouaWzUFZdITw==,type:str]
+  GOOGLE_API_KEY: ENC[AES256_GCM,data:RwGWFZWj0pY5OzaBn9fhpVIjhB/L0EJz266rk/48Ou+TdOO9BHQQf1zTaNOH9AfRQZ52Qm0=,iv:NT5sAptrzYvgFo6XLkjetb6qf6hQHRpz12uE25k4Lx8=,tag:rPrkUFrBzGOs2eMhwxT2xg==,type:str]
+  ANTHROPIC_API_KEY: ENC[AES256_GCM,data:0dqLu62OifmPOpNH0rKOADrX/eAK4ujvHrPThoABJAAZDjbz1kiwPhk5fAeCVzvIVuD393kwgoESf7Fb6Rie5LgBJ2t1141qkf+xGdnPjckDd6LAdNjQn2n7hkuVmti3RFTfwi3/rNcwY8fM,iv:pizVplmoG/bWIhDU0nT47fby2+Tdiw+Nvacw2N/Rmj8=,tag:c85OCXiTpJNdfcOJ3HF+qQ==,type:str]
+  CLAUDE_CODE_OAUTH_TOKEN: ENC[AES256_GCM,data:60q3ppsHTcUfwDqoerp5aEtBWreDM6SAJ0X3iu2uFMk2yedaJ59uZ1KrtBhaThQMjixrHbWWZOL/8izp1h3+1Bn2n7BItNhwMhihSIJMw8y0jPMEKkw3EyHI0lsBtzEEm0FdjGaG/fDa64lj,iv:gMxTYervLGMOQklmIvDLlG2iF5zT5IbnrDZ760Npx7s=,tag:rlDI4LFMDHoKr8CnW2wdtg==,type:str]
+  OPENROUTER_API_KEY: ENC[AES256_GCM,data:aS0VJFyHzTSCJi/+YK0NVixx3qBhqchl79A8ixveYvof81t4pOJZvoM8OGLLTX3ZYu8OBpiThZEv/X3sE+gUxWS2s2RfUvlMng==,iv:IBpMC28MAVs4ZDxWYe5TnepklIFRxDyKbTAkIJKcpEQ=,tag:5q7rNyGOUWKFsqINyeQvDg==,type:str]
+  FAL_KEY: ENC[AES256_GCM,data:PazMu5nDcYJBT6xC5h8ZyyQikWvih4b9eZEaCwyMI059cSF3nazcwFe50HQBvlYJ0IJn96Zzpshquk/urh1OeF0OTRKr,iv:D7kttmqWZJ2QIP2WJvxrWSaAH4oUu1F7+rKtQhV0CFQ=,tag:QX4oTDoimQHDmdHuvJlDsA==,type:str]
+  TELEGRAM_BOT_TOKEN: ENC[AES256_GCM,data:MytwMPUpF7uPsOPD25GeQ18fW7/7ugVo9L5JCHIdb/YaZIDLZ86UUUo0U1P5Bg==,iv:2raHx2kG+bmUdhpSMZ2T8XOE5jr2ZAQI9acXIkX87UU=,tag:7u7GQNssfKUfcmkzfgIhmw==,type:str]
+  TELEGRAM_ALLOWED_USERS: ENC[AES256_GCM,data:OKXYNULq8pgAbg==,iv:TpOLTZCBQ7SX8O0TyFp5mW8a1nyVVI3pSUm/LKrsHj4=,tag:u4ixqAr0KbPNzzIX2rQRKg==,type:str]
+  TELEGRAM_HOME_CHANNEL: ENC[AES256_GCM,data:obei1dNKeQqsfQ==,iv:n5n+SKWIM2yZHWyJSnS6n4vqmk7OGswe7/wz1EA+ch4=,tag:5b2LZJpWTwGkSlyc08GHgQ==,type:str]
+  TERMINAL_ENV: ENC[AES256_GCM,data:OTBX/7I=,iv:FOCzHqWRFeyy+NEytjGfcK9vFHZEJo4h/e/CHc4JYOM=,tag:HyfZeRCnzlkWYBo4bnAeMg==,type:str]
 sops:
   age:
     - enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBkU3MrTzQ0MmJSTldDYnJX
-        d3NML0s2bVJEblI5NUtzQ0lBNzhXb3R5VnhJCk9FcVQwSE9kSEQwTzFqODY2cWRw
-        V0g2R0RobldIaWRaMVlrOGFDWVZ3VTQKLS0tIFAzZDl6Ny9WWFJIWTlvQ21NdFg1
-        WXorS0RVZlV6aVFGazlVRjYzUjBCOUEKkPhNwNxAbBCByIZppJIpHGizJiBY/CgH
-        +PVTNSO0siwGB3D0Kg37Cplp0MGd5RuG/rafR74lcL8DHBgsZtjQbA==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBEamgyZVU5VG5TUmZoTFF6
+        TE0wd29PeUZPdURDaXdrL2VRR0ppRmFZQWc4Ck5ic3ppajBzdUM4WTJ0UEJURWlk
+        WWM1MGsxZ01UU0kza251Q0tQOFFHRVUKLS0tIHJZSUhCMVYvMVhaSGtQNWo0cUg1
+        bVFnNlVqcHVYQWc4eDRsVThWTWNxcDAKIdFj2mriL+A5NfpzIxPeAn/gszs+Cych
+        m7VKFMJjh7/aA5MIgScY/2yWVoEqcop6AUZrJ6lqPUl3VOLTmpzhng==
         -----END AGE ENCRYPTED FILE-----
       recipient: age1gekuxnpd95l5j8gsvmpsn2mewnevd0c5y5v66p4trzcqhmpn0svqkmnyy7
   encrypted_regex: ^(data|stringData)$
-  lastmodified: "2026-06-20T13:51:43Z"
-  mac: ENC[AES256_GCM,data:kGVGDKYQVvNeUO2ZoEDjDiB5SI2YK8WRnlVof1KeI3PUonosz20XsYyCE7Wzh0DkuV4qi6Rh8S1c88JYYCKwmohCqpXCYSJmHmBdTqwOOVfEs5lj5N5onVtA/31h5CbmneT0PKmM7+oce7yX0TgJEFdT05gSrfUOoGKTCN/eSW8=,iv:rnJBpNhdmOwpV+6oY65i0fOzxpB1TayZVY/uJh7PF5w=,tag:AA8WgV54kLvGQEvBzxhMMQ==,type:str]
+  lastmodified: "2026-07-31T12:29:59Z"
+  mac: ENC[AES256_GCM,data:58VhUL1923GmezMMsnAeJ9rHgiw95FodMSbpJMErWlc7k5uvQkMmjOb6R501zwe6hQbYupXCfwP1yVTt7fMhIT/0p9GXYW3K7O7MoA8v+6Dakn0/84TthffySek5V+ogoSKq/CLIzZaLhSxyjkY0kx6NVrN3TaIo30cL9fzLwpI=,iv:IqW4bF/f3Vqd9qWDEfNo27Qr0IWOWsKwbGwmuWjA+Mk=,tag:Ufmgj4BnMEhJvM5sKPig8Q==,type:str]
   mac_only_encrypted: true
-  version: 3.13.1
+  version: 3.13.2


### PR DESCRIPTION
## What

Hardens the Hermes AI Agent deployment: multi-provider routing (Gemini primary, Claude selective/fallback) and moves all credentials into Git-managed SOPS so config is reproducible.

## Changes

- **`secret.sops.yaml`** — migrated all 9 keys out of the imperative `/opt/data/.env` into the SOPS secret (single source of truth, injected via existing `envFrom`). Adds `GOOGLE_API_KEY` (Gemini AI Studio, validated authenticates), `CLAUDE_CODE_OAUTH_TOKEN` (Claude Pro subscription via `claude setup-token`), and retains `ANTHROPIC_API_KEY` as a pay-per-token rollback. Header documents the OAuth policy risk + one-key reversibility.
- **`helmrelease.yaml`** — pin `HERMES_HOME=/opt/data` (persistence contract for memory/skills/cron on the PVC) and tighten `HERMES_WRITE_SAFE_ROOT` to a scratch dir (locked-down: the agent's file-write tool can't clobber its own config/DB).
- **`README.md`** — full runbook: provider routing, OAuth reversibility, bootstrap + post-merge steps, security residual-risk section, Hermes/n8n division of labor.

## Runtime config (already set live; reproduced in README bootstrap)

`model.provider=gemini`, `model.default=gemini-2.5-flash`, curator paused, `skills.write_approval`+`guard_agent_created` on, `approvals.mode=manual`/`cron_mode=deny`.

## Post-merge (tracked, run after Flux applies the secret)

1. Verify keys present as env in the pod.
2. Blank the migrated keys in `/opt/data/.env` (backup kept) so Git is authoritative.
3. `hermes fallback add` → anthropic/claude-sonnet-4-6.
4. Verify Claude authenticates on OAuth (not the API key); if not, blank `ANTHROPIC_API_KEY`.

## Risk / reversibility

Claude subscription-OAuth is a **live policy risk** (Anthropic flipped it repeatedly in 2026). Isolated to one secret key — blank `CLAUDE_CODE_OAUTH_TOKEN` → Claude reverts to `ANTHROPIC_API_KEY`. Unattended/cron work stays on Gemini.

🤖 Generated with [Claude Code](https://claude.com/claude-code)