### PR TITLE
fix(recording-annotator): bump image to 0.1.1, fixes mixed-content playback

### DIFF
--- a/kubernetes/apps/default/recording-annotator/app/helmrelease.yaml
+++ b/kubernetes/apps/default/recording-annotator/app/helmrelease.yaml
@@ -28,7 +28,7 @@ spec:
           app:
             image:
               repository: ghcr.io/jasonkoopmans/recordingannotator
-              tag: "0.1.0"
+              tag: "0.1.1"
             env:
               Storage__Provider: Minio
               Storage__Endpoint: recording-annotator-minio.storage.svc.cluster.local:9000
@@ -228,7 +228,7 @@ spec:
             # touches the live PVC — only a temp download into its own emptyDir below.
             image:
               repository: ghcr.io/jasonkoopmans/recordingannotator
-              tag: "0.1.0"
+              tag: "0.1.1"
             args: ["restore-verify"]
             env:
               Backup__Provider: S3


### PR DESCRIPTION
## Summary
- Playback was broken with a mixed-content error: browser blocked `http://recording-annotator-minio.storage.svc.cluster.local:9000/...` on the https page.
- Cluster-side config (`Storage__PublicEndpoint`/`Storage__PublicUseSsl`, dedicated MinIO HTTPRoute) was already correct — the deployed app image (`0.1.0`) predates the presign code that consumes those settings.
- Cherry-picked the fix (PR #12: JasonKoopmans/RecordingAnnotator#12) onto `v0.1.0` as `v0.1.1` — CI built and published `ghcr.io/jasonkoopmans/recordingannotator:0.1.1`.
- Bumps both image refs in `helmrelease.yaml` (app controller + restore-drill cronjob) to `0.1.1`.

## Test plan
- [x] Cherry-pick build + full test suite green in RecordingAnnotator (`dotnet build`/`dotnet test`, 0 failures)
- [x] CI published `ghcr.io/jasonkoopmans/recordingannotator:0.1.1`
- [x] `helmrelease.yaml` YAML-syntax checked, diff reviewed (2-line change, no other drift)
- [ ] Flux Local CI diff on this PR
- [ ] After merge: confirm Flux reconciles, pod restarts on `0.1.1`, playback URL resolves to `recording-annotator-media.<domain>` over https

🤖 Generated with [Claude Code](https://claude.com/claude-code)