### PR TITLE
feat(recording-annotator-minio): configure S3 replication declaratively

### DIFF
--- a/kubernetes/apps/storage/recording-annotator-minio/app/kustomization.yaml
+++ b/kubernetes/apps/storage/recording-annotator-minio/app/kustomization.yaml
@@ -10,3 +10,5 @@ resources:
   - ./minio-root-credentials.sops.yaml
   - ./recording-annotator-minio-user-credentials.sops.yaml
   - ./recording-annotator-user-bootstrap-job.yaml
+  - ./recording-annotator-s3-replication-credentials.sops.yaml
+  - ./recording-annotator-replication-bootstrap-job.yaml

--- a/kubernetes/apps/storage/recording-annotator-minio/app/recording-annotator-replication-bootstrap-job.yaml
+++ b/kubernetes/apps/storage/recording-annotator-minio/app/recording-annotator-replication-bootstrap-job.yaml
@@ -1,0 +1,128 @@
+---
+# Minio -> AWS S3 replication bootstrap Job — runs once after Minio is healthy. This is the GitOps equivalent of
+# deploy/backup/configure-minio-replication.sh in the RecordingAnnotator repo (docs/backup-recovery.md §3, §9
+# phase 1), reimplemented here so a fresh cluster configures itself instead of depending on somebody remembering
+# to run a script by hand. Same reasoning as the sibling bootstrap Jobs in storage/minio.
+#
+# This is the ONLY offsite protection for the recordings bucket — its PVC is deliberately longhorn-2-no-backup,
+# because replication to the Object-Locked S3 bucket IS the backup. Nothing else copies those blobs anywhere.
+#
+# Deliberately NOT a port of the upstream script:
+#   - The script's two-step flow calls `mc admin bucket remote add`, which is DEPRECATED in this mc release and
+#     exits non-zero ("Please use 'mc replicate add' instead"). It would fail outright.
+#   - That flow embeds the AWS secret key in a URL, which is why the script carries a bash urlencode() helper for
+#     the '/', '+' and '=' that AWS keys contain. Passing an mc alias to --remote-bucket instead keeps the
+#     credentials in argv where no encoding is needed — and, just as importantly, avoids the ${...} parameter
+#     expansion that helper needs, which Flux's postBuild envsubst would rewrite before the shell ever saw it.
+#     Bare $VAR survives envsubst untouched; ${VAR} does not.
+#
+# --replicate is passed EXPLICITLY and must stay that way. mc defaults it to
+# "delete-marker,delete,existing-objects,metadata-sync" — replicating deletes. Per docs/backup-recovery.md §3 the
+# whole threat model is that accidental deletion and ransomware act out-of-band on the primary (mc rm, the
+# console, malware) and lay down delete markers; replicating those would let a poisoned primary erase the
+# replica. Leaving them off means an out-of-band delete on the primary never affects the replica's current view,
+# and every prior version stays behind Object Lock. "existing-objects" backfills blobs written before the rule
+# existed, so the first sync is complete rather than only-new-writes.
+#
+# Re-running: the Job is one-shot, and prune:false + ssa:IfNotPresent keep the completed object around, so it
+# will NOT re-run if the replication config is later lost (e.g. the Minio PVC is rebuilt while the cluster
+# stands). RecordingAnnotatorMediaReplicationNotConfigured is the alert that catches exactly that; to re-run,
+# delete the completed Job and let Flux recreate it:
+#   kubectl -n storage delete job recording-annotator-replication-bootstrap
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: recording-annotator-replication-bootstrap
+  namespace: storage
+  annotations:
+    # prune: false keeps the completed Job as an audit record if it is ever removed from kustomization.yaml.
+    kustomize.toolkit.fluxcd.io/prune: "false"
+    # ssa: IfNotPresent — a Job's spec.template is immutable, so without this every reconcile dry-run-applies
+    # against the completed Job and fails with "field is immutable", pinning this Kustomization Ready=False
+    # after the first successful run. Same fix as the sibling bootstrap Jobs (2026-07-19, PRs #324/#325).
+    kustomize.toolkit.fluxcd.io/ssa: IfNotPresent
+spec:
+  backoffLimit: 3
+  activeDeadlineSeconds: 3600
+  template:
+    spec:
+      restartPolicy: OnFailure
+      containers:
+        - name: mc
+          image: quay.io/minio/mc:RELEASE.2025-08-13T08-35-41Z
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -e
+
+              RETRIES=0; MAX_RETRIES=180
+              until mc alias set local "$MINIO_ENDPOINT" "$MINIO_ROOT_USER" "$MINIO_ROOT_PASSWORD"; do
+                RETRIES=$((RETRIES + 1))
+                if [ "$RETRIES" -ge "$MAX_RETRIES" ]; then
+                  echo "ERROR: minio did not become ready after $((MAX_RETRIES * 5))s, giving up"
+                  exit 1
+                fi
+                echo "waiting for minio... (attempt $RETRIES/$MAX_RETRIES)"; sleep 5
+              done
+
+              # Credentials go in argv, so no URL-encoding of the AWS secret key is needed.
+              mc alias set s3backup "$AWS_S3_ENDPOINT" \
+                "$BACKUP_ACCESS_KEY" "$BACKUP_SECRET_KEY" --api S3v4
+
+              # Replication requires versioning on the source. Idempotent; the S3 target already has it, since
+              # enabling Object Lock at bucket creation implies versioning.
+              mc version enable local/"$SOURCE_BUCKET"
+
+              # Idempotent: match on the destination bucket name, which appears in any rule already pointing at
+              # it, so a re-run never stacks a duplicate rule.
+              if mc replicate ls local/"$SOURCE_BUCKET" --json 2>/dev/null | grep -q "$BACKUP_BUCKET"; then
+                echo "replication rule for $BACKUP_BUCKET already present, skipping"
+              else
+                mc replicate add local/"$SOURCE_BUCKET" \
+                  --remote-bucket s3backup/"$BACKUP_BUCKET" \
+                  --replicate "existing-objects" \
+                  --region "$AWS_REGION" \
+                  --priority 1
+                echo "replication rule added (delete markers and version deletions NOT replicated)"
+              fi
+
+              mc replicate ls local/"$SOURCE_BUCKET"
+              echo "recording-annotator minio replication ready"
+          env:
+            - name: MINIO_ENDPOINT
+              value: http://recording-annotator-minio.storage.svc.cluster.local:9000
+            - name: SOURCE_BUCKET
+              value: recordings
+            - name: BACKUP_BUCKET
+              value: hiro-recording-annotator-media-backup
+            - name: AWS_REGION
+              value: us-east-1
+            - name: AWS_S3_ENDPOINT
+              value: https://s3.us-east-1.amazonaws.com
+            - name: MINIO_ROOT_USER
+              valueFrom:
+                secretKeyRef:
+                  name: recording-annotator-minio-root-credentials
+                  key: rootUser
+            - name: MINIO_ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: recording-annotator-minio-root-credentials
+                  key: rootPassword
+            - name: BACKUP_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: recording-annotator-s3-replication-credentials
+                  key: accessKey
+            - name: BACKUP_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: recording-annotator-s3-replication-credentials
+                  key: secretKey
+          resources:
+            requests:
+              cpu: 10m
+              memory: 64Mi
+            limits:
+              memory: 256Mi

--- a/kubernetes/apps/storage/recording-annotator-minio/app/recording-annotator-s3-replication-credentials.sops.yaml
+++ b/kubernetes/apps/storage/recording-annotator-minio/app/recording-annotator-s3-replication-credentials.sops.yaml
@@ -1,0 +1,23 @@
+# PLACEHOLDER — not real SOPS ciphertext. MUST be filled in and encrypted BEFORE this is merged, or Flux will
+# apply a Secret containing these literal strings and the replication bootstrap Job will fail to authenticate
+# against AWS.
+#
+# These are the credentials for the FIRST of the three IAM principals created by
+# deploy/backup/provision-iam-principals.sh in the RecordingAnnotator repo — the media-replication user, scoped
+# to the hiro-recording-annotator-media-backup bucket. Not the index-backup writer, and not the index-backup
+# reader; those two are separate principals and already live in the app's own secrets over in
+# kubernetes/apps/default/recording-annotator/.
+#
+# Consumed only by recording-annotator-replication-bootstrap-job.yaml. Minio stores the credentials in its own
+# config once the replication target is registered, so nothing else in the cluster needs them.
+#
+# Fill in the plaintext values, then:
+#   sops -e -i kubernetes/apps/storage/recording-annotator-minio/app/recording-annotator-s3-replication-credentials.sops.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: recording-annotator-s3-replication-credentials
+  namespace: storage
+stringData:
+  accessKey: ENC[AES256_GCM,data:PLACEHOLDER,iv:PLACEHOLDER,tag:PLACEHOLDER,type:str]
+  secretKey: ENC[AES256_GCM,data:PLACEHOLDER,iv:PLACEHOLDER,tag:PLACEHOLDER,type:str]

--- a/kubernetes/apps/storage/recording-annotator-minio/app/recording-annotator-s3-replication-credentials.sops.yaml
+++ b/kubernetes/apps/storage/recording-annotator-minio/app/recording-annotator-s3-replication-credentials.sops.yaml
@@ -1,7 +1,3 @@
-# PLACEHOLDER — not real SOPS ciphertext. MUST be filled in and encrypted BEFORE this is merged, or Flux will
-# apply a Secret containing these literal strings and the replication bootstrap Job will fail to authenticate
-# against AWS.
-#
 # These are the credentials for the FIRST of the three IAM principals created by
 # deploy/backup/provision-iam-principals.sh in the RecordingAnnotator repo — the media-replication user, scoped
 # to the hiro-recording-annotator-media-backup bucket. Not the index-backup writer, and not the index-backup
@@ -10,14 +6,27 @@
 #
 # Consumed only by recording-annotator-replication-bootstrap-job.yaml. Minio stores the credentials in its own
 # config once the replication target is registered, so nothing else in the cluster needs them.
-#
-# Fill in the plaintext values, then:
-#   sops -e -i kubernetes/apps/storage/recording-annotator-minio/app/recording-annotator-s3-replication-credentials.sops.yaml
 apiVersion: v1
 kind: Secret
 metadata:
   name: recording-annotator-s3-replication-credentials
   namespace: storage
 stringData:
-  accessKey: ENC[AES256_GCM,data:PLACEHOLDER,iv:PLACEHOLDER,tag:PLACEHOLDER,type:str]
-  secretKey: ENC[AES256_GCM,data:PLACEHOLDER,iv:PLACEHOLDER,tag:PLACEHOLDER,type:str]
+  accessKey: ENC[AES256_GCM,data:23ePOTRrIbC3OIm+J2T3o9YBopA=,iv:QIACl6t1zsu0I3xgMY9jDrBXK/wNusB/pOcdrcdNPF8=,tag:IWgA2SLfQVY3H4WRR0BTFA==,type:str]
+  secretKey: ENC[AES256_GCM,data:+9pLRAbMBTdw18li82JFaNX5RdhWUvQu0ZAv7RDzknHkg+pNeDATMg==,iv:wBgjju2J502SYNuKH9R+2/UTQ0gda96N3rEqlGkbTU4=,tag:8wTpdbjv0MOGkUK7dikmGw==,type:str]
+sops:
+  age:
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBYQVNBNW90SXo4S29iZGhW
+        MENIL0NLVTZGSVNLTEtnZlJ0S29DZnFRS1QwClc4Ynp4OC9PSXhyVlNFblIvY3d6
+        bmRRL1pxaUc5a2JtT1BFRklFbVk5Yk0KLS0tIHlhMTRJVmoxQ1JITVV4NFQ4ZHFh
+        N3dGY2U4RHQxSVlqL29zZ3hWWHk3UVUKICB/bXA+JN9Cb1S7mx2/t1xPnVEzLGlF
+        xnbn44wXLH46Odhp/XmGghzVhkH+rRWwJopPGDKdjERwR56uEMflYw==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1gekuxnpd95l5j8gsvmpsn2mewnevd0c5y5v66p4trzcqhmpn0svqkmnyy7
+  encrypted_regex: ^(data|stringData)$
+  lastmodified: "2026-08-08T20:18:31Z"
+  mac: ENC[AES256_GCM,data:H9Pe0+hCEl9PSHu/3lIHxBoYzDhFvoRcImfAGWVk97FcmTN5zoemLiPTHj/bBRyb6plC7CSEd5xN4g6X3YxSnNWcRJVdjrgq1POef2/OMCNe5ozCRQDe47nKRGXPKupHsjarCJm+qvpaO2lzP8A8ss6+6KPPmcOyIa3vT3HpzT4=,iv:wMjGb/afrCeRD9e4iT8bXp1bwcWxyJrRp2qiGmJf3IM=,tag:lo0uLbU1tGvRvmgtmZkyDw==,type:str]
+  mac_only_encrypted: true
+  version: 3.13.3


### PR DESCRIPTION
Replaces the "remember to run `configure-minio-replication.sh` by hand" step with a bootstrap Job, matching the sibling Jobs already in `storage/minio` (`bucket-lifecycle-bootstrap`, `bucket-quota-bootstrap`, `thanos-user-bootstrap`). A fresh cluster now configures its own offsite replication.

**It had never actually been run.** The recordings bucket's PVC is deliberately `longhorn-2-no-backup` *because* replication to the Object-Locked S3 bucket is the backup — so as a manual step, the backup existed only for as long as someone remembered to create it. `RecordingAnnotatorMediaReplicationNotConfigured` (PR #377) would have been firing correctly.

### Not a straight port of the upstream script

Both found by running the commands against the mc release we pin, not by reading:

- **`mc admin bucket remote add` is deprecated** in `RELEASE.2025-08-13T08-35-41Z` and exits non-zero — `mc: <ERROR> Deprecated command. Please use 'mc replicate add' instead.` The script's two-step flow would have failed on the first call.
- **The URL-encoding is avoidable.** That flow embeds the AWS secret key in a URL, which is why the script carries a bash `urlencode()` for the `/`, `+`, `=` that AWS keys contain. `--remote-bucket` accepts an **mc alias**, so credentials stay in argv where no encoding is needed. That also sidesteps a Flux trap: `urlencode()` needs `${s:i:1}` / `${#s}` parameter expansion, and Flux's `postBuild` envsubst rewrites `${...}` before the shell ever sees it. Bare `$VAR` survives — verified against the live `recording-annotator-user-bootstrap` Job's applied spec. The built output here contains no braced vars except the two intentional `${SECRET_DOMAIN}` hostnames.

### `--replicate` is explicit on purpose

mc defaults it to `delete-marker,delete,existing-objects,metadata-sync`. Replicating deletes would let a poisoned primary erase the replica — the exact inversion of the threat model in `docs/backup-recovery.md` §3, where accidental deletion and ransomware act out-of-band on the primary and lay down delete markers. Only `existing-objects` is passed, which also backfills blobs written before the rule existed.

### Deliberately not in `healthChecks`

The app's Kustomization `dependsOn` this one. Gating it on replication would turn bad or missing AWS credentials into an **app outage** rather than a backup gap. The alert covers the gap instead.

### Re-run semantics

One-shot Job with `prune: false` + `ssa: IfNotPresent`, so it will not re-run if replication is later lost (e.g. the Minio PVC is rebuilt while the cluster stands). A fresh cluster runs it; drift is caught by `RecordingAnnotatorMediaReplicationNotConfigured`, and the escape hatch is documented in the manifest:

```
kubectl -n storage delete job recording-annotator-replication-bootstrap
```

### ⚠️ Before merging

`recording-annotator-s3-replication-credentials.sops.yaml` is a **placeholder**. Fill in the media-replication IAM user's keys (the *first* principal from `provision-iam-principals.sh` — not either index-backup principal) and `sops -e -i` it, or Flux will apply a Secret containing the literal `ENC[...]` strings and the Job will fail to authenticate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)