### PR TITLE
fix(recording-annotator): pull private ghcr image, fix tag mismatch

### DIFF
--- a/kubernetes/apps/default/recording-annotator/app/helmrelease.yaml
+++ b/kubernetes/apps/default/recording-annotator/app/helmrelease.yaml
@@ -21,7 +21,7 @@ spec:
           app:
             image:
               repository: ghcr.io/jasonkoopmans/recordingannotator
-              tag: v0.1.0
+              tag: "0.1.0"
             env:
               Storage__Provider: Minio
               Storage__Endpoint: recording-annotator-minio.storage.svc.cluster.local:9000
@@ -110,6 +110,8 @@ spec:
                 # into a node's ephemeral storage. Sanity-check it against actual node disk before raising.
                 ephemeral-storage: 9Gi
         pod:
+          imagePullSecrets:
+            - name: recording-annotator-pullsecret
           securityContext:
             runAsNonRoot: true
             runAsUser: 1654   # the image's $APP_UID
@@ -205,6 +207,8 @@ spec:
           successfulJobsHistory: 3
           failedJobsHistory: 3
         pod:
+          imagePullSecrets:
+            - name: recording-annotator-pullsecret
           securityContext:
             runAsNonRoot: true
             runAsUser: 1654
@@ -217,7 +221,7 @@ spec:
             # touches the live PVC — only a temp download into its own emptyDir below.
             image:
               repository: ghcr.io/jasonkoopmans/recordingannotator
-              tag: v0.1.0
+              tag: "0.1.0"
             args: ["restore-verify"]
             env:
               Backup__Provider: S3

--- a/kubernetes/apps/default/recording-annotator/app/helmrelease.yaml
+++ b/kubernetes/apps/default/recording-annotator/app/helmrelease.yaml
@@ -9,6 +9,13 @@ spec:
     kind: OCIRepository
     name: recording-annotator
   interval: 1h
+  # Default 5m wait is too tight for this app: the app controller uses strategy: Recreate (RWO PVC), so an
+  # upgrade first fully terminates the old pod, then cold-pulls ghcr.io/jasonkoopmans/recordingannotator on
+  # whatever node it lands on. A cold pull + start that runs past 5m gets marked UpgradeFailed and auto-rolled
+  # back to the last "successful" release even if the pod would have come up seconds later — which is exactly
+  # what caused this app to flap back to a broken pre-fix release repeatedly. 15m matches other image-heavy
+  # apps in this cluster (hermes-ai-agent, freecad, openreel, obsidian).
+  timeout: 15m
   values:
     fullnameOverride: *app
     controllers:

--- a/kubernetes/apps/default/recording-annotator/app/kustomization.yaml
+++ b/kubernetes/apps/default/recording-annotator/app/kustomization.yaml
@@ -7,3 +7,4 @@ resources:
   - ./pvc.yaml
   - ./recording-annotator-secret.sops.yaml
   - ./recording-annotator-restore-secret.sops.yaml
+  - ./recording-annotator-pullsecret.sops.yaml

--- a/kubernetes/apps/default/recording-annotator/app/recording-annotator-pullsecret.sops.yaml
+++ b/kubernetes/apps/default/recording-annotator/app/recording-annotator-pullsecret.sops.yaml
@@ -1,0 +1,26 @@
+# dockerconfigjson for a ghcr.io PAT (classic, read:packages only) scoped to
+# jasonkoopmans/recordingannotator — the package is private, so both the app
+# and restore-drill controllers need this to pull ghcr.io/jasonkoopmans/recordingannotator.
+apiVersion: v1
+kind: Secret
+metadata:
+    name: recording-annotator-pullsecret
+type: kubernetes.io/dockerconfigjson
+data:
+    .dockerconfigjson: ENC[AES256_GCM,data:T08I3NKF19V2jL02ntgyUKx57yzW54/t6wf7SUjeqPMgCFt+MhRPsIId1lS6NaIXnGY+BoDh1V3fh2OhAJ0sfrHdcbvkxYt/NBR6o89po29V/09NN9AWhpLPks4UMC6VrfB7EGPssmRjt2HhLD3417yW5esqWK8i9XJDQcIQRYC3U/2vKi0lB75D6GFV0baOmjOjXTz2VOidvtqPN4YFBL3H3MjOSl4qdbge9qTu+9Gn3Fhnl29ANHZhhsr8BZlZvAgTGS9wcEsvXHwaPo1Vc8gdjSS8wggzaV2rTN5DsM/EhsTBGHBswGftzP5w2oMOaUzwoSOvxsI=,iv:9XD3x5PvSIgZYEbPSAqEdBRffR5Nn2XUHQ7BJSA43rY=,tag:yV27TyTsoR8RtIIHP+Dc7w==,type:str]
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBOblJ5Z2pSTjFQWW55T2NI
+            T3NWbjJzOTZzZ1cwbC9FZE1IQndPeitMWUZ3CklZY2xMWWNNNSs5ekJ0TkVXY0Nr
+            b25mcmliNWtOeVZJeUFBb2dzRWpwdGcKLS0tIDFtamRFQmlndzRtbDFaeSt0OE1D
+            NHJqNWRJbnVpMURFam9uMTdVM1MxbE0KWrhr5Wqupwk6TLqgqonQrAbMtnkjpYwq
+            unrrEACDWF1bHNRx4aiIQIAhVXQHlSpdHxB9Npi+5rASAounWSveXg==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1gekuxnpd95l5j8gsvmpsn2mewnevd0c5y5v66p4trzcqhmpn0svqkmnyy7
+    encrypted_regex: ^(data|stringData)$
+    lastmodified: "2026-08-01T15:26:23Z"
+    mac: ENC[AES256_GCM,data:sP0F4tepEwlkBGzOmJmt1IC72vXgPKUDfgoi1Bjq3/JfcL5Xy0YxAWO8SZvXbdE5Z0BWAz7gLHXCo8gnKQaSSTQRlikH6LyzF1q9dHIBmPGUxao3X0vGB4b79wRG3mYDT4CAZIPCUV2+ZLasyZeaaCDLq888m/WkYRAT+7z+dbE=,iv:ta7PQeOcL4T9YtNXwEvr//0iY9dPzIlaoudTBujddQA=,tag:8rj1Nssk41WToqkUBjPt0g==,type:str]
+    mac_only_encrypted: true
+    version: 3.13.3

--- a/kubernetes/apps/default/recording-annotator/app/recording-annotator-pullsecret.sops.yaml
+++ b/kubernetes/apps/default/recording-annotator/app/recording-annotator-pullsecret.sops.yaml
@@ -1,26 +1,27 @@
+---
 # dockerconfigjson for a ghcr.io PAT (classic, read:packages only) scoped to
 # jasonkoopmans/recordingannotator — the package is private, so both the app
 # and restore-drill controllers need this to pull ghcr.io/jasonkoopmans/recordingannotator.
 apiVersion: v1
 kind: Secret
 metadata:
-    name: recording-annotator-pullsecret
+  name: recording-annotator-pullsecret
 type: kubernetes.io/dockerconfigjson
 data:
-    .dockerconfigjson: ENC[AES256_GCM,data:T08I3NKF19V2jL02ntgyUKx57yzW54/t6wf7SUjeqPMgCFt+MhRPsIId1lS6NaIXnGY+BoDh1V3fh2OhAJ0sfrHdcbvkxYt/NBR6o89po29V/09NN9AWhpLPks4UMC6VrfB7EGPssmRjt2HhLD3417yW5esqWK8i9XJDQcIQRYC3U/2vKi0lB75D6GFV0baOmjOjXTz2VOidvtqPN4YFBL3H3MjOSl4qdbge9qTu+9Gn3Fhnl29ANHZhhsr8BZlZvAgTGS9wcEsvXHwaPo1Vc8gdjSS8wggzaV2rTN5DsM/EhsTBGHBswGftzP5w2oMOaUzwoSOvxsI=,iv:9XD3x5PvSIgZYEbPSAqEdBRffR5Nn2XUHQ7BJSA43rY=,tag:yV27TyTsoR8RtIIHP+Dc7w==,type:str]
+  .dockerconfigjson: ENC[AES256_GCM,data:T08I3NKF19V2jL02ntgyUKx57yzW54/t6wf7SUjeqPMgCFt+MhRPsIId1lS6NaIXnGY+BoDh1V3fh2OhAJ0sfrHdcbvkxYt/NBR6o89po29V/09NN9AWhpLPks4UMC6VrfB7EGPssmRjt2HhLD3417yW5esqWK8i9XJDQcIQRYC3U/2vKi0lB75D6GFV0baOmjOjXTz2VOidvtqPN4YFBL3H3MjOSl4qdbge9qTu+9Gn3Fhnl29ANHZhhsr8BZlZvAgTGS9wcEsvXHwaPo1Vc8gdjSS8wggzaV2rTN5DsM/EhsTBGHBswGftzP5w2oMOaUzwoSOvxsI=,iv:9XD3x5PvSIgZYEbPSAqEdBRffR5Nn2XUHQ7BJSA43rY=,tag:yV27TyTsoR8RtIIHP+Dc7w==,type:str]
 sops:
-    age:
-        - enc: |
-            -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBOblJ5Z2pSTjFQWW55T2NI
-            T3NWbjJzOTZzZ1cwbC9FZE1IQndPeitMWUZ3CklZY2xMWWNNNSs5ekJ0TkVXY0Nr
-            b25mcmliNWtOeVZJeUFBb2dzRWpwdGcKLS0tIDFtamRFQmlndzRtbDFaeSt0OE1D
-            NHJqNWRJbnVpMURFam9uMTdVM1MxbE0KWrhr5Wqupwk6TLqgqonQrAbMtnkjpYwq
-            unrrEACDWF1bHNRx4aiIQIAhVXQHlSpdHxB9Npi+5rASAounWSveXg==
-            -----END AGE ENCRYPTED FILE-----
-          recipient: age1gekuxnpd95l5j8gsvmpsn2mewnevd0c5y5v66p4trzcqhmpn0svqkmnyy7
-    encrypted_regex: ^(data|stringData)$
-    lastmodified: "2026-08-01T15:26:23Z"
-    mac: ENC[AES256_GCM,data:sP0F4tepEwlkBGzOmJmt1IC72vXgPKUDfgoi1Bjq3/JfcL5Xy0YxAWO8SZvXbdE5Z0BWAz7gLHXCo8gnKQaSSTQRlikH6LyzF1q9dHIBmPGUxao3X0vGB4b79wRG3mYDT4CAZIPCUV2+ZLasyZeaaCDLq888m/WkYRAT+7z+dbE=,iv:ta7PQeOcL4T9YtNXwEvr//0iY9dPzIlaoudTBujddQA=,tag:8rj1Nssk41WToqkUBjPt0g==,type:str]
-    mac_only_encrypted: true
-    version: 3.13.3
+  age:
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBOblJ5Z2pSTjFQWW55T2NI
+        T3NWbjJzOTZzZ1cwbC9FZE1IQndPeitMWUZ3CklZY2xMWWNNNSs5ekJ0TkVXY0Nr
+        b25mcmliNWtOeVZJeUFBb2dzRWpwdGcKLS0tIDFtamRFQmlndzRtbDFaeSt0OE1D
+        NHJqNWRJbnVpMURFam9uMTdVM1MxbE0KWrhr5Wqupwk6TLqgqonQrAbMtnkjpYwq
+        unrrEACDWF1bHNRx4aiIQIAhVXQHlSpdHxB9Npi+5rASAounWSveXg==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1gekuxnpd95l5j8gsvmpsn2mewnevd0c5y5v66p4trzcqhmpn0svqkmnyy7
+  encrypted_regex: ^(data|stringData)$
+  lastmodified: "2026-08-01T15:26:23Z"
+  mac: ENC[AES256_GCM,data:sP0F4tepEwlkBGzOmJmt1IC72vXgPKUDfgoi1Bjq3/JfcL5Xy0YxAWO8SZvXbdE5Z0BWAz7gLHXCo8gnKQaSSTQRlikH6LyzF1q9dHIBmPGUxao3X0vGB4b79wRG3mYDT4CAZIPCUV2+ZLasyZeaaCDLq888m/WkYRAT+7z+dbE=,iv:ta7PQeOcL4T9YtNXwEvr//0iY9dPzIlaoudTBujddQA=,tag:8rj1Nssk41WToqkUBjPt0g==,type:str]
+  mac_only_encrypted: true
+  version: 3.13.3


### PR DESCRIPTION
## Summary
- Pod was stuck in ImagePullBackOff after the initial recording-annotator deploy (claude/ra-app), for two independent reasons:
  - **Tag mismatch**: HelmRelease requested `ghcr.io/jasonkoopmans/recordingannotator:v0.1.0`, but the package only ever published `0.1.0` (no `v` prefix) — confirmed via `gh api users/jasonkoopmans/packages/container/recordingannotator/versions`.
  - **Missing pull secret**: the ghcr package is private; no `imagePullSecrets` were configured anywhere in the HelmRelease.
- Adds `recording-annotator-pullsecret.sops.yaml` (SOPS-encrypted dockerconfigjson, ghcr PAT scoped to `read:packages` only) and wires `imagePullSecrets` into the `app` and `restore-drill` controllers — the two that pull the private image. `index-backup`/`reconciliation` untouched since they only use public `curlimages/curl`.
- Fixes the tag string to `"0.1.0"` (quoted per repo style for numeric-looking strings) in both places it appears.

## Test plan
- [x] Verified via `gh api` that the ghcr package only has unprefixed `0.1.0`/sha tags, no `v0.1.0`.
- [x] `task apply path=default/recording-annotator` from this branch — pod pulled successfully and came up healthy.
- [x] Confirmed `recording-annotator-pullsecret.sops.yaml` is SOPS-encrypted (`ENC[...]` ciphertext, not plaintext) before commit.
- [ ] Merge `claude/ra-app` (base of this PR) first, then this on top, so Flux picks it up for real.

🤖 Generated with [Claude Code](https://claude.com/claude-code)