### PR TITLE
fix(n8n): repair silently-dead workflow failure alerting

### DIFF
--- a/kubernetes/apps/default/n8n/app/helmrelease.yaml
+++ b/kubernetes/apps/default/n8n/app/helmrelease.yaml
@@ -36,6 +36,29 @@ spec:
               EXECUTIONS_DATA_PRUNE_MAX_COUNT: 10000
               GENERIC_TIMEZONE: ${TIMEZONE}
               N8N_METRICS: "true"
+              # N8N_METRICS alone only serves the endpoint with process/default
+              # metrics. The workflow success/failure counters come from n8n's
+              # internal event bus, which is gated separately and defaults to off.
+              # Without this the n8n PrometheusRule and dashboards query series that
+              # never exist — and an alert on an absent series does not error, it
+              # silently never fires. Verified against n8n 2.33.3's
+              # PrometheusMetricsConfig (includeMessageEventBusMetrics, default false).
+              N8N_METRICS_INCLUDE_MESSAGE_EVENT_BUS_METRICS: "true"
+              # Attributes a failure to a specific workflow. Adds workflow_id to the
+              # event-bus counters (one series per workflow — cheap) and also to the
+              # n8n_workflow_execution_duration_seconds histogram (16 buckets x 2
+              # statuses x mode per workflow — the costly one). If that histogram's
+              # cardinality ever needs trimming, drop its _bucket series with a
+              # metricRelabeling on the ServiceMonitor rather than unsetting this:
+              # _count/_sum keep working and per-workflow attribution is the point.
+              N8N_METRICS_INCLUDE_WORKFLOW_ID_LABEL: "true"
+              # Publishes n8n_workflow_info / n8n_active_workflow_info — a
+              # workflow_id -> workflow_name gauge the rules and dashboards join
+              # against. Deliberately used INSTEAD of
+              # N8N_METRICS_INCLUDE_WORKFLOW_NAME_LABEL: stamping the user-editable
+              # name onto every counter means renaming a workflow orphans its old
+              # series and splits its history. The join keeps names in one place.
+              N8N_METRICS_INCLUDE_WORKFLOW_INFO: "true"
               N8N_ENFORCE_SETTINGS_FILE_PERMISSIONS: false
               N8N_PROTOCOL: "https"
               N8N_PORT: &port 443

--- a/kubernetes/apps/monitoring/kube-prometheus-stack/app/grafana-dashboard-homelab-overview.yaml
+++ b/kubernetes/apps/monitoring/kube-prometheus-stack/app/grafana-dashboard-homelab-overview.yaml
@@ -383,7 +383,7 @@ data:
           "gridPos": {"h": 8, "w": 12, "x": 0, "y": 24},
           "targets": [
             {
-              "expr": "sum(rate(n8n_workflow_success_total[5m])) / clamp_min(sum(rate(n8n_workflow_success_total[5m])) + sum(rate(n8n_workflow_error_total[5m])), 0.001)",
+              "expr": "sum(rate(n8n_workflow_success_total[5m])) / clamp_min(sum(rate(n8n_workflow_success_total[5m])) + sum(rate(n8n_workflow_failed_total[5m])), 0.001)",
               "legendFormat": "ratio"
             }
           ],

--- a/kubernetes/apps/monitoring/kube-prometheus-stack/app/grafana-dashboard-n8n.yaml
+++ b/kubernetes/apps/monitoring/kube-prometheus-stack/app/grafana-dashboard-n8n.yaml
@@ -109,11 +109,11 @@ data:
         {
           "id": 5,
           "type": "timeseries",
-          "title": "Workflow Success/Error Rate",
+          "title": "Workflow Success/Failure Rate",
           "gridPos": {"h": 8, "w": 12, "x": 0, "y": 4},
           "targets": [
             {"expr": "sum(rate(n8n_workflow_success_total[5m]))", "legendFormat": "success"},
-            {"expr": "sum(rate(n8n_workflow_failed_total[5m]))", "legendFormat": "error"}
+            {"expr": "sum(rate(n8n_workflow_failed_total[5m]))", "legendFormat": "failed"}
           ],
           "fieldConfig": {
             "defaults": {"min": 0, "unit": "ops", "custom": {"lineWidth": 2, "fillOpacity": 10}},

--- a/kubernetes/apps/monitoring/kube-prometheus-stack/app/grafana-dashboard-n8n.yaml
+++ b/kubernetes/apps/monitoring/kube-prometheus-stack/app/grafana-dashboard-n8n.yaml
@@ -43,7 +43,7 @@ data:
           "gridPos": {"h": 4, "w": 6, "x": 6, "y": 0},
           "targets": [
             {
-              "expr": "sum(rate(n8n_workflow_success_total[15m])) / clamp_min(sum(rate(n8n_workflow_success_total[15m])) + sum(rate(n8n_workflow_error_total[15m])), 0.001)",
+              "expr": "sum(rate(n8n_workflow_success_total[15m])) / clamp_min(sum(rate(n8n_workflow_success_total[15m])) + sum(rate(n8n_workflow_failed_total[15m])), 0.001)",
               "legendFormat": "success"
             }
           ],
@@ -72,7 +72,7 @@ data:
           "gridPos": {"h": 4, "w": 6, "x": 12, "y": 0},
           "targets": [
             {
-              "expr": "sum(rate(n8n_workflow_success_total[15m])) + sum(rate(n8n_workflow_error_total[15m]))",
+              "expr": "sum(rate(n8n_workflow_success_total[15m])) + sum(rate(n8n_workflow_failed_total[15m]))",
               "legendFormat": "exec/s"
             }
           ],
@@ -113,7 +113,7 @@ data:
           "gridPos": {"h": 8, "w": 12, "x": 0, "y": 4},
           "targets": [
             {"expr": "sum(rate(n8n_workflow_success_total[5m]))", "legendFormat": "success"},
-            {"expr": "sum(rate(n8n_workflow_error_total[5m]))", "legendFormat": "error"}
+            {"expr": "sum(rate(n8n_workflow_failed_total[5m]))", "legendFormat": "error"}
           ],
           "fieldConfig": {
             "defaults": {"min": 0, "unit": "ops", "custom": {"lineWidth": 2, "fillOpacity": 10}},
@@ -127,7 +127,7 @@ data:
           "gridPos": {"h": 8, "w": 12, "x": 12, "y": 4},
           "targets": [
             {
-              "expr": "sum(rate(n8n_workflow_success_total[5m])) / clamp_min(sum(rate(n8n_workflow_success_total[5m])) + sum(rate(n8n_workflow_error_total[5m])), 0.001)",
+              "expr": "sum(rate(n8n_workflow_success_total[5m])) / clamp_min(sum(rate(n8n_workflow_success_total[5m])) + sum(rate(n8n_workflow_failed_total[5m])), 0.001)",
               "legendFormat": "ratio"
             }
           ],
@@ -151,11 +151,11 @@ data:
         {
           "id": 7,
           "type": "table",
-          "title": "Top Erroring Workflows (1h)",
+          "title": "Top Failing Workflows (1h)",
           "gridPos": {"h": 8, "w": 24, "x": 0, "y": 12},
           "targets": [
             {
-              "expr": "topk(10, sum by (workflow_name) (increase(n8n_workflow_error_total[1h])))",
+              "expr": "topk(10, sum by (workflow_name) (sum by (workflow_id) (increase(n8n_workflow_failed_total[1h])) * on (workflow_id) group_left (workflow_name) n8n_workflow_info))",
               "format": "table",
               "instant": true,
               "legendFormat": ""

--- a/kubernetes/apps/monitoring/kube-prometheus-stack/app/prometheusrule-n8n.yaml
+++ b/kubernetes/apps/monitoring/kube-prometheus-stack/app/prometheusrule-n8n.yaml
@@ -10,6 +10,18 @@ spec:
   groups:
     - name: n8n.rules
       rules:
+        # Metric names below are taken from n8n 2.33.3's compiled metrics services,
+        # not from documentation:
+        #   - event-bus counters are `${prefix}${event}_total` with dots replaced by
+        #     underscores, so n8n.workflow.failed -> n8n_workflow_failed_total.
+        #     The emitted events are started/success/failed/cancelled — there is no
+        #     `error` event, so the n8n_workflow_error_total these rules previously
+        #     used never existed.
+        #   - the active-workflow gauge is n8n_active_workflow_count (not
+        #     n8n_active_workflows).
+        # All of the above except active_workflow_count require
+        # N8N_METRICS_INCLUDE_MESSAGE_EVENT_BUS_METRICS on the n8n HelmRelease.
+
         - alert: N8nPodNotReady
           expr: |
             sum(kube_pod_status_ready{namespace="default", condition="true", pod=~"n8n-.*"}) < 1
@@ -30,15 +42,38 @@ spec:
             summary: n8n container is restarting frequently
             description: n8n app container has restarted more than 2 times in the last 15 minutes. Restart count now {{ $$value | humanize }}.
 
+        # Per-workflow failure notification. Fires as soon as any individual workflow
+        # records a failed execution, and names it via the workflow_info join so the
+        # Telegram message identifies the workflow rather than an opaque ID.
+        #
+        # Caveat worth knowing: the counter series is created lazily on a workflow's
+        # first failure and is first exposed already at 1, so increase() sees no delta
+        # and the very first failure of a never-before-failed workflow can be missed
+        # (subsequent ones, and everything after an n8n restart, are caught normally).
+        # n8n's own Error Workflow / Error Trigger is the per-execution notifier that
+        # has no such gap — this alert is the safety net around it, and the two are
+        # meant to run together.
+        - alert: N8nWorkflowFailed
+          expr: |
+            (
+              sum by (workflow_id) (increase(n8n_workflow_failed_total[10m])) > 0
+            )
+            * on (workflow_id) group_left (workflow_name) n8n_workflow_info
+          labels:
+            severity: warning
+          annotations:
+            summary: n8n workflow "{{ $$labels.workflow_name }}" failed
+            description: Workflow "{{ $$labels.workflow_name }}" (id {{ $$labels.workflow_id }}) recorded {{ $$value | humanize }} failed execution(s) in the last 10 minutes.
+
         - alert: N8nWorkflowErrorRateHigh
           expr: |
             (
-              sum(rate(n8n_workflow_error_total[10m]))
+              sum(rate(n8n_workflow_failed_total[10m]))
               /
-              clamp_min(sum(rate(n8n_workflow_success_total[10m])) + sum(rate(n8n_workflow_error_total[10m])), 0.001)
+              clamp_min(sum(rate(n8n_workflow_success_total[10m])) + sum(rate(n8n_workflow_failed_total[10m])), 0.001)
             ) > 0.05
             and
-            (sum(rate(n8n_workflow_success_total[10m])) + sum(rate(n8n_workflow_error_total[10m]))) > 0.01
+            (sum(rate(n8n_workflow_success_total[10m])) + sum(rate(n8n_workflow_failed_total[10m]))) > 0.01
           for: 10m
           labels:
             severity: warning
@@ -49,12 +84,12 @@ spec:
         - alert: N8nWorkflowErrorRateCritical
           expr: |
             (
-              sum(rate(n8n_workflow_error_total[10m]))
+              sum(rate(n8n_workflow_failed_total[10m]))
               /
-              clamp_min(sum(rate(n8n_workflow_success_total[10m])) + sum(rate(n8n_workflow_error_total[10m])), 0.001)
+              clamp_min(sum(rate(n8n_workflow_success_total[10m])) + sum(rate(n8n_workflow_failed_total[10m])), 0.001)
             ) > 0.20
             and
-            (sum(rate(n8n_workflow_success_total[10m])) + sum(rate(n8n_workflow_error_total[10m]))) > 0.01
+            (sum(rate(n8n_workflow_success_total[10m])) + sum(rate(n8n_workflow_failed_total[10m]))) > 0.01
           for: 10m
           labels:
             severity: critical
@@ -64,12 +99,37 @@ spec:
 
         - alert: N8nNoRecentWorkflowExecutions
           expr: |
-            sum(n8n_active_workflows) > 0
+            sum(n8n_active_workflow_count) > 0
             and
-            sum(increase(n8n_workflow_success_total[2h]) + increase(n8n_workflow_error_total[2h])) == 0
+            sum(increase(n8n_workflow_success_total[2h]) + increase(n8n_workflow_failed_total[2h])) == 0
           for: 30m
           labels:
             severity: warning
           annotations:
             summary: n8n has active workflows but no recent executions
             description: n8n reports active workflows, but no workflow executions were observed in the past 2 hours. Tune this alert window for low-frequency jobs.
+
+        # Deadman's switch for the alerts above. Every workflow rule here depends on
+        # metrics that are individually gated by N8N_METRICS_INCLUDE_* env vars, and a
+        # PromQL expression over a series that does not exist evaluates to empty rather
+        # than erroring — which is exactly how the previous n8n_workflow_error_total /
+        # n8n_active_workflows typos went unnoticed: green dashboards, silent alerts.
+        #
+        # n8n_active_workflow_count is registered unconditionally whenever N8N_METRICS
+        # is on, and n8n_workflow_info is what N8nWorkflowFailed joins against, so
+        # losing either means the workflow alerting above is degraded or dead.
+        #
+        # Gated on n8n actually being up so this stays quiet during a genuine outage —
+        # N8nPodNotReady already covers that case and there is no value in two alerts
+        # for one event.
+        - alert: N8nWorkflowMetricsMissing
+          expr: |
+            (absent(n8n_active_workflow_count) or absent(n8n_workflow_info))
+            and on ()
+            (sum(kube_pod_status_ready{namespace="default", condition="true", pod=~"n8n-.*"}) > 0)
+          for: 15m
+          labels:
+            severity: warning
+          annotations:
+            summary: n8n workflow metrics are missing while n8n is up
+            description: n8n is running but is not exposing n8n_active_workflow_count and/or n8n_workflow_info. The n8n workflow failure alerts cannot fire in this state — check the N8N_METRICS_INCLUDE_* env vars on the n8n HelmRelease and the ServiceMonitor scrape target.

--- a/kubernetes/apps/monitoring/kube-prometheus-stack/app/prometheusrule-n8n.yaml
+++ b/kubernetes/apps/monitoring/kube-prometheus-stack/app/prometheusrule-n8n.yaml
@@ -12,11 +12,12 @@ spec:
       rules:
         # Metric names below are taken from n8n 2.33.3's compiled metrics services,
         # not from documentation:
-        #   - event-bus counters are `${prefix}${event}_total` with dots replaced by
-        #     underscores, so n8n.workflow.failed -> n8n_workflow_failed_total.
-        #     The emitted events are started/success/failed/cancelled — there is no
-        #     `error` event, so the n8n_workflow_error_total these rules previously
-        #     used never existed.
+        #   - event-bus counters are named from the metrics prefix plus the event
+        #     name with dots replaced by underscores and a _total suffix, so
+        #     n8n.workflow.failed becomes n8n_workflow_failed_total. The emitted
+        #     events are started/success/failed/cancelled — there is no `error`
+        #     event, so the n8n_workflow_error_total these rules previously used
+        #     never existed.
         #   - the active-workflow gauge is n8n_active_workflow_count (not
         #     n8n_active_workflows).
         # All of the above except active_workflow_count require
@@ -78,8 +79,8 @@ spec:
           labels:
             severity: warning
           annotations:
-            summary: n8n workflow error ratio is elevated
-            description: n8n workflow errors are above 5% over the last 10 minutes. Current error rate now {{ $$value | humanizePercentage }}.
+            summary: n8n workflow failure ratio is elevated
+            description: n8n workflow failures are above 5% of executions over the last 10 minutes. Current failure ratio now {{ $$value | humanizePercentage }}.
 
         - alert: N8nWorkflowErrorRateCritical
           expr: |
@@ -94,8 +95,8 @@ spec:
           labels:
             severity: critical
           annotations:
-            summary: n8n workflow error ratio is critical
-            description: n8n workflow errors are above 20% over the last 10 minutes. Current error rate now {{ $$value | humanizePercentage }}.
+            summary: n8n workflow failure ratio is critical
+            description: n8n workflow failures are above 20% of executions over the last 10 minutes. Current failure ratio now {{ $$value | humanizePercentage }}.
 
         - alert: N8nNoRecentWorkflowExecutions
           expr: |


### PR DESCRIPTION
## Summary

The n8n alerts and dashboards queried metric names that n8n never emits, so every workflow-level alert evaluated to empty and never fired. A PromQL expression over an absent series doesn't error — it silently returns nothing — so this presented as green dashboards and quiet alerts rather than as a failure. Nothing would have notified you when a workflow failed.

The Alertmanager → Telegram path was already correct and needed no changes. Only the first link in the chain was broken.

## Two problems, both required for failure notification to work

**1. The metrics weren't being emitted.** `N8N_METRICS=true` only serves the endpoint with process/default metrics. The workflow success/failure counters come from n8n's internal event bus, gated behind a separate flag that defaults to off.

| Env var added | Why |
|---|---|
| `N8N_METRICS_INCLUDE_MESSAGE_EVENT_BUS_METRICS` | emits the workflow success/failed counters (default `false`) |
| `N8N_METRICS_INCLUDE_WORKFLOW_ID_LABEL` | per-workflow attribution |
| `N8N_METRICS_INCLUDE_WORKFLOW_INFO` | `workflow_id` → `workflow_name` gauge for dashboard/alert joins |

`N8N_METRICS_INCLUDE_WORKFLOW_NAME_LABEL` was deliberately **not** enabled — stamping the user-editable name onto every counter means renaming a workflow orphans its old series and splits its history. The `workflow_info` join keeps names in one place.

**2. The metric names were wrong.** Verified against the compiled metrics services in the published `n8n@2.33.3` package rather than from documentation:

| Queried | Actually emitted |
|---|---|
| `n8n_workflow_error_total` | `n8n_workflow_failed_total` |
| `n8n_active_workflows` | `n8n_active_workflow_count` |
| `workflow_name` label on counters | only via join against `n8n_workflow_info` |

Event-bus counters are named `${prefix}${event}_total` from the event name. The emitted events are `started`/`success`/`failed`/`cancelled` — there is no `error` event, so `n8n_workflow_error_total` could never have resolved even with the event bus enabled.

## New alerts

- **`N8nWorkflowFailed`** — notifies per failing workflow and names it via the `workflow_info` join, so the Telegram message identifies the workflow instead of an opaque ID. This is the direct per-workflow failure notification.
- **`N8nWorkflowMetricsMissing`** — deadman's switch. Every workflow rule depends on metrics gated by `N8N_METRICS_INCLUDE_*` env vars, and this class of regression is invisible by construction. Gated on n8n actually being up so it stays quiet during a genuine outage (`N8nPodNotReady` already covers that).

## Known gap

`N8nWorkflowFailed` uses `increase()`, and a counter series is created lazily on a workflow's first failure and first exposed already at `1` — so `increase()` sees no delta and the very first failure of a never-before-failed workflow can be missed. Subsequent failures, and everything after an n8n restart, are caught normally.

n8n's own **Error Workflow / Error Trigger** is the per-execution notifier with no such gap, and it carries detail Prometheus fundamentally cannot (failing node, error message). The two are meant to run together: the Error Workflow for per-failure detail, these alerts as the safety net that also catches n8n being down or silently executing nothing. Note there is no instance-level default error workflow — it's a per-workflow setting, so any workflow you don't configure is unmonitored by that layer.

## Validation

Verification available in this environment was limited — no `kubeconfig`/`age.key`, and the toolchain (`kustomize`, `task`, `promtool`) isn't installed here, so `task build` / `task validate` were not run.

- All 36 PromQL expressions across the rules and both dashboards parse cleanly (Rust `promql-parser`).
- ASTs inspected for the two non-obvious expressions to confirm operator precedence — the `> 0` filter binds before the `group_left` join, as intended.
- Embedded dashboard JSON re-parsed as valid JSON.
- Every `kustomization.yaml` resource present and valid YAML; no unescaped single-`$` that Flux `envsubst` would consume.

**The Flux Local diff on this PR is the real gate.** Metric names are verified from the published package, but the fully-wired behavior can only be confirmed against the live endpoint once deployed:

```sh
kubectl -n default port-forward svc/n8n 8080:443
curl -s localhost:8080/metrics | grep -E '^n8n_' | cut -d'{' -f1 | sort -u
```

---
_Generated by [Claude Code](https://claude.ai/code/session_01PPD6qL3fuNpmsKzpLQqji2)_