### PR TITLE
fix(recording-annotator): pull private ghcr image, fix tag mismatch, stop upgrade flap

### DIFF
--- a/kubernetes/apps/default/recording-annotator/app/helmrelease.yaml
+++ b/kubernetes/apps/default/recording-annotator/app/helmrelease.yaml
@@ -9,6 +9,13 @@ spec:
     kind: OCIRepository
     name: recording-annotator
   interval: 1h
+  # Default 5m wait is too tight for this app: the app controller uses strategy: Recreate (RWO PVC), so an
+  # upgrade first fully terminates the old pod, then cold-pulls ghcr.io/jasonkoopmans/recordingannotator on
+  # whatever node it lands on. A cold pull + start that runs past 5m gets marked UpgradeFailed and auto-rolled
+  # back to the last "successful" release even if the pod would have come up seconds later — which is exactly
+  # what caused this app to flap back to a broken pre-fix release repeatedly. 15m matches other image-heavy
+  # apps in this cluster (hermes-ai-agent, freecad, openreel, obsidian).
+  timeout: 15m
   values:
     fullnameOverride: *app
     controllers:
@@ -21,7 +28,7 @@ spec:
           app:
             image:
               repository: ghcr.io/jasonkoopmans/recordingannotator
-              tag: v0.1.0
+              tag: "0.1.0"
             env:
               Storage__Provider: Minio
               Storage__Endpoint: recording-annotator-minio.storage.svc.cluster.local:9000
@@ -110,6 +117,8 @@ spec:
                 # into a node's ephemeral storage. Sanity-check it against actual node disk before raising.
                 ephemeral-storage: 9Gi
         pod:
+          imagePullSecrets:
+            - name: recording-annotator-pullsecret
           securityContext:
             runAsNonRoot: true
             runAsUser: 1654   # the image's $APP_UID
@@ -205,6 +214,8 @@ spec:
           successfulJobsHistory: 3
           failedJobsHistory: 3
         pod:
+          imagePullSecrets:
+            - name: recording-annotator-pullsecret
           securityContext:
             runAsNonRoot: true
             runAsUser: 1654
@@ -217,7 +228,7 @@ spec:
             # touches the live PVC — only a temp download into its own emptyDir below.
             image:
               repository: ghcr.io/jasonkoopmans/recordingannotator
-              tag: v0.1.0
+              tag: "0.1.0"
             args: ["restore-verify"]
             env:
               Backup__Provider: S3

--- a/kubernetes/apps/default/recording-annotator/app/kustomization.yaml
+++ b/kubernetes/apps/default/recording-annotator/app/kustomization.yaml
@@ -7,3 +7,4 @@ resources:
   - ./pvc.yaml
   - ./recording-annotator-secret.sops.yaml
   - ./recording-annotator-restore-secret.sops.yaml
+  - ./recording-annotator-pullsecret.sops.yaml

--- a/kubernetes/apps/default/recording-annotator/app/recording-annotator-pullsecret.sops.yaml
+++ b/kubernetes/apps/default/recording-annotator/app/recording-annotator-pullsecret.sops.yaml
@@ -1,0 +1,27 @@
+---
+# dockerconfigjson for a ghcr.io PAT (classic, read:packages only) scoped to
+# jasonkoopmans/recordingannotator — the package is private, so both the app
+# and restore-drill controllers need this to pull ghcr.io/jasonkoopmans/recordingannotator.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: recording-annotator-pullsecret
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: ENC[AES256_GCM,data:T08I3NKF19V2jL02ntgyUKx57yzW54/t6wf7SUjeqPMgCFt+MhRPsIId1lS6NaIXnGY+BoDh1V3fh2OhAJ0sfrHdcbvkxYt/NBR6o89po29V/09NN9AWhpLPks4UMC6VrfB7EGPssmRjt2HhLD3417yW5esqWK8i9XJDQcIQRYC3U/2vKi0lB75D6GFV0baOmjOjXTz2VOidvtqPN4YFBL3H3MjOSl4qdbge9qTu+9Gn3Fhnl29ANHZhhsr8BZlZvAgTGS9wcEsvXHwaPo1Vc8gdjSS8wggzaV2rTN5DsM/EhsTBGHBswGftzP5w2oMOaUzwoSOvxsI=,iv:9XD3x5PvSIgZYEbPSAqEdBRffR5Nn2XUHQ7BJSA43rY=,tag:yV27TyTsoR8RtIIHP+Dc7w==,type:str]
+sops:
+  age:
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBOblJ5Z2pSTjFQWW55T2NI
+        T3NWbjJzOTZzZ1cwbC9FZE1IQndPeitMWUZ3CklZY2xMWWNNNSs5ekJ0TkVXY0Nr
+        b25mcmliNWtOeVZJeUFBb2dzRWpwdGcKLS0tIDFtamRFQmlndzRtbDFaeSt0OE1D
+        NHJqNWRJbnVpMURFam9uMTdVM1MxbE0KWrhr5Wqupwk6TLqgqonQrAbMtnkjpYwq
+        unrrEACDWF1bHNRx4aiIQIAhVXQHlSpdHxB9Npi+5rASAounWSveXg==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1gekuxnpd95l5j8gsvmpsn2mewnevd0c5y5v66p4trzcqhmpn0svqkmnyy7
+  encrypted_regex: ^(data|stringData)$
+  lastmodified: "2026-08-01T15:26:23Z"
+  mac: ENC[AES256_GCM,data:sP0F4tepEwlkBGzOmJmt1IC72vXgPKUDfgoi1Bjq3/JfcL5Xy0YxAWO8SZvXbdE5Z0BWAz7gLHXCo8gnKQaSSTQRlikH6LyzF1q9dHIBmPGUxao3X0vGB4b79wRG3mYDT4CAZIPCUV2+ZLasyZeaaCDLq888m/WkYRAT+7z+dbE=,iv:ta7PQeOcL4T9YtNXwEvr//0iY9dPzIlaoudTBujddQA=,tag:8rj1Nssk41WToqkUBjPt0g==,type:str]
+  mac_only_encrypted: true
+  version: 3.13.3


### PR DESCRIPTION
## Summary
`#378` merged this fix into `claude/ra-app` instead of `main` — `claude/ra-app` had already been merged via `#376`, so the fix never made it to `main`. This PR carries the one stranded commit (`0792cb8`) forward.

- Private ghcr image needed `imagePullSecrets`; tag was requested as `v0.1.0` but the package only publishes unprefixed `0.1.0`.
- HelmRelease had no `timeout` (defaults to 5m); combined with `strategy: Recreate` + a cold pull of a private image, upgrades were timing out and getting auto-rolled-back to the broken pre-fix release — which is what caused the app (and its hourly index-backup CronJob) to flap. Raised to `15m`, matching other image-heavy apps in this cluster.

## Test plan
- [x] Verified live in-cluster: pod running `ghcr.io/jasonkoopmans/recordingannotator:0.1.0` with the pull secret attached, passing `/readyz`.
- [x] Confirmed via `gh pr list`/`gh pr view` that `claude/ra-app` is otherwise identical to `main` plus this one commit — no duplicate or conflicting changes.
- [ ] Watch the next hourly `recording-annotator-index-backup` CronJob run clean once this is live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)