### PR TITLE
feat(monitoring): alerting for RecordingAnnotator and its Minio instance

### DIFF
--- a/docs/backup-recovery.md
+++ b/docs/backup-recovery.md
@@ -1,0 +1,200 @@
+# Recording Annotator: Backup and Recovery
+
+This document describes the backup strategy, data integrity guarantees, and recovery
+procedures for the **recording-annotator** application. The app stores recording blobs
+in a dedicated MinIO instance (`recording-annotator-minio`) and maintains a separate
+index. Several Prometheus alerts reference sections of this document as pointers for
+on-call response.
+
+---
+
+## §1 Overview of data stores
+
+| Store | Contents | Backup mechanism |
+|---|---|---|
+| MinIO PVC (`recordings` bucket) | Raw recording blobs | Server-side replication to Object-Locked S3 bucket (see §6) |
+| Index PVC | SQLite / file-based index of all artifacts | Hourly offsite snapshot (see §5) |
+
+The index and the blobs are intentionally decoupled: the index is small and
+snapshotted independently, while blobs are large and replicated directly. Recovery
+may require restoring the index from a snapshot and reconciling it against the live
+blob store (see §8).
+
+---
+
+## §2 MinIO replication to S3
+
+Replication from the `recordings` MinIO bucket to the remote Object-Locked S3 bucket
+is configured imperatively by `deploy/backup/configure-minio-replication.sh`. It is
+**not** driven by Flux/GitOps and therefore can be silently absent after a rebuild of
+the MinIO instance.
+
+The `RecordingAnnotatorMediaReplicationNotConfigured` alert fires when no replication
+metrics are present for the bucket, indicating the script was never run or the
+bucket-metrics scrape is broken. Re-run the script against the new instance and
+confirm the `minio_bucket_replication_failed_count{bucket="recordings"}` series
+appears.
+
+---
+
+## §3 Index vs. blob lifetime
+
+The index is the authoritative record of which recordings exist and where their blobs
+are stored. It is backed up separately from the blobs because:
+
+- It is small and changes frequently (every recording session).
+- The blob store has its own durability guarantee (Object-Locked S3 replication).
+- A corrupted or missing index can be partially recovered by scanning the blob store,
+  but the index contains richer metadata that cannot be reconstructed from blobs alone.
+
+---
+
+## §4 Write-order guarantee
+
+The application always **writes the blob to MinIO before writing the index entry**.
+This means that in the event of a crash between the two writes, the blob exists but
+the index does not reference it — an orphan object, not a dangling reference.
+
+**A dangling reference** (an index entry pointing to a blob that does not exist) is
+therefore impossible in normal operation. If the
+`RecordingAnnotatorReconciliationDanglingReferences` alert fires, treat it as a real
+bug or a replication gap (blobs deleted out-of-band, or a partial restore that brought
+the index forward past the blob store's state), not an expected transient condition.
+
+---
+
+## §5 Hourly index snapshot (offsite backup)
+
+A CronJob (`recording-annotator-index-backup`) runs hourly and exports a snapshot of
+the index to the offsite S3 bucket. The snapshot path follows the pattern:
+
+```
+s3://<backup-bucket>/recording-annotator/index/<YYYY>/<MM>/<DD>/index-<timestamp>.snap
+```
+
+The `recording_annotator_index_snapshot_timestamp_seconds` gauge (scraped from the app
+process) tracks when the last successful snapshot completed. The
+`RecordingAnnotatorIndexBackupStale` alert fires when this gauge is more than 90
+minutes old (i.e. a second scheduled run has been missed), and
+`RecordingAnnotatorIndexBackupNeverSucceeded` fires when the gauge has been zero for 3
+consecutive hours, meaning no snapshot has ever completed on this instance.
+
+**To diagnose a stale or missing snapshot:**
+
+```sh
+# Check recent CronJob and Job status
+kubectl get cronjob recording-annotator-index-backup -n default
+kubectl get jobs -n default -l app=recording-annotator-index-backup --sort-by=.metadata.creationTimestamp | tail -5
+
+# Inspect the most recent Job's logs
+kubectl logs -n default -l job-name=<most-recent-job-name>
+```
+
+Common causes: S3 credentials expired or missing, network policy blocking egress to
+the S3 endpoint, or the index volume being too large for the snapshot to complete
+within the Job's active deadline.
+
+---
+
+## §6 S3 Object-Lock configuration
+
+The remote S3 bucket must have Object Lock enabled in compliance mode with a minimum
+retention period (configured at the time the bucket was created — check the bucket
+settings in the AWS console). This prevents any actor, including the replication
+service account, from deleting or overwriting objects within the retention window.
+
+Verify Object Lock status:
+
+```sh
+aws s3api get-object-lock-configuration --bucket <remote-bucket-name>
+```
+
+---
+
+## §7 Daily reconciliation audit
+
+A CronJob (`recording-annotator-reconciliation`) runs daily and compares the index
+against the live MinIO blob store. It reports two classes of inconsistency as
+Prometheus gauges (scraped from the app process):
+
+| Gauge | Meaning |
+|---|---|
+| `recording_annotator_reconciliation_dangling_references` | Index entries whose blob is missing from MinIO |
+| `recording_annotator_reconciliation_orphan_objects` | MinIO objects with no owning index entry past the orphan grace window |
+
+**Orphan grace window:** newly uploaded blobs temporarily exist in MinIO before the
+index entry is written (see §4). The reconciliation job ignores objects younger than
+the grace window (default: 2 hours) to avoid false orphan reports during normal
+ingestion. Objects outside the grace window with no index entry are genuine orphans
+and safe to remove if storage reclamation is needed.
+
+The `RecordingAnnotatorReconciliationStale` alert fires when the
+`recording_annotator_reconciliation_timestamp_seconds` gauge is more than 36 hours old
+(a second daily run has been missed). Until the audit re-runs, the dangling and orphan
+gauges read stale values and must not be trusted for operational decisions.
+
+**To diagnose a stale reconciliation:**
+
+```sh
+kubectl get cronjob recording-annotator-reconciliation -n default
+kubectl get jobs -n default -l app=recording-annotator-reconciliation --sort-by=.metadata.creationTimestamp | tail -5
+kubectl logs -n default -l job-name=<most-recent-job-name>
+```
+
+---
+
+## §8 Recovering the index from a snapshot
+
+If the index PVC is lost or corrupted, restore from the most recent hourly snapshot
+(see §5). The restore procedure:
+
+1. Stop the recording-annotator deployment (scale to 0 replicas).
+2. Download the most recent snapshot from S3:
+   ```sh
+   aws s3 ls s3://<backup-bucket>/recording-annotator/index/ --recursive \
+     | sort | tail -1   # find the latest snapshot key
+   aws s3 cp s3://<backup-bucket>/recording-annotator/index/<path> /tmp/index.snap
+   ```
+3. Mount the index PVC in a recovery pod and overwrite with the snapshot.
+4. Scale the deployment back up.
+5. Run the reconciliation CronJob manually to verify consistency:
+   ```sh
+   kubectl create job -n default --from=cronjob/recording-annotator-reconciliation manual-reconcile-$(date +%s)
+   ```
+6. Confirm the dangling-references gauge reads zero before declaring recovery complete.
+
+Any recordings ingested between the last snapshot and the failure will have blobs in
+MinIO (durable via S3 replication) but no index entry — they will appear as orphan
+objects in the reconciliation output. These can be re-indexed by scanning the blob
+store, or accepted as orphans and cleaned up.
+
+---
+
+## §9 Monthly restore drill
+
+A CronJob (`recording-annotator-restore-drill`) runs monthly and performs an
+end-to-end proof that the offsite index backup is actually restorable. The drill
+consists of four phases:
+
+| Phase | Action |
+|---|---|
+| 1 | Download the most recent index snapshot from S3 |
+| 2 | Load the snapshot into a temporary ephemeral volume |
+| 3 | Run a read-only consistency check against the live blob store |
+| 4 | Verify that a sample of index entries can be resolved to real, accessible blobs in MinIO |
+
+**Phase 4** is the critical verification step — it proves the snapshot is not just
+syntactically valid but that the blobs it references are actually present and readable.
+If the `RecordingAnnotatorRestoreDrillJobFailed` alert fires, the index backup must be
+treated as **unverified** until the drill is re-run successfully and passes all four
+phases.
+
+To manually trigger a restore drill:
+
+```sh
+kubectl create job -n default --from=cronjob/recording-annotator-restore-drill manual-drill-$(date +%s)
+kubectl logs -n default -l job-name=<created-job-name> -f
+```
+
+After resolving the root cause, re-run the drill and confirm it passes before
+clearing the alert.

--- a/kubernetes/apps/monitoring/kube-prometheus-stack/app/kustomization.yaml
+++ b/kubernetes/apps/monitoring/kube-prometheus-stack/app/kustomization.yaml
@@ -20,6 +20,7 @@ resources:
   - ./prometheusrule-opnsense.yaml
   - ./prometheusrule-envoy.yaml
   - ./prometheusrule-pod-limit-pressure.yaml
+  - ./prometheusrule-recording-annotator.yaml
   - ./httproute.yaml
   - ./httproute-prometheus.yaml
   - ./grafana-secret.sops.yaml

--- a/kubernetes/apps/monitoring/kube-prometheus-stack/app/prometheusrule-recording-annotator.yaml
+++ b/kubernetes/apps/monitoring/kube-prometheus-stack/app/prometheusrule-recording-annotator.yaml
@@ -1,0 +1,158 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: recording-annotator-alerts
+  namespace: monitoring
+  labels:
+    release: kube-prometheus-stack
+spec:
+  groups:
+    - name: recording-annotator.rules
+      rules:
+        - alert: RecordingAnnotatorIndexBackupJobFailed
+          expr: kube_job_failed{namespace="default", job_name=~"recording-annotator-index-backup-.*"} > 0
+          for: 5m
+          labels:
+            severity: critical
+          annotations:
+            summary: RecordingAnnotator hourly index backup Job failed
+            description: The recording-annotator-index-backup CronJob has a failed Job. The offsite index snapshot (docs/backup-recovery.md §5) did not complete this hour.
+
+        - alert: RecordingAnnotatorReconciliationJobFailed
+          expr: kube_job_failed{namespace="default", job_name=~"recording-annotator-reconciliation-.*"} > 0
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: RecordingAnnotator reconciliation audit Job failed
+            description: The recording-annotator-reconciliation CronJob has a failed Job. Index/blob consistency has not been audited today (docs/backup-recovery.md §7).
+
+        - alert: RecordingAnnotatorRestoreDrillJobFailed
+          expr: kube_job_failed{namespace="default", job_name=~"recording-annotator-restore-drill-.*"} > 0
+          for: 5m
+          labels:
+            severity: critical
+          annotations:
+            summary: RecordingAnnotator monthly restore drill failed
+            description: The recording-annotator-restore-drill CronJob failed — the offsite index backup could NOT be proven restorable this month (docs/backup-recovery.md §7, §9 phase 4). Treat the index backup as unverified until this is fixed and re-run.
+
+        # Gauges set on the live app process, scraped via the app's ServiceMonitor (spec section 9) — not from
+        # the CronJob trigger containers themselves.
+        - alert: RecordingAnnotatorReconciliationDanglingReferences
+          expr: recording_annotator_reconciliation_dangling_references > 0
+          for: 5m
+          labels:
+            severity: critical
+          annotations:
+            summary: RecordingAnnotator has dangling artifact references
+            description: "{{ $$value }} artifact(s) reference a MinIO object that does not exist. Write-order (docs/backup-recovery.md §4) makes this impossible in normal operation — treat as a real bug or a replication gap, i.e. broken playback."
+
+        - alert: RecordingAnnotatorOrphanObjectsHigh
+          expr: recording_annotator_reconciliation_orphan_objects > 50
+          for: 30m
+          labels:
+            severity: warning
+          annotations:
+            summary: RecordingAnnotator has a growing number of orphan blobs
+            description: "{{ $$value }} MinIO objects have no owning artifact past the grace window (docs/backup-recovery.md §7) — expected to be small; a persistently high count is wasted space worth investigating."
+
+        # The `> 0` guard on both staleness rules is load-bearing. AppMetrics declares these with prometheus-net's
+        # Metrics.CreateGauge, which publishes the series immediately at 0 — so a bare
+        # `time() - <gauge> > threshold` evaluates to ~1.7e9 the moment the pod starts and would fire on every
+        # rollout, before the first scheduled run could possibly have happened. The paired *NeverSucceeded rules
+        # close the hole that guard opens: a gauge pinned at 0 means the job has never once succeeded, which must
+        # still page. Those lean on `for:` rather than a range-vector window because `for:` requires the condition
+        # to hold for real elapsed time, which is what makes them behave correctly on a fresh install instead of
+        # firing against a window that is not full yet. Caveat: a Prometheus restart resets `for:` state, so a
+        # long-pending one starts its clock over.
+        - alert: RecordingAnnotatorIndexBackupStale
+          expr: |
+            recording_annotator_index_snapshot_timestamp_seconds > 0
+            and time() - recording_annotator_index_snapshot_timestamp_seconds > 5400
+          for: 5m
+          labels:
+            severity: critical
+          annotations:
+            summary: RecordingAnnotator index backup has not run recently
+            description: No successful index snapshot in over 90 minutes despite an hourly schedule — the backup pipeline may have silently stopped (docs/backup-recovery.md §5), which is exactly the failure mode an untested backup hides.
+
+        - alert: RecordingAnnotatorIndexBackupNeverSucceeded
+          expr: recording_annotator_index_snapshot_timestamp_seconds == 0
+          for: 3h
+          labels:
+            severity: critical
+          annotations:
+            summary: RecordingAnnotator has never completed an index backup
+            description: The index snapshot timestamp has been zero for 3 hours against an hourly schedule, so no snapshot has ever succeeded on this app instance. Briefly expected right after a first deploy; if it persists, the offsite index backup does not exist at all.
+
+        - alert: RecordingAnnotatorReconciliationStale
+          expr: |
+            recording_annotator_reconciliation_timestamp_seconds > 0
+            and time() - recording_annotator_reconciliation_timestamp_seconds > 129600
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: RecordingAnnotator reconciliation audit has not run recently
+            description: No successful reconciliation audit in over 36 hours despite a daily schedule — the dangling/orphan gauges above are no longer trustworthy (docs/backup-recovery.md §7).
+
+        - alert: RecordingAnnotatorReconciliationNeverSucceeded
+          expr: recording_annotator_reconciliation_timestamp_seconds == 0
+          for: 26h
+          labels:
+            severity: warning
+          annotations:
+            summary: RecordingAnnotator has never completed a reconciliation audit
+            description: The reconciliation timestamp has been zero for 26 hours against a daily schedule, so the audit has never succeeded on this app instance. The dangling-reference and orphan-object gauges read zero because nothing has ever measured them, not because the store is clean.
+
+    # The dedicated Minio instance backing this app. The existing prometheusrule-minio.yaml rules are scoped to
+    # the shared instance (`up{job="minio"}`, `pod=~"minio-.*"`) and do not match `recording-annotator-minio-*`,
+    # so without this group the store holding every recording has no availability or replication alerting at all.
+    - name: recording-annotator-minio.rules
+      rules:
+        - alert: RecordingAnnotatorMinioDown
+          # Job label comes from the chart's Probe (jobName: recording-annotator-minio) and node ServiceMonitor;
+          # confirm against `up{job=~"recording-annotator-minio.*"}` after the first scrape.
+          expr: up{job=~"recording-annotator-minio.*"} == 0
+          for: 10m
+          labels:
+            severity: critical
+          annotations:
+            summary: RecordingAnnotator's Minio instance is down
+            description: Target {{ $$labels.instance }} has been unreachable for 10 minutes. Media upload and playback are both broken while this is true.
+
+        - alert: RecordingAnnotatorMinioPodNotReady
+          expr: |
+            sum(kube_pod_status_ready{namespace="storage", condition="true", pod=~"recording-annotator-minio-.*"}) < 1
+          for: 10m
+          labels:
+            severity: critical
+          annotations:
+            summary: RecordingAnnotator's Minio pod is not ready
+            description: No ready recording-annotator-minio pod in the storage namespace for 10 minutes.
+
+        # Media has no Longhorn backup by design — server-side replication to the Object-Locked S3 bucket IS the
+        # backup. It is configured imperatively by deploy/backup/configure-minio-replication.sh, so it can be
+        # absent (never run, or lost on a rebuild of this instance) with no other symptom. These two alerts are
+        # the only thing standing between that and silent total loss of the recordings' offsite copy.
+        # Series come from the bucket metrics endpoint, scraped by the probe-bucket-metrics.yaml in that app's
+        # directory. Confirm the exact metric names against the first live scrape before trusting silence here —
+        # Minio has renamed bucket replication series across releases.
+        - alert: RecordingAnnotatorMediaReplicationNotConfigured
+          expr: absent(minio_bucket_replication_failed_count{bucket="recordings"})
+          for: 1h
+          labels:
+            severity: critical
+          annotations:
+            summary: Minio replication to S3 is not reporting for the recordings bucket
+            description: No replication metrics for the recordings bucket. Either configure-minio-replication.sh was never run against this instance, the rule was removed, or the bucket-metrics scrape is broken. Until this is resolved the recordings have NO offsite copy — the PVC is on longhorn-2-no-backup precisely because replication was meant to cover it.
+
+        - alert: RecordingAnnotatorMediaReplicationFailing
+          expr: minio_bucket_replication_failed_count{bucket="recordings"} > 0
+          for: 30m
+          labels:
+            severity: critical
+          annotations:
+            summary: Minio replication to S3 is failing for the recordings bucket
+            description: "{{ $$value }} replication operation(s) have failed for 30 minutes. Newly uploaded recordings are not reaching the Object-Locked S3 bucket; check the replication target credentials and the remote bucket's object-lock configuration."


### PR DESCRIPTION
**3 of 3.** Follows #375 and #376. Independently mergeable — alerts referencing not-yet-existing metrics simply never fire — but pointless until those land.

Most of the value in RecordingAnnotator's backup design is the *assurance* that the backups work, and that assurance is only real if a silent failure pages. Covers the three CronJobs, the reconciliation audit's gauges, staleness of both scheduled runs, and the dedicated Minio.

### Two things worth reviewing closely

**The staleness rules guard on `> 0`.** `AppMetrics` declares these with prometheus-net's `Metrics.CreateGauge`, which publishes the series **immediately at 0**. So the obvious expression — `time() - <gauge> > threshold` — evaluates to ~1.7e9 the moment the pod starts and fires on every single rollout, before the first scheduled run could possibly have happened. On a `critical`-severity alert. That is how alert fatigue starts, and it would have quietly undermined the exact assurance this is for.

The paired `*NeverSucceeded` rules close the hole the guard opens: a gauge pinned at 0 means the job has *never* succeeded, which must still page. They use `for:` rather than a range-vector window, because `for:` requires the condition to hold for real elapsed time — which is what makes them behave correctly on a fresh install instead of testing a window that is not full yet. Caveat noted in the file: a Prometheus restart resets `for:` state.

**The Minio rules are a separate group on purpose.** The existing `minio.rules` is scoped to the shared instance (`up{job="minio"}`, `pod=~"minio-.*"`) and never matches `recording-annotator-minio-*` — so without this, the store holding every recording has no availability alerting at all.

The replication pair matters most. That bucket's only offsite protection is server-side replication to the Object-Locked S3 bucket, it is configured imperatively outside Git, and it can therefore be absent — never run, or lost on a rebuild of the instance — with **no other symptom**. Contrast the index, which gets a monthly restore drill. This was the largest asymmetry against the stated goal.

⚠️ `MediaReplicationNotConfigured` alerts on *absence*, and Minio has renamed bucket replication series across releases. Confirm `minio_bucket_replication_failed_count` against the first live scrape before trusting silence from it.

### Formatting

Follows the `{{ $$value }}` convention added in ce7d176 on threshold/rate/count alerts, so the Telegram template has a number to render. `$$` escaping is required — Flux postBuild substitution would otherwise eat a single `$`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)