### PR TITLE
feat(recording-annotator-minio): dedicated Minio instance for RecordingAnnotator

### DIFF
--- a/kubernetes/apps/storage/kustomization.yaml
+++ b/kubernetes/apps/storage/kustomization.yaml
@@ -10,3 +10,4 @@ resources:
   - ./namespace.yaml
   - ./longhorn-system/ks.yaml
   - ./minio/ks.yaml
+  - ./recording-annotator-minio/ks.yaml

--- a/kubernetes/apps/storage/recording-annotator-minio/app/helmrelease.yaml
+++ b/kubernetes/apps/storage/recording-annotator-minio/app/helmrelease.yaml
@@ -1,0 +1,62 @@
+---
+# yaml-language-server: $schema=https://lds-schemas.pages.dev/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: recording-annotator-minio
+spec:
+  interval: 1h
+  chart:
+    spec:
+      chart: minio
+      # renovate: registryUrl=https://charts.min.io/
+      version: "5.4.0"
+      sourceRef:
+        kind: HelmRepository
+        name: recording-annotator-minio
+        namespace: storage
+  values:
+    # Single-node deployment dedicated to RecordingAnnotator (spec section 9) — deliberately separate from
+    # the shared storage/minio instance (Thanos/Loki), which is already capacity-constrained and unrelated
+    # in purpose to this app's recordings.
+    mode: standalone
+
+    existingSecret: recording-annotator-minio-root-credentials
+
+    # Disable the default console user created by chart post-install jobs
+    users: []
+
+    # Pre-create the bucket the app expects (RecordingAnnotator README "Deploy")
+    buckets:
+      - name: recordings
+        policy: none
+        purge: false
+
+    service:
+      type: ClusterIP
+
+    consoleService:
+      type: ClusterIP
+
+    persistence:
+      enabled: true
+      # No Longhorn backup: offsite protection for this bucket is MinIO server-side replication to an
+      # Object-Locked AWS S3 bucket (docs/backup-recovery.md §3 in the app repo), configured out-of-band
+      # per deploy/backup/RUNBOOK.md. A Longhorn backup here would just double the write cost for no
+      # additional protection against the threat that actually matters (ransomware/corruption).
+      storageClass: longhorn-2-no-backup
+      # Start small; grow as real recordings land rather than over-provisioning day one.
+      size: 2Gi
+
+    resources:
+      requests:
+        cpu: 25m
+        memory: 128Mi
+      limits:
+        memory: 512Mi
+
+    metrics:
+      serviceMonitor:
+        enabled: true
+        includeNode: true
+        interval: 30s

--- a/kubernetes/apps/storage/recording-annotator-minio/app/helmrepository.yaml
+++ b/kubernetes/apps/storage/recording-annotator-minio/app/helmrepository.yaml
@@ -1,0 +1,10 @@
+---
+# yaml-language-server: $schema=https://lds-schemas.pages.dev/source.toolkit.fluxcd.io/helmrepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: recording-annotator-minio
+spec:
+  interval: 1h
+  url: https://charts.min.io/
+  timeout: 3m

--- a/kubernetes/apps/storage/recording-annotator-minio/app/httproute-console.yaml
+++ b/kubernetes/apps/storage/recording-annotator-minio/app/httproute-console.yaml
@@ -1,0 +1,28 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/gateway.networking.k8s.io/httproute_v1.json
+# The Minio web console, for logging in to inspect or diagnose the recordings bucket by hand. Separate service
+# on port 9001, distinct from the S3 API on 9000 (httproute-s3.yaml) — mirrors the shared instance's
+# storage/minio/app/httproute-console.yaml. Login is the root credentials from
+# recording-annotator-minio-root-credentials.sops.yaml.
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: recording-annotator-minio-console
+  annotations:
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/icon: minio
+    gethomepage.dev/title: Recordings Object Store
+    gethomepage.dev/description: "Minio console for RecordingAnnotator media"
+    gethomepage.dev/group: "Media"
+spec:
+  hostnames:
+    - recording-annotator-minio.${SECRET_DOMAIN}
+  parentRefs:
+    - name: envoy-internal
+      namespace: network
+      sectionName: https
+  rules:
+    - backendRefs:
+        - name: recording-annotator-minio-console
+          namespace: storage
+          port: 9001

--- a/kubernetes/apps/storage/recording-annotator-minio/app/httproute-s3.yaml
+++ b/kubernetes/apps/storage/recording-annotator-minio/app/httproute-s3.yaml
@@ -1,0 +1,37 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/gateway.networking.k8s.io/httproute_v1.json
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: recording-annotator-minio-s3
+spec:
+  # Unlike the shared storage/minio instance (whose S3 API only needs cluster-internal callers — Thanos/Loki),
+  # RecordingAnnotator's browser client plays media back via presigned URLs, so the S3 API itself must be
+  # reachable from LAN clients, not just the admin console. This is Storage__PublicEndpoint in the app config.
+  hostnames: ["recording-annotator-media.${SECRET_DOMAIN}"]
+  parentRefs:
+    - name: envoy-internal
+      namespace: network
+      sectionName: https
+  rules:
+    # Minio serves its metrics endpoints on the same port 9000 as the S3 API, so publishing the S3 API publishes
+    # those too. The chart defaults metrics.serviceMonitor.public=true, i.e. MINIO_PROMETHEUS_AUTH_TYPE=public —
+    # /minio/v2/metrics/* takes no credentials at all and would hand any LAN client the bucket names, object
+    # counts and usage. Prometheus scrapes the in-cluster Service, so nothing legitimate needs this path here.
+    #
+    # /minio/admin/* is deliberately NOT blocked: it is what `mc admin ...` talks to, so blocking it would break
+    # CLI administration from a workstation. Unlike the metrics endpoints it is SigV4-authenticated, and the only
+    # credentials that carry an admin policy are the root ones, which never leave the storage namespace — the
+    # scoped recording-annotator-rw user cannot use it. The web console is a different service on port 9001
+    # (see httproute-console.yaml), not this path.
+    - matches:
+        - path: { type: PathPrefix, value: /minio/v2/metrics }
+      filters:
+        - type: RequestRedirect
+          requestRedirect:
+            scheme: https
+            path: { type: ReplaceFullPath, replaceFullPath: / }
+            statusCode: 302
+    - backendRefs:
+        - name: recording-annotator-minio
+          port: 9000

--- a/kubernetes/apps/storage/recording-annotator-minio/app/kustomization.yaml
+++ b/kubernetes/apps/storage/recording-annotator-minio/app/kustomization.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrepository.yaml
+  - ./helmrelease.yaml
+  - ./httproute-s3.yaml
+  - ./httproute-console.yaml
+  - ./probe-bucket-metrics.yaml
+  - ./minio-root-credentials.sops.yaml
+  - ./recording-annotator-minio-user-credentials.sops.yaml
+  - ./recording-annotator-user-bootstrap-job.yaml

--- a/kubernetes/apps/storage/recording-annotator-minio/app/minio-root-credentials.sops.yaml
+++ b/kubernetes/apps/storage/recording-annotator-minio/app/minio-root-credentials.sops.yaml
@@ -1,5 +1,4 @@
-# PLACEHOLDER — not real SOPS ciphertext. Owner must replace stringData below with real values and encrypt:
-#   sops -e -i kubernetes/apps/storage/recording-annotator-minio/app/minio-root-credentials.sops.yaml
+# SOPS-encrypted Secret — real ciphertext, managed by the repo age key.
 apiVersion: v1
 kind: Secret
 metadata:

--- a/kubernetes/apps/storage/recording-annotator-minio/app/minio-root-credentials.sops.yaml
+++ b/kubernetes/apps/storage/recording-annotator-minio/app/minio-root-credentials.sops.yaml
@@ -1,0 +1,26 @@
+# PLACEHOLDER — not real SOPS ciphertext. Owner must replace stringData below with real values and encrypt:
+#   sops -e -i kubernetes/apps/storage/recording-annotator-minio/app/minio-root-credentials.sops.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: recording-annotator-minio-root-credentials
+  namespace: storage
+stringData:
+  rootUser: ENC[AES256_GCM,data:1whF+73u2yq3dDHlqEUaQck83+ZgI6D/,iv:qYsaTFEBOtZ3kGSUvBl1IvHulPfya4TXf70LX3om3ZA=,tag:7lmJtsivDjG/nqIzLOZKHA==,type:str]
+  rootPassword: ENC[AES256_GCM,data:NAWd+bhh8LmI0CgbR2CuCxhZq2g+tcCUyYqgz+1AejieLC7Zy8Lllg==,iv:eTiBozZSKR6gD+y0xre4UVQ/UnKeljK+BntIbslcllw=,tag:oj0BbAAvXn0MhpVd7erZ3A==,type:str]
+sops:
+  age:
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBTVkk2RmdacTJDQkRMMjlJ
+        L2VTWWl1cHJGVUdlTEcrME1FRnB5NFJkMnljClJDRTNqeitGY0xKRXhpNWd4SnE5
+        Vi9rWHJ4YUR5VnhJN3I1UGpvTDJoU1EKLS0tIDdVajJWVEhjT2RTRVZydmptdEFK
+        UTJVdzRCdm8vekRod1dFVS9GVytWQlEKPmO7XAhb7bwKIwkRqDhp2FjJrFyq7KAw
+        jZbzCgnK6XrcGTzV7uhjH5XP6UKV6uKH5hZ34ExZVFV43eVLPitudA==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1gekuxnpd95l5j8gsvmpsn2mewnevd0c5y5v66p4trzcqhmpn0svqkmnyy7
+  encrypted_regex: ^(data|stringData)$
+  lastmodified: "2026-08-01T12:54:58Z"
+  mac: ENC[AES256_GCM,data:EYy7T1Nwr6PmjlZ8pB0vPGggpgstVvv00f6PSdpeZiyIlnGpWpEY0vluI/LhWEgMH9/NMHE639UUrMax27mCLDLD7TO5bT41W5RNF68Xgg3tKb7dAQbAQ1qPTsT8gZ8bqZxrXaLPhEVxXH0jsReyN2NBKhDtwgI1LqJeswiavow=,iv:pjbB4BuRiHtE2V3t9k1puNtgAiID6jk+vG23wQpYBfM=,tag:6f5nBNS/dKGbXixLxz+uqQ==,type:str]
+  mac_only_encrypted: true
+  version: 3.13.2

--- a/kubernetes/apps/storage/recording-annotator-minio/app/probe-bucket-metrics.yaml
+++ b/kubernetes/apps/storage/recording-annotator-minio/app/probe-bucket-metrics.yaml
@@ -1,0 +1,36 @@
+---
+# The Minio chart's own ServiceMonitor/Probe (enabled via helmrelease.yaml
+# metrics.serviceMonitor) only cover /minio/v2/metrics/cluster and
+# /minio/v2/metrics/node — it doesn't scrape /minio/v2/metrics/bucket, which
+# is the only endpoint exposing the per-bucket series. Mirrors the shared
+# instance's storage/minio/app/probe-bucket-metrics.yaml, including the trick
+# of using Minio itself as the "prober" (it ignores the injected target param
+# and returns the requested path) and relying on MINIO_PROMETHEUS_AUTH_TYPE
+# being "public" so no bearer token is needed.
+#
+# This matters more here than it does for the shared instance. The recordings
+# bucket's ONLY offsite protection is server-side replication to the
+# Object-Locked S3 bucket — the PVC is deliberately longhorn-2-no-backup.
+# Replication is configured imperatively, outside Git, by
+# deploy/backup/configure-minio-replication.sh, so if it is never run, silently
+# misconfigured, or lost when this instance is rebuilt, the media has no backup
+# at all and nothing else would notice. minio_bucket_replication_* comes from
+# this endpoint and is what the RecordingAnnotatorMediaReplication* alerts key
+# off.
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
+  name: recording-annotator-minio-bucket
+  namespace: storage
+  labels:
+    app: minio
+spec:
+  jobName: recording-annotator-minio-bucket
+  prober:
+    url: recording-annotator-minio.storage:9000
+    path: /minio/v2/metrics/bucket
+    scheme: http
+  targets:
+    staticConfig:
+      static:
+        - recording-annotator-minio.storage

--- a/kubernetes/apps/storage/recording-annotator-minio/app/recording-annotator-minio-user-credentials.sops.yaml
+++ b/kubernetes/apps/storage/recording-annotator-minio/app/recording-annotator-minio-user-credentials.sops.yaml
@@ -1,10 +1,9 @@
-# PLACEHOLDER — not real SOPS ciphertext. Consumed by recording-annotator-user-bootstrap-job.yaml to
-# create a MinIO user scoped to the recordings bucket only (not root). The SAME accessKey/secretKey pair
-# also needs to end up in kubernetes/apps/default/recording-annotator/app/recording-annotator-secret.sops.yaml's
-# Storage__AccessKey/Storage__SecretKey — this is the app's actual storage credential, root stays confined
-# to this namespace. Generate a random pair yourself, e.g.:
-# then encrypt:
-#   sops -e -i kubernetes/apps/storage/recording-annotator-minio/app/recording-annotator-minio-user-credentials.sops.yaml
+# SOPS-encrypted Secret — real ciphertext, managed by the repo age key. Consumed by
+# recording-annotator-user-bootstrap-job.yaml to create a MinIO user scoped to the recordings
+# bucket only (not root). The SAME accessKey/secretKey pair also needs to be present in
+# kubernetes/apps/default/recording-annotator/app/recording-annotator-secret.sops.yaml's
+# Storage__AccessKey/Storage__SecretKey — this is the app's actual storage credential; root
+# credentials stay confined to this namespace.
 apiVersion: v1
 kind: Secret
 metadata:

--- a/kubernetes/apps/storage/recording-annotator-minio/app/recording-annotator-minio-user-credentials.sops.yaml
+++ b/kubernetes/apps/storage/recording-annotator-minio/app/recording-annotator-minio-user-credentials.sops.yaml
@@ -1,0 +1,31 @@
+# PLACEHOLDER — not real SOPS ciphertext. Consumed by recording-annotator-user-bootstrap-job.yaml to
+# create a MinIO user scoped to the recordings bucket only (not root). The SAME accessKey/secretKey pair
+# also needs to end up in kubernetes/apps/default/recording-annotator/app/recording-annotator-secret.sops.yaml's
+# Storage__AccessKey/Storage__SecretKey — this is the app's actual storage credential, root stays confined
+# to this namespace. Generate a random pair yourself, e.g.:
+# then encrypt:
+#   sops -e -i kubernetes/apps/storage/recording-annotator-minio/app/recording-annotator-minio-user-credentials.sops.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: recording-annotator-minio-user-credentials
+  namespace: storage
+stringData:
+  accessKey: ENC[AES256_GCM,data:DxW8DB02sIBtEXmA7YnF3roBd4A=,iv:63X5LN5fUGiwbMt/4Y5vnDcQtR+EpmivhREBFbmSxn0=,tag:5CgYdo7rkOTlU9J/8kPcZQ==,type:str]
+  secretKey: ENC[AES256_GCM,data:aleBCmmGlS3QMpAXmteSP/e2fo15t4hz4AMHMXIX3ptY28C+0Zw0L0MJCchvYIwYqnSkVUaTUAdpduHb,iv:KGHG4PxooS625541dN7L0ku5AXZTUfDt5PEc6OLnwsI=,tag:/+cndln956qvzuRgloXMQQ==,type:str]
+sops:
+  age:
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAwWGk4eXhjMEt1cXJnU2FE
+        ekEvbk5BOHpsajQ5WHErRHhWaWUxQWZhUUM0Ci9iQTlQVUptN1RCMGZjTWJsMHNh
+        QjRPV093YUNlTlZwL05nUVB2eGFtalUKLS0tIFBON0JwMmMrOXlnWTlrZFJBVm5z
+        WitScTh5aW5xMFFnb29wbHRkZHJqZnMKH7szBKjsNAYkdLZJMc/afiq9WMazE6Tt
+        a0AYPw19uchK0RS1Gwz4pHvZZGUs37m+/xyr9/wb6W1xYKf54mhwIA==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1gekuxnpd95l5j8gsvmpsn2mewnevd0c5y5v66p4trzcqhmpn0svqkmnyy7
+  encrypted_regex: ^(data|stringData)$
+  lastmodified: "2026-08-01T13:08:00Z"
+  mac: ENC[AES256_GCM,data:+wJitJhNHuF9/PH2LHSuABKuoH/fcoOrdTL19xGky1xNN6HNwRDfpKoYM/ex8ib2WPebDhEzb8oAg+b8i+UfJ7zy/C13PT6WwAYtU3HjE3aFqg8JLUiJB1RgmGMKkITeVnCrUSVw8RzfU2AwSdF3N1ShoUwYUo1rL8U6dxv4ly4=,iv:QSasTR95KvpPvnOddqRUZ1Yl1Qbe7JX+66ndJkPfkCM=,tag:xqcwTB5mwOPbiuUXN5oIIg==,type:str]
+  mac_only_encrypted: true
+  version: 3.13.2

--- a/kubernetes/apps/storage/recording-annotator-minio/app/recording-annotator-user-bootstrap-job.yaml
+++ b/kubernetes/apps/storage/recording-annotator-minio/app/recording-annotator-user-bootstrap-job.yaml
@@ -1,0 +1,120 @@
+---
+# RecordingAnnotator IAM user bootstrap Job — runs once after Minio is healthy. Creates a Minio user
+# scoped to only the recordings bucket (not the root credentials) and attaches it to the credentials
+# already generated and SOPS-encrypted in recording-annotator-minio-user-credentials.sops.yaml. The app
+# authenticates as this user via kubernetes/apps/default/recording-annotator/app/recording-annotator-secret.sops.yaml,
+# which holds the same accessKey/secretKey pair (Storage__AccessKey/Storage__SecretKey).
+#
+# Mirrors kubernetes/apps/storage/minio/app/thanos-user-bootstrap-job.yaml almost exactly — same shape,
+# same known-good annotations. No DeleteObject in the policy (unlike Thanos/Loki): the app has no v1
+# blob-delete path by design (RecordingAnnotator docs/backup-recovery.md §2), so it's tightened out.
+#
+# Manual equivalent:
+#   mc alias set local http://recording-annotator-minio.storage.svc.cluster.local:9000 <root user> <root password>
+#   mc admin policy create local recording-annotator-rw /tmp/policy.json
+#   mc admin user add local <accessKey> <secretKey>
+#   mc admin policy attach local recording-annotator-rw --user <accessKey>
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: recording-annotator-user-bootstrap
+  namespace: storage
+  annotations:
+    # prune: false prevents Flux from deleting this Job if the pod outlives the reconcile window. To
+    # fully decommission this Job, remove it from
+    # storage/recording-annotator-minio/app/kustomization.yaml — kubectl delete alone won't work because
+    # Flux will recreate it on the next reconcile while it remains in the resources list.
+    kustomize.toolkit.fluxcd.io/prune: "false"
+    # ssa: IfNotPresent tells kustomize-controller to skip applying/dry-running this resource once it
+    # already exists. Without this, a Job's spec.template is immutable and a fresh dry-run apply on every
+    # reconcile fails with "field is immutable" against the live object's controller-added labels — which
+    # permanently flips this Kustomization Ready=False after the Job's first successful run. This bit
+    # storage/minio's sibling bootstrap Jobs (bucket-bootstrap, thanos-user-bootstrap, loki-user-bootstrap,
+    # etc.) on 2026-07-19; applying the fix here from the start rather than rediscovering it.
+    kustomize.toolkit.fluxcd.io/ssa: IfNotPresent
+spec:
+  backoffLimit: 2
+  activeDeadlineSeconds: 3600
+  template:
+    spec:
+      restartPolicy: OnFailure
+      containers:
+        - name: mc
+          image: quay.io/minio/mc:RELEASE.2025-08-13T08-35-41Z
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -e
+              RETRIES=0; MAX_RETRIES=180
+              until mc alias set local http://recording-annotator-minio.storage.svc.cluster.local:9000 \
+                "$MINIO_ROOT_USER" "$MINIO_ROOT_PASSWORD"; do
+                RETRIES=$((RETRIES + 1))
+                if [ "$RETRIES" -ge "$MAX_RETRIES" ]; then
+                  echo "ERROR: minio did not become ready after $((MAX_RETRIES * 5))s, giving up"
+                  exit 1
+                fi
+                echo "waiting for minio... (attempt $RETRIES/$MAX_RETRIES)"; sleep 5
+              done
+
+              cat > /tmp/recording-annotator-policy.json <<POLICY
+              {
+                "Version": "2012-10-17",
+                "Statement": [
+                  {
+                    "Effect": "Allow",
+                    "Action": ["s3:ListBucket", "s3:GetBucketLocation"],
+                    "Resource": ["arn:aws:s3:::recordings"]
+                  },
+                  {
+                    "Effect": "Allow",
+                    "Action": ["s3:GetObject", "s3:PutObject"],
+                    "Resource": ["arn:aws:s3:::recordings/*"]
+                  }
+                ]
+              }
+              POLICY
+
+              # Idempotent: create policy only if it does not already exist
+              if ! mc admin policy info local recording-annotator-rw > /dev/null 2>&1; then
+                mc admin policy create local recording-annotator-rw /tmp/recording-annotator-policy.json
+              else
+                echo "policy recording-annotator-rw already exists, skipping"
+              fi
+
+              # Idempotent: create user only if it does not already exist
+              if ! mc admin user info local "$RECORDING_ANNOTATOR_ACCESS_KEY" > /dev/null 2>&1; then
+                mc admin user add local "$RECORDING_ANNOTATOR_ACCESS_KEY" "$RECORDING_ANNOTATOR_SECRET_KEY"
+              else
+                echo "user $RECORDING_ANNOTATOR_ACCESS_KEY already exists, skipping"
+              fi
+
+              mc admin policy attach local recording-annotator-rw --user "$RECORDING_ANNOTATOR_ACCESS_KEY"
+              echo "recording-annotator minio user ready"
+          env:
+            - name: MINIO_ROOT_USER
+              valueFrom:
+                secretKeyRef:
+                  name: recording-annotator-minio-root-credentials
+                  key: rootUser
+            - name: MINIO_ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: recording-annotator-minio-root-credentials
+                  key: rootPassword
+            - name: RECORDING_ANNOTATOR_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: recording-annotator-minio-user-credentials
+                  key: accessKey
+            - name: RECORDING_ANNOTATOR_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: recording-annotator-minio-user-credentials
+                  key: secretKey
+          resources:
+            requests:
+              cpu: 10m
+              memory: 64Mi
+            limits:
+              memory: 256Mi

--- a/kubernetes/apps/storage/recording-annotator-minio/ks.yaml
+++ b/kubernetes/apps/storage/recording-annotator-minio/ks.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: recording-annotator-minio
+spec:
+  # Gate this Kustomization's Ready condition on the scoped-user bootstrap Job completing, so
+  # downstream `dependsOn: recording-annotator-minio` consumers (the app itself) actually wait for
+  # their MinIO user to exist instead of only waiting for apply to succeed — mirrors storage/minio/ks.yaml.
+  healthChecks:
+    - apiVersion: batch/v1
+      kind: Job
+      name: recording-annotator-user-bootstrap
+      namespace: storage
+  interval: 1h
+  path: ./kubernetes/apps/storage/recording-annotator-minio/app
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: storage
+  wait: false


### PR DESCRIPTION
**1 of 3.** Merge this first — `default/recording-annotator` has `dependsOn` on it and will not reconcile until the bootstrap Job here has run.

Single-tenant Minio backing RecordingAnnotator, separate from the shared `storage/minio` (Thanos/Loki), which is already capacity-constrained and unrelated in purpose.

### Scoped credentials, not root

The app authenticates as a non-root user created by `recording-annotator-user-bootstrap`, so root credentials never leave the `storage` namespace — same shape as the existing thanos/loki bootstraps. The Job carries `kustomize.toolkit.fluxcd.io/ssa: IfNotPresent` from the start: a Job's `spec.template` is immutable, and without it kustomize-controller's dry-run apply fails after first success and pins the Kustomization `Ready=False` (the 2026-07-19 incident, PRs #324/#325).

The policy omits `s3:DeleteObject`. Checked rather than assumed: `IMediaStorage.DeleteAsync` is implemented upstream but has no callers and no HTTP verb, so nothing needs it.

### Exposure

Unlike the shared instance, the S3 API has to be LAN-reachable — the browser fetches media via presigned URLs. Two consequences:

- **`/minio/v2/metrics/*` is bounced at the gateway.** Minio serves it on the same port 9000, and the chart defaults `metrics.serviceMonitor.public=true` → `MINIO_PROMETHEUS_AUTH_TYPE=public`, so those paths take **no credentials at all** and would hand any LAN client the bucket names, object counts and usage. Prometheus scrapes the in-cluster Service instead.
- **`/minio/admin/*` is deliberately left reachable.** It is SigV4-authenticated, only root carries an admin policy, and the scoped app user cannot use it — blocking it would only break `mc admin` from a workstation.
- **Console gets its own route** (`httproute-console.yaml`, port 9001) so the bucket can be inspected by hand.

### Replication observability

`probe-bucket-metrics.yaml` mirrors the shared instance's. The chart scrapes only `/metrics/cluster` and `/metrics/node`, so without it the per-bucket series do not exist in Prometheus at all.

This matters more here than for the shared instance: the PVC is on `longhorn-2-no-backup` **because** server-side replication to the Object-Locked S3 bucket *is* the media backup. That replication is configured imperatively, outside Git, so `minio_bucket_replication_*` is the only signal it is still working. Alerts land in PR 3.

### Review notes

- PVC is **2Gi and holds every recording permanently** — expect to grow this early.
- Both `*.sops.yaml` files are real ciphertext and already encrypted.
- Verified with `kustomize build` on all three namespace groups plus `helm template` of the chart with these exact values; Flux Local on this PR is the real gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)