### PR TITLE
fix(hermes-ai-agent): dashboard redirect loop + gemini model doc

### DIFF
--- a/kubernetes/apps/default/hermes-ai-agent/README.md
+++ b/kubernetes/apps/default/hermes-ai-agent/README.md
@@ -28,8 +28,21 @@ should not duplicate managed keys once migration is verified (see "Post-merge").
 
 ## Provider routing
 
-- **Primary / default: Gemini** — `model.provider=gemini`, `model.default=gemini-2.5-flash`.
-  Uses `GOOGLE_API_KEY` (Google AI Pro / AI Studio). This is what unattended cron uses.
+- **Primary / default: Gemini** — `model.provider=gemini`, `model.default=gemini-flash-latest`
+  (alias, not a pinned version — see below). Uses `GOOGLE_API_KEY` (Google AI Pro / AI
+  Studio). This is what unattended cron uses.
+
+  **Why an alias, not a pinned model:** on 2026-07-31, `gemini-2.5-flash` (the original
+  pin) started returning `404: This model ... is no longer available to new users` for
+  this key — Google retires versioned model ids out from under existing keys with no
+  warning. Fallback correctly routed to Claude when this happened (see below), but it's
+  not something to rely on for routine primary-provider availability. `gemini-flash-latest`
+  is Google's floating alias to their current default flash model — it can't go stale the
+  same way, though it means the underlying model can change without a deploy. Verify a
+  candidate resolves before switching pins:
+  `curl -s -X POST "https://generativelanguage.googleapis.com/v1beta/models/<id>:generateContent?key=$GOOGLE_API_KEY" -d '{"contents":[{"parts":[{"text":"hi"}]}]}'`
+  — check for a `candidates` response, not just a non-404 status (a bare `-w '%{http_code}'`
+  check without `-H 'Content-Type: application/json'` can itself 404 and mislead).
 - **Fallback: Claude** — resilience only; `fallback_providers` fires on Gemini
   rate-limit/overload/connection errors, **not** on task difficulty.
 - **Claude selectively for hard tasks** — manual `/model claude-sonnet-4-6` in Telegram,

--- a/kubernetes/apps/default/hermes-ai-agent/README.md
+++ b/kubernetes/apps/default/hermes-ai-agent/README.md
@@ -40,7 +40,7 @@ should not duplicate managed keys once migration is verified (see "Post-merge").
   is Google's floating alias to their current default flash model — it can't go stale the
   same way, though it means the underlying model can change without a deploy. Verify a
   candidate resolves before switching pins:
-  `curl -s -X POST "https://generativelanguage.googleapis.com/v1beta/models/<id>:generateContent?key=$GOOGLE_API_KEY" -d '{"contents":[{"parts":[{"text":"hi"}]}]}'`
+  `curl -s -X POST -H 'Content-Type: application/json' "https://generativelanguage.googleapis.com/v1beta/models/<id>:generateContent?key=$GOOGLE_API_KEY" -d '{"contents":[{"parts":[{"text":"hi"}]}]}'`
   — check for a `candidates` response, not just a non-404 status (a bare `-w '%{http_code}'`
   check without `-H 'Content-Type: application/json'` can itself 404 and mislead).
 - **Fallback: Claude** — resilience only; `fallback_providers` fires on Gemini

--- a/kubernetes/apps/default/hermes-ai-agent/app/helmrelease.yaml
+++ b/kubernetes/apps/default/hermes-ai-agent/app/helmrelease.yaml
@@ -127,10 +127,17 @@ spec:
         rules:
           # Dashboard mounted at /dashboard on the same host, ahead of the
           # catch-all API rule below (Gateway API evaluates in list order).
-          # The dashboard reconstructs absolute URLs (OAuth redirects, SPA
-          # asset paths, cookie Path) from X-Forwarded-Prefix, so the path
-          # is passed through unrewritten and the header carries the mount
-          # point — see hermes_cli/dashboard_auth/prefix.py.
+          # The app's own auth-gate allowlist (_GATE_PUBLIC_PREFIXES in
+          # hermes_cli/dashboard_auth/middleware.py) matches literal paths
+          # like "/login" with NO prefix awareness — it expects the proxy
+          # to strip the mount prefix before forwarding, and only uses
+          # X-Forwarded-Prefix to reconstruct the prefix back onto outgoing
+          # Location headers / cookie paths / asset URLs (see
+          # hermes_cli/dashboard_auth/prefix.py). Forwarding "/dashboard/login"
+          # unrewritten made every request — including the login page itself —
+          # look non-public, causing a redirect loop. URLRewrite strips the
+          # prefix for the backend; the header lets it add "/dashboard" back
+          # for the browser.
           - matches:
               - path:
                   type: PathPrefix
@@ -141,6 +148,11 @@ spec:
                   set:
                     - name: X-Forwarded-Prefix
                       value: /dashboard
+              - type: URLRewrite
+                urlRewrite:
+                  path:
+                    type: ReplacePrefixMatch
+                    replacePrefixMatch: /
             backendRefs:
               - identifier: app
                 port: *dashboardPort


### PR DESCRIPTION
## Summary
- Fixes an infinite redirect loop on `hermes.${SECRET_DOMAIN}/dashboard`: the dashboard's auth-gate allowlist matches literal paths (`/login`) with no prefix awareness, so forwarding `/dashboard/*` unrewritten made every request — including the login page — look non-public. Adds a `URLRewrite` (`ReplacePrefixMatch`) alongside the existing `X-Forwarded-Prefix` header so the backend sees unprefixed paths but still reconstructs `/dashboard`-prefixed URLs for the browser.
- Documents the `model.default` switch (already applied live in-pod) from the now-404ing pinned `gemini-2.5-flash` to the `gemini-flash-latest` alias — Google retired the pinned id for this key's account class without warning.

## Test plan
- [x] `kubectl kustomize` renders the route with both filters in the correct order
- [ ] After merge: `curl -Lv https://hermes.${SECRET_DOMAIN}/dashboard` reaches the login page without looping; log in with configured credentials

🤖 Generated with [Claude Code](https://claude.com/claude-code)