### PR TITLE
feat(ci): add Kubescape exceptions file with review-date expiry

### DIFF
--- a/.github/workflows/security-scan.yaml
+++ b/.github/workflows/security-scan.yaml
@@ -96,7 +96,23 @@ jobs:
         # None of those kinds carry a pod spec, so no NSA control applies to them
         # anyway; raising the log threshold drops the noise without touching the
         # actual scan results.
-        run: kubescape scan framework nsa rendered.yaml --logger error 2>&1 | tee kubescape-results.txt
+        # --exceptions: triaged findings (false positives, deliberate repo
+        # conventions, deferred work) in security/kubescape-exceptions.json —
+        # see docs/kubescape-exceptions.md.
+        run: kubescape scan framework nsa rendered.yaml --exceptions security/kubescape-exceptions.json --logger error 2>&1 | tee kubescape-results.txt
+
+      - name: Check exception expiry
+        if: always()
+        run: |
+          jq -r --arg today "$(date +%F)" \
+            '.[] | select(.reviewBy < $today) | "\(.name) (reviewBy \(.reviewBy))"' \
+            security/kubescape-exceptions.json > expired-exceptions.txt
+          if [ -s expired-exceptions.txt ]; then
+            echo "## :warning: Expired Kubescape exceptions — needs re-review" >> "$GITHUB_STEP_SUMMARY"
+            echo '```' >> "$GITHUB_STEP_SUMMARY"
+            cat expired-exceptions.txt >> "$GITHUB_STEP_SUMMARY"
+            echo '```' >> "$GITHUB_STEP_SUMMARY"
+          fi
 
       - name: Publish summary
         if: always()

--- a/.github/workflows/security-scan.yaml
+++ b/.github/workflows/security-scan.yaml
@@ -103,6 +103,7 @@ jobs:
 
       - name: Check exception expiry
         if: always()
+        continue-on-error: true
         run: |
           jq -r --arg today "$(date +%F)" \
             '.[] | select(.reviewBy < $today) | "\(.name) (reviewBy \(.reviewBy))"' \

--- a/docs/kubescape-exceptions.md
+++ b/docs/kubescape-exceptions.md
@@ -1,0 +1,47 @@
+# Kubescape exceptions
+
+`security/kubescape-exceptions.json` suppresses specific NSA-framework findings
+from the Security Scan workflow (`.github/workflows/security-scan.yaml`). It's
+loaded via `kubescape scan --exceptions security/kubescape-exceptions.json`.
+
+Security Scan is report-only — nothing here blocks a PR. The point of the
+exceptions file is to keep the compliance score honest: without it, the same
+triaged-and-rejected findings resurface every scan and drown out real drift.
+
+## Format
+
+Standard kubescape exception schema (array of objects, matched by resource
+`kind`/`name`/`namespace`, excluded from one or more `controlID`s). See
+[kubescape/examples/exceptions](https://github.com/kubescape/kubescape/tree/master/examples/exceptions)
+for the full spec. Two conventions on top of the standard schema:
+
+- **`controlID`, not `controlName`** — control names get reworded across
+  kubescape releases; the ID is stable.
+- **`reviewBy` (custom field, `YYYY-MM-DD`)** — kubescape has no native
+  expiration mechanism (checked 2026-08-06 against the upstream docs); this
+  field is our own, ignored by kubescape itself, and enforced by the
+  workflow's "Check exception expiry" step, which posts to the run's step
+  summary when a `reviewBy` date has passed. Non-blocking, matching this
+  workflow's report-only convention — an expired exception degrades to a
+  loud warning, not a build failure.
+
+## Current exceptions
+
+| Name | Control | Why |
+|---|---|---|
+| `C-0270-cpu-limits-repo-convention` | C-0270 | Repo-wide: CPU is compressible, not a security boundary; see PR #401 |
+| `C-0012-credential-pattern-false-positives` | C-0012 | 7 resources, manually triaged — flag names/enum values, not secrets |
+| `C-0271-scratch-test-workloads` | C-0271 | `default/test`, multus test pod — committed scratch apps, not production |
+| `C-0271-cni-dataplane-daemons` | C-0271 | Cilium + multus — node-critical, needs vendor guidance before sizing |
+| `C-0271-longhorn-and-spegel` | C-0271 | Longhorn daemons + one-shot upgrade Jobs — too short-lived to measure |
+| `C-0271-monitoring-stack-sidecars` | C-0271 | kube-prometheus-stack/loki/alloy/k8s-gateway/mariadb-operator — deferred pending the same measured-peak treatment PR #401 gave thanos/homepage |
+
+## Adding an exception
+
+1. Confirm the finding is a false positive or a deliberate, documented
+   decision — not just an inconvenient true positive.
+2. Add an entry with `controlID`, matching `resources`, a `reviewBy` date
+   (roughly: 6 months for settled architectural decisions, ~90 days for
+   "deferred, will fix" items), and a `reason` explaining the judgment call.
+3. When a `reviewBy` date fires, re-triage: either extend it with a fresh
+   reason, or fix the underlying finding and delete the entry.

--- a/security/kubescape-exceptions.json
+++ b/security/kubescape-exceptions.json
@@ -1,0 +1,109 @@
+[
+  {
+    "name": "C-0270-cpu-limits-repo-convention",
+    "reviewBy": "2027-02-01",
+    "reason": "CPU is compressible; a limit only adds CFS throttling risk, not a security boundary. Nodes are CPU-asymmetric (2-3 cores) and run Longhorn/Envoy on the latency path. default/echo already omits CPU limits as the repo's deliberate convention. See PR #401 discussion.",
+    "policyType": "postureExceptionPolicy",
+    "actions": ["alertOnly"],
+    "resources": [
+      { "designatorType": "Attributes", "attributes": { "namespace": ".*" } }
+    ],
+    "posturePolicies": [
+      { "controlID": "C-0270" }
+    ]
+  },
+  {
+    "name": "C-0012-credential-pattern-false-positives",
+    "reviewBy": "2027-02-01",
+    "reason": "Manually triaged 2026-08-06: env/config keys matched by name, not value. FB_NOAUTH is a boolean feature flag, HTTP_AUTH_HEADER/WEBHOOK_SECRET_NAME are header/secret-object names not secret material, cilium-config keys are policy-engine toggles, MINIO_PROMETHEUS_AUTH_TYPE=public is a metrics-auth-mode enum. None of these values are credentials.",
+    "policyType": "postureExceptionPolicy",
+    "actions": ["alertOnly"],
+    "resources": [
+      { "designatorType": "Attributes", "attributes": { "kind": "Deployment", "name": "guacamole", "namespace": "default" } },
+      { "designatorType": "Attributes", "attributes": { "kind": "Deployment", "name": "qbittorrent", "namespace": "default" } },
+      { "designatorType": "Attributes", "attributes": { "kind": "Deployment", "name": "scanner-files", "namespace": "default" } },
+      { "designatorType": "Attributes", "attributes": { "kind": "Deployment", "name": "operator-webhook", "namespace": "knative-serving" } },
+      { "designatorType": "Attributes", "attributes": { "kind": "ConfigMap", "name": "cilium-config", "namespace": "kube-system" } },
+      { "designatorType": "Attributes", "attributes": { "kind": "Deployment", "name": "minio", "namespace": "storage" } },
+      { "designatorType": "Attributes", "attributes": { "kind": "Deployment", "name": "recording-annotator-minio", "namespace": "storage" } }
+    ],
+    "posturePolicies": [
+      { "controlID": "C-0012" }
+    ]
+  },
+  {
+    "name": "C-0271-scratch-test-workloads",
+    "reviewBy": "2026-11-01",
+    "reason": "Committed scratch/smoke-test workloads (AGENTS.md: default/test is explicitly not a pattern to extend or replicate). Not production, low priority.",
+    "policyType": "postureExceptionPolicy",
+    "actions": ["alertOnly"],
+    "resources": [
+      { "designatorType": "Attributes", "attributes": { "kind": "Deployment", "name": "test", "namespace": "default" } },
+      { "designatorType": "Attributes", "attributes": { "kind": "Pod", "name": "multus-test-pod", "namespace": "default" } }
+    ],
+    "posturePolicies": [
+      { "controlID": "C-0271" }
+    ]
+  },
+  {
+    "name": "C-0271-cni-dataplane-daemons",
+    "reviewBy": "2026-11-01",
+    "reason": "Deferred: Cilium CNI/dataplane and multus install DaemonSets. Upstream-chart-owned, node-critical hot path; sizing needs vendor guidance plus measured data before overriding, not yet done.",
+    "policyType": "postureExceptionPolicy",
+    "actions": ["alertOnly"],
+    "resources": [
+      { "designatorType": "Attributes", "attributes": { "kind": "DaemonSet", "name": "cilium", "namespace": "kube-system" } },
+      { "designatorType": "Attributes", "attributes": { "kind": "DaemonSet", "name": "cilium-envoy", "namespace": "kube-system" } },
+      { "designatorType": "Attributes", "attributes": { "kind": "Deployment", "name": "cilium-operator", "namespace": "kube-system" } },
+      { "designatorType": "Attributes", "attributes": { "kind": "DaemonSet", "name": "kube-multus-ds", "namespace": "network" } }
+    ],
+    "posturePolicies": [
+      { "controlID": "C-0271" }
+    ]
+  },
+  {
+    "name": "C-0271-longhorn-and-spegel",
+    "reviewBy": "2026-11-01",
+    "reason": "Deferred: Longhorn storage daemons/one-shot upgrade-uninstall Jobs and spegel image-mirror cleanup. Upstream-owned; the upgrade/uninstall Jobs run too briefly for cadvisor to ever sample, so limits here are judgment, not measurement -- needs a deliberate pass, not a default.",
+    "policyType": "postureExceptionPolicy",
+    "actions": ["alertOnly"],
+    "resources": [
+      { "designatorType": "Attributes", "attributes": { "kind": "DaemonSet", "name": "longhorn-manager", "namespace": "storage" } },
+      { "designatorType": "Attributes", "attributes": { "kind": "Deployment", "name": "longhorn-driver-deployer", "namespace": "storage" } },
+      { "designatorType": "Attributes", "attributes": { "kind": "Deployment", "name": "longhorn-ui", "namespace": "storage" } },
+      { "designatorType": "Attributes", "attributes": { "kind": "Job", "name": "longhorn-post-upgrade", "namespace": "storage" } },
+      { "designatorType": "Attributes", "attributes": { "kind": "Job", "name": "longhorn-pre-upgrade", "namespace": "storage" } },
+      { "designatorType": "Attributes", "attributes": { "kind": "Job", "name": "longhorn-uninstall", "namespace": "storage" } },
+      { "designatorType": "Attributes", "attributes": { "kind": "DaemonSet", "name": "spegel-cleanup", "namespace": "kube-system" } },
+      { "designatorType": "Attributes", "attributes": { "kind": "Pod", "name": "spegel-cleanup-wait", "namespace": "kube-system" } }
+    ],
+    "posturePolicies": [
+      { "controlID": "C-0271" }
+    ]
+  },
+  {
+    "name": "C-0271-monitoring-stack-sidecars",
+    "reviewBy": "2026-11-01",
+    "reason": "Deferred: kube-prometheus-stack/grafana/loki/alloy sidecars and operators, k8s-gateway, reloader, mariadb-operator. Upstream-chart-owned; needs the same measured-peak treatment as thanos/homepage (PR #401) before setting real limits.",
+    "policyType": "postureExceptionPolicy",
+    "actions": ["alertOnly"],
+    "resources": [
+      { "designatorType": "Attributes", "attributes": { "kind": "DaemonSet", "name": "alloy", "namespace": "monitoring" } },
+      { "designatorType": "Attributes", "attributes": { "kind": "Deployment", "name": "kube-prometheus-stack-grafana", "namespace": "monitoring" } },
+      { "designatorType": "Attributes", "attributes": { "kind": "Deployment", "name": "kube-prometheus-stack-operator", "namespace": "monitoring" } },
+      { "designatorType": "Attributes", "attributes": { "kind": "DaemonSet", "name": "loki-canary", "namespace": "monitoring" } },
+      { "designatorType": "Attributes", "attributes": { "kind": "Deployment", "name": "loki-gateway", "namespace": "monitoring" } },
+      { "designatorType": "Attributes", "attributes": { "kind": "StatefulSet", "name": "loki-chunks-cache", "namespace": "monitoring" } },
+      { "designatorType": "Attributes", "attributes": { "kind": "StatefulSet", "name": "loki-results-cache", "namespace": "monitoring" } },
+      { "designatorType": "Attributes", "attributes": { "kind": "StatefulSet", "name": "loki", "namespace": "monitoring" } },
+      { "designatorType": "Attributes", "attributes": { "kind": "Deployment", "name": "k8s-gateway", "namespace": "network" } },
+      { "designatorType": "Attributes", "attributes": { "kind": "Deployment", "name": "reloader", "namespace": "kube-system" } },
+      { "designatorType": "Attributes", "attributes": { "kind": "Deployment", "name": "mariadb-operator", "namespace": "database" } },
+      { "designatorType": "Attributes", "attributes": { "kind": "Deployment", "name": "mariadb-operator-cert-controller", "namespace": "database" } },
+      { "designatorType": "Attributes", "attributes": { "kind": "Deployment", "name": "mariadb-operator-webhook", "namespace": "database" } }
+    ],
+    "posturePolicies": [
+      { "controlID": "C-0271" }
+    ]
+  }
+]


### PR DESCRIPTION
## Summary

- Adds `security/kubescape-exceptions.json`, wired into the Kubescape scan step via `--exceptions`.
- Kubescape has no native exception expiry (confirmed against upstream schema/docs) — added a custom `reviewBy` field plus a non-blocking CI step that flags expired exceptions in the run's step summary, forcing periodic re-triage instead of silent permanent suppression.
- Follow-up from #401's triage work.

## What's suppressed and why

| Exception | Control | Reason |
|---|---|---|
| `C-0270-cpu-limits-repo-convention` | C-0270 | Repo-wide: CPU is compressible, not a security boundary (asymmetric 2-3 CPU nodes, Longhorn/Envoy on the latency path) |
| `C-0012-credential-pattern-false-positives` | C-0012 | 7 resources manually triaged — flag names/enum values, not secrets (`FB_NOAUTH`, `HTTP_AUTH_HEADER`, `WEBHOOK_SECRET_NAME`, cilium-config toggles, `MINIO_PROMETHEUS_AUTH_TYPE`) |
| `C-0271-scratch-test-workloads` | C-0271 | `default/test`, multus test pod — committed scratch apps, not production (AGENTS.md explicitly excludes these as pattern references) |
| `C-0271-cni-dataplane-daemons` | C-0271 | Cilium + multus — node-critical hot path, needs vendor guidance before sizing |
| `C-0271-longhorn-and-spegel` | C-0271 | Longhorn daemons + one-shot upgrade/uninstall Jobs — too short-lived for cadvisor to ever sample |
| `C-0271-monitoring-stack-sidecars` | C-0271 | kube-prometheus-stack/loki/alloy/k8s-gateway/mariadb-operator — deferred pending the same measured-peak treatment #401 gave thanos/homepage |

Documented in `docs/kubescape-exceptions.md`, including the format and how to add/retire an entry.

## Test plan

- [x] JSON validated (`python3 -m json.load`)
- [x] Workflow YAML validated (`yaml.safe_load`)
- [x] Expiry-check logic verified against current date and a future date (all 6 entries correctly stay live until their `reviewBy`)
- [ ] Flux Local / Security Scan CI run on this PR — first real run of `kubescape scan --exceptions ...` against this file

🤖 Generated with [Claude Code](https://claude.com/claude-code)