### PR TITLE
fix(recording-annotator): use GET for backup/reconcile CronJob triggers

### DIFF
--- a/kubernetes/apps/default/recording-annotator/app/helmrelease.yaml
+++ b/kubernetes/apps/default/recording-annotator/app/helmrelease.yaml
@@ -151,7 +151,7 @@ spec:
               - --max-time
               - "240"
               - -X
-              - POST
+              - GET
               - http://recording-annotator:8080/internal/backup/index
             securityContext:
               allowPrivilegeEscalation: false
@@ -190,7 +190,7 @@ spec:
               - --max-time
               - "540"
               - -X
-              - POST
+              - GET
               - http://recording-annotator:8080/internal/reconcile
             securityContext:
               allowPrivilegeEscalation: false


### PR DESCRIPTION
## Summary
Every hourly `recording-annotator-index-backup` Job (and the daily `reconciliation` one) was failing — but not because the app was down. Confirmed live against the running pod:

```
$ curl -X POST http://recording-annotator:8080/internal/backup/index
HTTP/1.1 405 Method Not Allowed
Allow: GET, HEAD
```

The app only exposes `GET`/`HEAD` on `/internal/backup/index` and `/internal/reconcile`; the CronJob trigger containers were calling both with `curl -X POST`. Switched both to `-X GET` and confirmed against the live pod: `200 OK`.

The 9 failed pods currently sitting in the namespace (3 Jobs × `backoffLimit: 2` retries = 3 pods/Job, capped at `failedJobsHistoryLimit: 3`) are expected retention, not a leak — they'll roll off as new successful Jobs replace them.

## Test plan
- [x] `curl -X GET .../internal/backup/index` against the live pod → `200 OK`.
- [ ] Watch next hourly index-backup Job succeed once this merges and reconciles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)