### PR TITLE
feat(default): replace filebrowser sidecar with caddy directory browse

### DIFF
--- a/kubernetes/apps/default/qbittorrent/app/helmrelease.yaml
+++ b/kubernetes/apps/default/qbittorrent/app/helmrelease.yaml
@@ -124,12 +124,12 @@ spec:
         data:
           Caddyfile: |-
             {
-            	admin off
+              admin off
             }
 
             :8081 {
-            	root * /downloads
-            	file_server browse
+              root * /downloads
+              file_server browse
             }
 
     service:

--- a/kubernetes/apps/default/qbittorrent/app/helmrelease.yaml
+++ b/kubernetes/apps/default/qbittorrent/app/helmrelease.yaml
@@ -23,39 +23,27 @@ spec:
         annotations:
           reloader.stakater.com/auto: "true"
         containers:
-          filebrowser:
+          browser:
             image:
-              repository: docker.io/filebrowser/filebrowser
-              tag: v2.63.23
-
-            tty: true
-            stdin: true
+              repository: docker.io/library/caddy
+              tag: 2.11.4-alpine
 
             securityContext:
               allowPrivilegeEscalation: false
               capabilities:
-                drop:
-                  - ALL
-              readOnlyRootFilesystem: false
+                drop: [ALL]
+                add: [NET_BIND_SERVICE]
+              readOnlyRootFilesystem: true
               runAsGroup: 1001
               runAsNonRoot: true
               runAsUser: 1001
 
-            env:
-              FB_DATABASE: /config/filebrowser.db
-              FB_ROOT: /downloads
-              FB_LOG: stdout
-              FB_NOAUTH: true
-              FB_PORT: &filebrowserPort 8081
-              PUID: "1001"
-              PGID: "1001"
-
             resources:
               requests:
                 cpu: 10m
-                memory: 64Mi
+                memory: 32Mi
               limits:
-                memory: 256Mi
+                memory: 128Mi
 
           gluetun:
             image:
@@ -131,6 +119,19 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
         supplementalGroups: [1001]
 
+    configMaps:
+      browser-caddyfile:
+        data:
+          Caddyfile: |-
+            {
+            	admin off
+            }
+
+            :8081 {
+            	root * /downloads
+            	file_server browse
+            }
+
     service:
       main:
         controller: main
@@ -140,7 +141,7 @@ spec:
       browser:
         ports:
           http:
-            port: *filebrowserPort
+            port: &browserPort 8081
 
     route:
       main:
@@ -175,7 +176,7 @@ spec:
         rules:
           - backendRefs:
               - identifier: browser
-                port: *filebrowserPort
+                port: *browserPort
 
     persistence:
       config:
@@ -186,3 +187,19 @@ spec:
 
       tmp:
         type: emptyDir
+
+      browser-caddyfile:
+        type: configMap
+        identifier: browser-caddyfile
+        advancedMounts:
+          main:
+            browser:
+              - path: /etc/caddy
+                readOnly: true
+
+      browser-data:
+        type: emptyDir
+        advancedMounts:
+          main:
+            browser:
+              - path: /data

--- a/kubernetes/apps/default/scanner-files/app/helmrelease.yaml
+++ b/kubernetes/apps/default/scanner-files/app/helmrelease.yaml
@@ -31,23 +31,43 @@ spec:
                 memory: 512Mi
           browser:
             image:
-              repository: docker.io/filebrowser/filebrowser
-              tag: v2.63.23
+              repository: docker.io/library/caddy
+              tag: 2.11.4-alpine
             env:
               TZ: "${TIMEZONE}"
-              FB_DATABASE: /config/filebrowser.db
-              FB_ROOT: /srv
-              FB_LOG: stdout
-              FB_NOAUTH: true
-              FB_PORT: &port 8080
-              PUID: 0
-              GUID: 0
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities:
+                drop: [ALL]
+                add: [NET_BIND_SERVICE]
+              readOnlyRootFilesystem: true
+              runAsNonRoot: true
+              runAsUser: 65534
+              runAsGroup: 65534
             resources:
               requests:
                 cpu: 10m
-                memory: 64Mi
+                memory: 32Mi
               limits:
-                memory: 256Mi
+                memory: 128Mi
+
+    defaultPodOptions:
+      securityContext:
+        fsGroup: 65534
+        fsGroupChangePolicy: OnRootMismatch
+
+    configMaps:
+      browser-caddyfile:
+        data:
+          Caddyfile: |-
+            {
+            	admin off
+            }
+
+            :8080 {
+            	root * /srv
+            	file_server browse
+            }
 
     service:
       app:
@@ -61,7 +81,7 @@ spec:
       browser:
         ports:
           http:
-            port: *port
+            port: &port 8080
 
     route:
       app:
@@ -97,3 +117,29 @@ spec:
     persistence:
       srv:
         existingClaim: scanner-files
+      browser-caddyfile:
+        type: configMap
+        identifier: browser-caddyfile
+        advancedMounts:
+          main:
+            browser:
+              - path: /etc/caddy
+                readOnly: true
+      browser-data:
+        type: emptyDir
+        advancedMounts:
+          main:
+            browser:
+              - path: /data
+      browser-config:
+        type: emptyDir
+        advancedMounts:
+          main:
+            browser:
+              - path: /config
+      browser-tmp:
+        type: emptyDir
+        advancedMounts:
+          main:
+            browser:
+              - path: /tmp

--- a/kubernetes/apps/default/scanner-files/app/helmrelease.yaml
+++ b/kubernetes/apps/default/scanner-files/app/helmrelease.yaml
@@ -61,12 +61,12 @@ spec:
         data:
           Caddyfile: |-
             {
-            	admin off
+              admin off
             }
 
             :8080 {
-            	root * /srv
-            	file_server browse
+              root * /srv
+              file_server browse
             }
 
     service:


### PR DESCRIPTION
## Summary
- filebrowser/filebrowser `v2.63.23` is its final release — repo archives 2026-09-01, no further fixes including security. Both sidecars ran it `FB_NOAUTH: true`.
- Replaces the `browser` sidecar in `scanner-files` and `qbittorrent` with the official `caddy` image using `file_server browse` — no third-party module, no single-maintainer image to track (the exact risk class that put filebrowser here).
- Same noauth/LAN-only exposure model kept (explicit decision — low threat, behind `envoy-internal` already), but the container itself is hardened: non-root, read-only rootfs, all caps dropped except `NET_BIND_SERVICE` (Caddy's binary needs it in the bounding set to exec at all, even when binding a port >1024 — confirmed by testing, not assumed).
- Caddy's stock browse template renders inline `<img>` thumbnails for image files in grid view out of the box — no custom template required.
- `qbittorrent`'s sidecar container key renamed `filebrowser` → `browser` to match `scanner-files`' existing naming.

## Why Caddy over alternatives
Researched FileBrowser Quantum (gtsteffaniak fork), copyparty, dufs, Alist/OpenList, Filestash, and nginx+fancyindex. Landed on Caddy because:
- It's a Docker Official Image maintained by the Caddy project itself, not a solo hobbyist repo — directly avoids repeating filebrowser's EOL failure mode.
- Directory browsing is a built-in directive, not a compiled third-party module (nginx+fancyindex would trade one maintenance dependency for another).
- Config is a single small Caddyfile, no database, tiny image/footprint.
- Download-only, "just browse and download" was confirmed as the actual requirement for both apps — Caddy covers that natively, with thumbnails as a bonus rather than a driver of the choice.

## Test plan
- [x] Verified locally with `docker run` against the pinned `caddy:2.11.4-alpine` tag: non-root uid, `--read-only` rootfs, `--cap-drop ALL --cap-add NET_BIND_SERVICE`, directory-mounted Caddyfile (simulating the ConfigMap volume) — container starts clean, serves `200 OK`, grid view renders image thumbnails.
- [ ] Flux Local CI diff on this PR (the real gate — `kustomize`/`task validate` aren't available in this worktree, see repo docs).
- [ ] After merge: confirm both `scans.${SECRET_DOMAIN}` and `downloads.${SECRET_DOMAIN}` reconcile and serve listings; confirm Longhorn PVCs (`scanner-files`, `qbittorrent-downloads`) mount correctly under the new container.

Closes #399

🤖 Generated with [Claude Code](https://claude.com/claude-code)