### PR TITLE
fix(ci): reinstall Kubescape scoped to security-scan.yaml only

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -366,7 +366,7 @@ grep -r "kind: OCIRepository" kubernetes/apps/<group>/
 
 ## Development Environment
 
-- **mise** (`.mise.toml`) manages CLI tool versions (kubectl, flux, talosctl, sops, kustomize, kubeconform, etc.) and sets `KUBECONFIG`, `SOPS_AGE_KEY_FILE`, and `TALOSCONFIG` to repo-local paths. Also pins the security scanning toolchain used by the Security Scan / Image Vulnerability Scan workflows: `kube-linter`, `trivy`, `gitleaks`, `kubescape`, `conftest` (the last is available for future OPA/Rego policy checks but isn't wired into CI).
+- **mise** (`.mise.toml`) manages CLI tool versions (kubectl, flux, talosctl, sops, kustomize, kubeconform, etc.) and sets `KUBECONFIG`, `SOPS_AGE_KEY_FILE`, and `TALOSCONFIG` to repo-local paths. Also pins the security scanning toolchain used by the Security Scan / Image Vulnerability Scan workflows: `kube-linter`, `trivy`, `gitleaks`, `conftest` (the last is available for future OPA/Rego policy checks but isn't wired into CI). **Kubescape is the exception** — aqua's registry has no linux/arm64 build, which broke `mise install` in the arm64 devcontainer, so it's installed inline in `security-scan.yaml` (still via mise/aqua, just scoped to that CI job) instead of living in the shared `.mise.toml`.
 - A `.devcontainer/` config is provided for VS Code / Codespaces.
 - **Task** (`Taskfile.yaml` + `.taskfiles/`) provides common workflows:
   - `task reconcile` — force Flux to sync from Git

--- a/.github/workflows/security-scan.yaml
+++ b/.github/workflows/security-scan.yaml
@@ -48,6 +48,17 @@ jobs:
         with:
           cache: false
 
+      # Kubescape isn't in the shared .mise.toml — aqua's registry has no
+      # linux/arm64 build for it, which broke `mise install` in the arm64
+      # devcontainer. This runner is amd64-only, so install it here instead,
+      # scoped to this workflow. Still goes through mise/aqua (checksum +
+      # attestation verified) rather than a raw curl-to-shell script.
+      - name: Install Kubescape (CI-only)
+        run: |
+          # renovate: datasource=github-releases depName=kubescape/kubescape
+          KUBESCAPE_VERSION=4.0.11
+          mise use --global "aqua:kubescape/kubescape@${KUBESCAPE_VERSION}"
+
       # Runs before rendering so it only ever sees committed repo content —
       # once flux-local writes rendered.yaml into the working tree, `gitleaks
       # dir .` would scan that generated artifact too (checksum/* annotations


### PR DESCRIPTION
## Summary

- Kubescape was dropped from the shared `.mise.toml` on 2026-07-31 (arm64 devcontainer fix — aqua's registry has no linux/arm64 build for it). That silently broke the NSA framework scan in `security-scan.yaml`: the step still ran unconditionally, `continue-on-error` masked the failure, and the job stayed green with `kubescape: command not found` buried in the logs.
- Adds a scoped `Install Kubescape (CI-only)` step to `security-scan.yaml` that installs it via `mise use --global aqua:kubescape/kubescape@4.0.11` — still checksum/attestation-verified through mise/aqua, but confined to this amd64 CI job so the arm64 devcontainer fix stays intact. A `# renovate: datasource=github-releases depName=kubescape/kubescape` hint comment keeps future version bumps automatic, following the pattern already used elsewhere in this repo.
- Updates `.github/copilot-instructions.md` to document Kubescape as the one security-scan tool that lives outside `.mise.toml`, and why.

## Verification

Manually dispatched `security-scan.yaml` on this branch after pushing — Kubescape now runs and produces a real NSA compliance score again (68.51%, 20 controls: 5 passed / 15 failed), matching its behavior before the regression. All other steps (gitleaks, KubeLinter, render) remain green.

## Test plan

- [x] `security-scan.yaml` manually dispatched on this branch — Kubescape install + scan both succeed
- [x] Confirmed the regression's root cause (`.mise.toml` diff removing `aqua:kubescape/kubescape` on 2026-07-31) and that this fix doesn't touch `.mise.toml` or the devcontainer
- [ ] Weekly scheduled run on `main` after merge (next Monday) — real end-to-end confirmation outside manual dispatch


---
_Generated by [Claude Code](https://claude.ai/code/session_01EogQtnH1sNcfXiKUUD1E5U)_