### PR TITLE
fix(devcontainer): resolve mise install failures on arm64

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,7 @@
 {
 	"name": "Mise",
 	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-	"image": "jdxcode/mise",
+	"image": "jdxcode/mise:2026.7.8",
 
 
 	// Features to add to the dev container. More info: https://containers.dev/features.
@@ -19,5 +19,13 @@
 	// "customizations": {},
 
 	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
-	"remoteUser": "root"
+	"remoteUser": "root",
+
+	"mounts": [
+		"source=aws-cli-config,target=/root/.aws,type=volume"
+	],
+
+	"remoteEnv": {
+		"GITHUB_TOKEN": "${localEnv:GITHUB_TOKEN}"
+	}
 }

--- a/.mise.toml
+++ b/.mise.toml
@@ -36,6 +36,6 @@ TALOSCONFIG = "{{config_root}}/talos/clusterconfig/talosconfig"
 "aqua:stackrox/kube-linter" = "0.8.3"
 "aqua:aquasecurity/trivy" = "0.72.0"
 "aqua:open-policy-agent/conftest" = "0.68.2"
-"aqua:kubescape/kubescape" = "4.0.11"
 "npm:@anthropic-ai/claude-code" = "2.1.220"
 node = "26.5.1"
+aws = { version = "latest", symlink_bins = "true" }


### PR DESCRIPTION
## Summary
- Pass host `GITHUB_TOKEN` into the devcontainer via `remoteEnv`, fixing flaky `aqua` GitHub attestation verification (unauthenticated GitHub API calls were rate-limited / failing to decode response bodies during `mise install`).
- Drop `aqua:kubescape/kubescape` from `.mise.toml` — the aqua-registry entry for kubescape has no `linux/arm64` build, so `mise install` always fails on Apple Silicon devcontainers. It's only consumed by the report-only Security Scan CI workflow (amd64 GH runners), so it isn't needed for local dev.
- Pin devcontainer base image to `jdxcode/mise:2026.7.8` (was floating `jdxcode/mise`/`latest`). The old pulled image (mise 2025.10.17) picks a `freethreaded` python-build-standalone asset on linux/arm64, whose layout mise's own `lib`-directory check doesn't recognize, failing `core:python@3.14.6` install with "Python installation is missing a `lib` directory". Fixed upstream in jdx/mise#8672 (mise v2026.3.10+, excludes freethreaded builds from precompiled selection by default). Pinning also gives Renovate's built-in `devcontainer` manager (already enabled via `config:recommended`, no extra config needed) something concrete to track and bump going forward.

## Test plan
- [ ] Rebuild devcontainer with `GITHUB_TOKEN` exported on host
- [ ] `mise install` completes without the three original errors