### PR TITLE
feat(recording-annotator): deploy RecordingAnnotator to the default namespace

### DIFF
--- a/kubernetes/apps/default/kustomization.yaml
+++ b/kubernetes/apps/default/kustomization.yaml
@@ -28,3 +28,4 @@ resources:
   - ./guacamole/ks.yaml
   - ./freecad/ks.yaml
   - ./audacity/ks.yaml
+  - ./recording-annotator/ks.yaml

--- a/kubernetes/apps/default/recording-annotator/app/helmrelease.yaml
+++ b/kubernetes/apps/default/recording-annotator/app/helmrelease.yaml
@@ -1,0 +1,334 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app recording-annotator
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: recording-annotator
+  interval: 1h
+  values:
+    fullnameOverride: *app
+    controllers:
+      app:
+        strategy: Recreate   # RWO PVC can't attach to old+new pod at once during rollout (LiteDB is single-file/process)
+        replicas: 1
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            image:
+              repository: ghcr.io/jasonkoopmans/recordingannotator
+              tag: v0.1.0
+            env:
+              Storage__Provider: Minio
+              Storage__Endpoint: recording-annotator-minio.storage.svc.cluster.local:9000
+              # Browser-reachable endpoint for presigned playback URLs — NOT the cluster-internal address above.
+              Storage__PublicEndpoint: recording-annotator-media.${SECRET_DOMAIN}
+              Storage__Bucket: recordings
+              Storage__UseSsl: false
+              Storage__PublicUseSsl: true
+              LiteDb__DataDirectory: /data
+              # Deliberate deviation from upstream, which puts staging under /data on the same PVC as the LiteDB
+              # file. Staging holds whole in-flight recordings — routinely larger than the entire index — and has
+              # no GC for abandoned .part files (IUploadStagingStore.DiscardAsync only runs on an explicit
+              # discard). On a shared volume one abandoned multi-GB upload fills /data and LiteDB can no longer
+              # write, turning a failed upload into an outage on the crown-jewel data. Splitting it caps the
+              # blast radius at the upload itself. Safe to move: the staging store never crosses the volume
+              # boundary — it appends to .part here, streams it to Minio via OpenReadAsync, then deletes it.
+              # Cost of the split: staging no longer survives a pod restart, so an upload interrupted by a
+              # restart restarts instead of resuming. Acceptable for a single-user LAN app; revisit if uploads
+              # get big enough that losing one hurts.
+              Upload__StagingDirectory: /staging
+              Backup__Provider: S3
+              Backup__Endpoint: s3.us-east-1.amazonaws.com
+              Backup__Region: us-east-1
+              Backup__Bucket: hiro-recording-annotator-index-backup
+              Backup__Prefix: index
+              Backup__RetentionDays: 30
+              Backup__QuiesceTimeoutSeconds: 30
+              # RAISE THIS ONCE REAL RECORDINGS EXIST. It is the restore drill's only assertion that a snapshot
+              # has content: RestoreDrillService fails the drill when the restored artifact count is below it.
+              # At 0 the drill passes on a snapshot that opens and Rebuild()s cleanly but is completely empty —
+              # exactly the silent backup-rot the monthly drill exists to catch. 0 is correct only for a
+              # pre-launch install, where a real floor would false-alarm on every run.
+              Backup__MinArtifacts: 0
+              Reconciliation__OrphanGraceMinutes: 60
+              Storage__AccessKey:
+                secretKeyRef:
+                  name: recording-annotator-secret
+                  key: Storage__AccessKey
+              Storage__SecretKey:
+                secretKeyRef:
+                  name: recording-annotator-secret
+                  key: Storage__SecretKey
+              Backup__AccessKey:
+                secretKeyRef:
+                  name: recording-annotator-secret
+                  key: Backup__AccessKey
+              Backup__SecretKey:
+                secretKeyRef:
+                  name: recording-annotator-secret
+                  key: Backup__SecretKey
+            probes:
+              # No dependency checks — restarting the pod won't fix a downstream MinIO/S3 outage.
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /healthz
+                    port: &port 8080
+                  initialDelaySeconds: 10
+                  periodSeconds: 15
+              # Gates traffic on LiteDB open + MinIO reachable; also creates the bucket on first success.
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /readyz
+                    port: *port
+                  initialDelaySeconds: 5
+                  periodSeconds: 10
+            securityContext:
+              runAsNonRoot: true
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: { drop: ["ALL"] }
+            resources:
+              requests:
+                cpu: 100m
+                memory: 256Mi
+                ephemeral-storage: 1Gi
+              limits:
+                memory: 512Mi
+                # Covers the staging emptyDir (8Gi) plus /tmp and logs. Sized so the emptyDir's own sizeLimit
+                # trips first on a single runaway upload; this is the backstop that keeps the pod from eating
+                # into a node's ephemeral storage. Sanity-check it against actual node disk before raising.
+                ephemeral-storage: 9Gi
+        pod:
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1654   # the image's $APP_UID
+            runAsGroup: 1654
+            fsGroup: 1654     # makes the mounted PVC writable by the non-root user
+
+      index-backup:
+        type: cronjob
+        cronjob:
+          schedule: "0 * * * *"   # top of every hour — meets the 1h index RPO (docs/backup-recovery.md §5)
+          concurrencyPolicy: Forbid   # a snapshot holds the write quiesce; never run two at once
+          startingDeadlineSeconds: 300
+          activeDeadlineSeconds: 300
+          backoffLimit: 2
+          successfulJobsHistory: 3
+          failedJobsHistory: 3
+        pod:
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1654
+            runAsGroup: 1654
+        containers:
+          trigger:
+            image:
+              repository: curlimages/curl
+              tag: "8.11.1"
+            command:
+              - curl
+              - -fsS
+              - --max-time
+              - "240"
+              - -X
+              - POST
+              - http://recording-annotator:8080/internal/backup/index
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: { drop: ["ALL"] }
+            resources:
+              requests:
+                cpu: 10m
+                memory: 16Mi
+              limits:
+                memory: 32Mi
+
+      reconciliation:
+        type: cronjob
+        cronjob:
+          schedule: "17 3 * * *"   # daily, off the top-of-hour index-backup cadence (docs/backup-recovery.md §7)
+          concurrencyPolicy: Forbid
+          startingDeadlineSeconds: 300
+          activeDeadlineSeconds: 600
+          backoffLimit: 2
+          successfulJobsHistory: 3
+          failedJobsHistory: 3
+        pod:
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1654
+            runAsGroup: 1654
+        containers:
+          trigger:
+            image:
+              repository: curlimages/curl
+              tag: "8.11.1"
+            command:
+              - curl
+              - -fsS
+              - --max-time
+              - "540"
+              - -X
+              - POST
+              - http://recording-annotator:8080/internal/reconcile
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: { drop: ["ALL"] }
+            resources:
+              requests:
+                cpu: 10m
+                memory: 16Mi
+              limits:
+                memory: 32Mi
+
+      restore-drill:
+        type: cronjob
+        cronjob:
+          schedule: "0 4 1 * *"   # monthly, 1st of the month (docs/backup-recovery.md §7, §9 phase 4)
+          concurrencyPolicy: Forbid
+          startingDeadlineSeconds: 600
+          activeDeadlineSeconds: 1800
+          backoffLimit: 1
+          successfulJobsHistory: 3
+          failedJobsHistory: 3
+        pod:
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1654
+            runAsGroup: 1654
+            fsGroup: 1654
+        containers:
+          restore-drill:
+            # Same image as the app controller; "restore-verify" selects the console drill entrypoint (pulls
+            # the latest index snapshot, Rebuild()s it, reads row counts back) instead of the web host. Never
+            # touches the live PVC — only a temp download into its own emptyDir below.
+            image:
+              repository: ghcr.io/jasonkoopmans/recordingannotator
+              tag: v0.1.0
+            args: ["restore-verify"]
+            env:
+              Backup__Provider: S3
+              Backup__Endpoint: s3.us-east-1.amazonaws.com
+              Backup__Region: us-east-1
+              Backup__Bucket: hiro-recording-annotator-index-backup
+              Backup__Prefix: index
+              # READ-only creds — deliberately NOT recording-annotator-secret's write-only ones.
+              Backup__AccessKey:
+                secretKeyRef:
+                  name: recording-annotator-restore-secret
+                  key: Backup__AccessKey
+              Backup__SecretKey:
+                secretKeyRef:
+                  name: recording-annotator-restore-secret
+                  key: Backup__SecretKey
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: { drop: ["ALL"] }
+            resources:
+              requests:
+                cpu: 100m
+                memory: 128Mi
+                ephemeral-storage: 512Mi
+              limits:
+                memory: 512Mi
+                # Peak /tmp is ~2x the snapshot (Rebuild() writes a second copy beside the download). Bound to
+                # THIS pod so an oversized snapshot evicts the drill instead of pressuring node neighbours.
+                ephemeral-storage: 4Gi
+
+    persistence:
+      data:
+        existingClaim: recording-annotator-data
+        advancedMounts:
+          app:
+            app:
+              - path: /data
+      # readOnlyRootFilesystem leaves .NET with nowhere to put its diagnostic IPC socket (/tmp/.dotnet) or the
+      # DataProtection key ring, both of which degrade to warnings rather than failing — but the fallback is
+      # silent, so give it a real scratch dir. Uploads themselves stream from Request.Body as octet-stream
+      # (not multipart), so Kestrel never spools a body here; small is fine.
+      app-tmp:
+        type: emptyDir
+        sizeLimit: 128Mi
+        advancedMounts:
+          app:
+            app:
+              - path: /tmp
+      # In-flight upload staging, split off the LiteDB PVC (see Upload__StagingDirectory above). sizeLimit caps
+      # one abandoned upload at 8Gi; the container's matching ephemeral-storage limit is what actually gets it
+      # evicted, so a runaway upload takes out this pod rather than the node's other tenants. fsGroup 1654 on the
+      # pod makes the volume group-writable, and the staging store creates the directory itself on startup.
+      staging:
+        type: emptyDir
+        sizeLimit: 8Gi
+        advancedMounts:
+          app:
+            app:
+              - path: /staging
+      tmp:
+        type: emptyDir
+        sizeLimit: 4Gi
+        advancedMounts:
+          restore-drill:
+            restore-drill:
+              - path: /tmp
+
+    service:
+      app:
+        controller: app
+        ports:
+          http:
+            port: *port
+
+    route:
+      app:
+        hostnames: ["recordings.${SECRET_DOMAIN}"]
+        annotations:
+          gethomepage.dev/enabled: "true"
+          gethomepage.dev/icon: sh-recordings
+          gethomepage.dev/title: Recording Annotator
+          gethomepage.dev/description: "Time-coded comments on meeting recordings"
+          gethomepage.dev/group: "Media"
+        parentRefs:
+          - name: envoy-internal
+            namespace: network
+            sectionName: https
+        rules:
+          # /internal/* and /metrics are unauthenticated in v1 (BackupController and ReconciliationController
+          # carry no [Authorize]), so they must not be reachable through the gateway. A LAN client POSTing
+          # /internal/backup/index in a loop would quiesce writes AND mint S3 objects under COMPLIANCE-mode
+          # object lock, which nobody — including the account root — can delete for Backup__RetentionDays.
+          # The three CronJobs call the Service directly (http://recording-annotator:8080), never through the
+          # gateway, so bouncing these paths here costs nothing. Prometheus likewise scrapes via the Service.
+          # A longer path prefix wins over the catch-all rule below by Gateway API match precedence, which is
+          # specificity-based rather than list-order-based — the ordering here is only for readability.
+          - matches:
+              - path: { type: PathPrefix, value: /internal }
+              - path: { type: PathPrefix, value: /metrics }
+            filters:
+              - type: RequestRedirect
+                requestRedirect:
+                  scheme: https
+                  path: { type: ReplaceFullPath, replaceFullPath: / }
+                  statusCode: 302
+          - backendRefs:
+              - identifier: app
+                port: *port
+
+    serviceMonitor:
+      app:
+        endpoints:
+          - port: http

--- a/kubernetes/apps/default/recording-annotator/app/kustomization.yaml
+++ b/kubernetes/apps/default/recording-annotator/app/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml
+  - ./pvc.yaml
+  - ./recording-annotator-secret.sops.yaml
+  - ./recording-annotator-restore-secret.sops.yaml

--- a/kubernetes/apps/default/recording-annotator/app/ocirepository.yaml
+++ b/kubernetes/apps/default/recording-annotator/app/ocirepository.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: recording-annotator
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/default/recording-annotator/app/pvc.yaml
+++ b/kubernetes/apps/default/recording-annotator/app/pvc.yaml
@@ -1,0 +1,17 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/api/core/v1/persistentvolumeclaim_v1.json
+# LiteDB index file + upload staging directory (RecordingAnnotator docs/backup-recovery.md §2, §9). RWO is
+# sufficient: LiteDB is single-file, single-process, matching the single-replica Deployment. Longhorn (3
+# replica + backup) is belt-and-suspenders under the app's own independent hourly S3 index export — starting
+# small (2Gi) and growing as real recordings land rather than over-provisioning day one.
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: recording-annotator-data
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: longhorn
+  resources:
+    requests:
+      storage: 2Gi

--- a/kubernetes/apps/default/recording-annotator/app/pvc.yaml
+++ b/kubernetes/apps/default/recording-annotator/app/pvc.yaml
@@ -1,6 +1,6 @@
 ---
 # yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/api/core/v1/persistentvolumeclaim_v1.json
-# LiteDB index file + upload staging directory (RecordingAnnotator docs/backup-recovery.md §2, §9). RWO is
+# LiteDB index file (RecordingAnnotator docs/backup-recovery.md §2, §9). RWO is
 # sufficient: LiteDB is single-file, single-process, matching the single-replica Deployment. Longhorn (3
 # replica + backup) is belt-and-suspenders under the app's own independent hourly S3 index export — starting
 # small (2Gi) and growing as real recordings land rather than over-provisioning day one.

--- a/kubernetes/apps/default/recording-annotator/app/recording-annotator-restore-secret.sops.yaml
+++ b/kubernetes/apps/default/recording-annotator/app/recording-annotator-restore-secret.sops.yaml
@@ -1,0 +1,27 @@
+# READ-only AWS IAM principal for the restore-drill CronJob (GetObject/ListBucket on
+# hiro-recording-annotator-index-backup only). Deliberately a DIFFERENT Secret/principal from
+# recording-annotator-secret's write-only Backup__* creds — the restore-drill controller mounts THIS secret
+# so the read-only credential is the one in effect, never the app's write-only one.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: recording-annotator-restore-secret
+stringData:
+  Backup__AccessKey: ENC[AES256_GCM,data:CLsuOj+IFlvFxFlMNMM7uw4g1qo=,iv:CFy3BEnBNYMB1KSBMz/QYx+6lOeKUpGIHsTBFXxtQMU=,tag:SYL2Nx1MLDgzWGNimj8Fbw==,type:str]
+  Backup__SecretKey: ENC[AES256_GCM,data:WZ1WebsdJVqW9q+3nvDFMEWwF+Lc8HWgeLdH8NoQqlBrN/OZQIGr1Q==,iv:TNNL+amsyOqs0tvReBLQl4N9o5rhk2+3m7IBHFA6ZeU=,tag:UhhFa/ZEcB8RQiodztAyeA==,type:str]
+sops:
+  age:
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB4OFh2RnFVdDllTkJ1MXJS
+        bTJYVEZSVjNPL1FSNENKZ2x5elVEU29ucGxVCkhjR0lCZ3Uvb0llWWRRS0JoWDQ5
+        NURoekl4QnBCU1d4VUM3SXl2MUJJbVEKLS0tIHA3Tm9peHBSZnM5SCs3UGxlamRm
+        WllqdHVHeXFKSkpQQTJ5YUIyaWxRS1UK2ST3YLxU/rJiC+5stVaLPmObEVdqEYV9
+        +M/Ue+Q6bZmSZbHS/R+DXj0mgUjIXrDJrMtbFokPW70N5MkDRni8aQ==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1gekuxnpd95l5j8gsvmpsn2mewnevd0c5y5v66p4trzcqhmpn0svqkmnyy7
+  encrypted_regex: ^(data|stringData)$
+  lastmodified: "2026-08-01T13:15:27Z"
+  mac: ENC[AES256_GCM,data:EKhULVmfYCyIYHAzB+3OxKouP7nXJTE5PokdJgLvpFmFuIZpG5nLxDek6Ek8rcylnHDbx1fAwI4pGtpZlf1UqXYCrmQgIzDMYf1WonGrEVT347RDALC15JrIKgE1oPFdv0baq/aoIiKKNN4Uafws+XCFxrr++RcVpPRAiERsyUU=,iv:/izRYt90KgO68S8907S0dgqVbweEP9vfdtYvgyDbpQs=,tag:Ufgk47ieHtXi0T9GjWCABg==,type:str]
+  mac_only_encrypted: true
+  version: 3.13.2

--- a/kubernetes/apps/default/recording-annotator/app/recording-annotator-secret.sops.yaml
+++ b/kubernetes/apps/default/recording-annotator/app/recording-annotator-secret.sops.yaml
@@ -1,0 +1,33 @@
+# Storage__* : the SCOPED (non-root) MinIO user for the recordings bucket — same accessKey/secretKey pair
+# as kubernetes/apps/storage/recording-annotator-minio/app/recording-annotator-minio-user-credentials.sops.yaml,
+# provisioned there by a bootstrap Job (mirrors storage/minio's thanos-user-bootstrap pattern). Root creds
+# never leave the storage namespace. Generate the pair there first, then copy the SAME values here.
+# Backup__*  : a WRITE-only AWS IAM principal scoped to the hiro-recording-annotator-index-backup S3 bucket
+# (PutObject only — deliberately cannot read/delete, so a compromised app can add snapshots but not destroy
+# or read existing ones). See deploy/backup/RUNBOOK.md in the RecordingAnnotator repo for the least-privilege
+# policy shape (mirror it, scoped to the index bucket instead of the media bucket).
+apiVersion: v1
+kind: Secret
+metadata:
+  name: recording-annotator-secret
+stringData:
+  Storage__AccessKey: ENC[AES256_GCM,data:Cq1k8ol9YAEzRH2/M/M5sdzWoeI=,iv:VLrWxfki5ExTmiyEF4iOJPuDIBpxXiZ1kpgMLxwkKiw=,tag:EmnELOxHpZqZJU6/RDi2+A==,type:str]
+  Storage__SecretKey: ENC[AES256_GCM,data:rPuynx9+3UcwYDNpFA/BX6GNfPHjP0BNsVxWg8jeSyqww1Nh8OUiH35tV0QUepk7Lba7y9SUicGLY1qq,iv:AMwcm5lqE2IjtTR57BEiN/lbTwE39yUAXQynwQqpsF0=,tag:di/fbcA4QaxkaZQag71L/g==,type:str]
+  Backup__AccessKey: ENC[AES256_GCM,data:OHNk0mmN6Rfg2wAoLFUAo7Dlc0M=,iv:txF3IAP1OTdYjf1XUcKFo7kAdh2EX9bRDK1ZeDu+apk=,tag:V/Thdby2F4/4JTZzScb34A==,type:str]
+  Backup__SecretKey: ENC[AES256_GCM,data:PILKJF8Nvx9Fk5ND423FKQg+zG2cO+OFi7foQSDtWBZ/Gmh01/cBJw==,iv:bXdrRL3arDlmJnDha3nwhLrBRc8QRzIIE6RrwOQBPLQ=,tag:lOx7hrS9YmEa2ndaEbPKMQ==,type:str]
+sops:
+  age:
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA3Y2ZNdjBYVkVxc0c4WTBE
+        NWZWVXB2eUxwRytHa1BiaGdJMWZUWnJSZHhZCjljUXRIalRMcHZyeUN5eUt4eWda
+        RlhLVUtBWVRiOXJZdEdHdGFvK2hsejQKLS0tIHh6VTlqUEpReERsZkJtRXBjWm1S
+        dGsvU0w2SjdTOWE0dDJENi9mdkNkVDAKcBBhGMOZkOZoYF1688V0uMeIJb2NaCDf
+        UzNobZC2yV+dSVQBRHZzWg9tugX5Uw+XCiMEzKjbF+MKs6iNN4ux8w==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1gekuxnpd95l5j8gsvmpsn2mewnevd0c5y5v66p4trzcqhmpn0svqkmnyy7
+  encrypted_regex: ^(data|stringData)$
+  lastmodified: "2026-08-01T13:14:12Z"
+  mac: ENC[AES256_GCM,data:g+2ClxRaIuf1BKkYNM/qjXhPo77LMjMVXJhntcfVXxGBxFVhuW72ROAlYpKZYCqZ4D/uLT2i0dZv4b46ZN75t3Lr+HIXRjC2SmYAhnDYoSmxtMTO++nA9mBa9b5klA22A8MoL5G6cYcbakZwHI5XjuPicu/TuOhpkHyf4yFz448=,iv:7H/oFJT5GlGeGhosf5SNaHqnYqZYtiFcGXOBxdxxmFQ=,tag:MfHNl9PtxkXj8lC4azHYkw==,type:str]
+  mac_only_encrypted: true
+  version: 3.13.2

--- a/kubernetes/apps/default/recording-annotator/ks.yaml
+++ b/kubernetes/apps/default/recording-annotator/ks.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: recording-annotator
+spec:
+  dependsOn:
+    - name: recording-annotator-minio
+      namespace: storage
+  interval: 1h
+  path: ./kubernetes/apps/default/recording-annotator/app
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: default
+  wait: false


### PR DESCRIPTION
**2 of 3.** Depends on #375 — `dependsOn: recording-annotator-minio` means this will not go `Ready` until that Minio and its bootstrap Job exist. Builds and diffs fine on its own; only cluster reconcile is ordered.

Self-hosted app for time-coded markdown comments on meeting recordings. One app-template HelmRelease, four controllers: the web app plus the three scheduled jobs that make up the upstream backup design — hourly index snapshot to Object-Locked S3, daily reconciliation audit, monthly restore drill.

State is split deliberately. The LiteDB index sits on a 3-replica Longhorn-backed PVC *and* is exported offsite hourly; media blobs live in the dedicated Minio and are protected by replication rather than a second Longhorn copy.

### Deviations from a naive port of upstream's manifests

**Upload staging moved off the LiteDB PVC onto its own emptyDir.** Upstream co-locates them. But staging holds whole in-flight recordings — routinely larger than the entire index — and abandoned `.part` files are never collected (`DiscardAsync` only runs on an explicit discard). On a shared volume one abandoned multi-GB upload fills `/data` and **LiteDB can no longer write**, turning a failed upload into an outage on the most valuable data. Safe to split: the staging store never crosses the volume boundary — appends to `.part`, streams out via `OpenReadAsync`, deletes. No `File.Move`, so no cross-device failure.

*Cost:* an upload interrupted by a pod restart restarts instead of resuming. Upstream put staging on the PVC specifically for that. Acceptable for a single-user LAN app.

**`/internal/*` and `/metrics` bounced at the gateway.** `BackupController` and `ReconciliationController` carry no `[Authorize]` and the app has no auth in v1. Without this, any LAN client could `POST /internal/backup/index` in a loop — each call quiesces writes **and** mints an S3 object under COMPLIANCE-mode object lock that nobody, including the account root, can delete for `Backup__RetentionDays`. Irreversible cost amplification plus an availability lever. The CronJobs and Prometheus both reach the Service directly, so nothing legitimate uses those paths.

**restore-drill** runs the app image in `restore-verify` mode with the read-only backup credentials — not the app's write-only pair — and mounts no PVC.

**`readOnlyRootFilesystem`** is on, so the app gets a small emptyDir `/tmp`; .NET otherwise degrades silently on its diagnostic socket and DataProtection key ring. (Not an upload risk — uploads stream `application/octet-stream` from `Request.Body`, so Kestrel never spools a body there.)

### Needs a decision from you

- **`Backup__MinArtifacts: 0`** is correct only pre-launch. It is the restore drill's *sole* assertion that a snapshot has content — at 0 the drill passes on a completely empty restore, which is exactly the silent backup-rot the drill exists to catch. Upstream's own comment says to raise it once real data exists. Flagged in the manifest.
- **`ephemeral-storage` 1Gi request / 9Gi limit** and the 8Gi staging `sizeLimit` are sized for a multi-GB recording plus headroom. I have not checked these against actual node disk — worth a sanity check before merge.

### Verification

`kustomize build` on all three namespace groups, plus `helm template` of app-template 5.0.1 with these exact values — confirmed the Service selector scopes to the `app` controller only (CronJob pods excluded), the CronJob curl target resolves, and the route filters render. Flux Local on this PR is the real gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)