### PR TITLE
feat(mcp): add mcp namespace group and kubernetes MCP server

### DIFF
--- a/kubernetes/apps/mcp/kustomization.yaml
+++ b/kubernetes/apps/mcp/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: mcp
+
+components:
+  - ../../components/sops
+
+resources:
+  - ./namespace.yaml
+  - ./mcp-kubernetes/ks.yaml

--- a/kubernetes/apps/mcp/mcp-kubernetes/app/helmrelease.yaml
+++ b/kubernetes/apps/mcp/mcp-kubernetes/app/helmrelease.yaml
@@ -1,0 +1,116 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app mcp-kubernetes
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: *app
+  interval: 1h
+  values:
+    controllers:
+      main:
+        # Streamable HTTP sessions are stateful and pinned to a pod; a second
+        # replica would need sticky sessions the gateway doesn't provide.
+        replicas: 1
+        strategy: Recreate
+        containers:
+          app:
+            image:
+              repository: flux159/mcp-server-kubernetes
+              tag: v4.1.3
+            env:
+              # Upstream labels the HTTP transports "unsafe" because the server
+              # ships no authn. Internal-only and unauthenticated is the phase-1
+              # choice; MCP_AUTH_TOKEN (X-MCP-AUTH header) is the seam for
+              # adding auth later without touching anything else here.
+              ENABLE_UNSAFE_STREAMABLE_HTTP_TRANSPORT: "1"
+              HOST: 0.0.0.0
+              PORT: &port 3000
+              # Second lock on the read-only door: even if the ServiceAccount
+              # were widened by mistake, the server refuses write tools.
+              ALLOW_ONLY_READONLY_TOOLS: "true"
+              MASK_SECRETS: "true"
+              # Rejects requests whose Host header isn't listed. This is the
+              # gateway hostname. Cluster-DNS callers send
+              # mcp-kubernetes.mcp.svc.cluster.local instead — UNVERIFIED
+              # whether that path is accepted or whether this var takes a list.
+              DNS_REBINDING_ALLOWED_HOST: mcp-kubernetes.${SECRET_DOMAIN}
+              # The server shells out to kubectl, which writes a discovery cache
+              # under $HOME/.kube. Pointing HOME at the emptyDir below is what
+              # lets readOnlyRootFilesystem stay true. In-cluster credentials
+              # outrank ~/.kube/config, so this doesn't affect auth.
+              HOME: /tmp
+            probes:
+              # Health/readiness paths are undocumented upstream, so probe the
+              # socket rather than guess a URL. Swap to httpGet once confirmed.
+              liveness: &probes
+                enabled: true
+                custom: true
+                spec:
+                  tcpSocket:
+                    port: *port
+                  initialDelaySeconds: 10
+                  periodSeconds: 10
+                  timeoutSeconds: 3
+                  failureThreshold: 3
+              readiness: *probes
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: { drop: ["ALL"] }
+            resources:
+              requests:
+                cpu: 10m
+                memory: 64Mi
+              limits:
+                memory: 256Mi
+
+    # Creates the ServiceAccount named `mcp-kubernetes`; rbac.yaml binds it to a
+    # read-only ClusterRole. The mounted token is the server's credential — it
+    # uses in-cluster auth, which outranks every KUBECONFIG_* / K8S_* source.
+    serviceAccount:
+      mcp-kubernetes: {}
+
+    defaultPodOptions:
+      automountServiceAccountToken: true
+      # runAsNonRoot is not set: the image's UID is unverified, and guessing
+      # wrong yields a pod that never starts. Resolve on first deploy with
+      #   kubectl -n mcp exec deploy/mcp-kubernetes -- id
+      # then pin runAsUser/runAsGroup here.
+
+    persistence:
+      # Writable scratch for the kubectl discovery cache (see HOME above).
+      # No globalMounts needed — app-template mounts an unqualified volume at
+      # /<name>, so this lands on /tmp.
+      tmp:
+        type: emptyDir
+
+    service:
+      main:
+        controller: main
+        ports:
+          http:
+            port: *port
+
+    route:
+      main:
+        # Single-label hostname on purpose: the wildcard cert is
+        # ["${SECRET_DOMAIN}", "*.${SECRET_DOMAIN}"] and does not cover a second
+        # label, so mcp-kubernetes.mcp.${SECRET_DOMAIN} would fail TLS.
+        hostnames: ["mcp-kubernetes.${SECRET_DOMAIN}"]
+        parentRefs:
+          - name: envoy-internal
+            namespace: network
+            sectionName: https
+        rules:
+          # Path-scoped so only the MCP endpoint is reachable through the
+          # gateway. Widen if a client needs /.well-known OAuth discovery.
+          - matches:
+              - path:
+                  value: /mcp
+            backendRefs:
+              - identifier: main
+                port: *port

--- a/kubernetes/apps/mcp/mcp-kubernetes/app/helmrelease.yaml
+++ b/kubernetes/apps/mcp/mcp-kubernetes/app/helmrelease.yaml
@@ -12,8 +12,12 @@ spec:
   values:
     controllers:
       main:
-        # Streamable HTTP sessions are stateful and pinned to a pod; a second
-        # replica would need sticky sessions the gateway doesn't provide.
+        # This server runs Streamable HTTP statelessly (sessionIdGenerator is
+        # undefined upstream, so every request gets a fresh transport), so it
+        # would scale horizontally. One replica because the load doesn't justify
+        # more — not because sessions pin to a pod. Don't copy this as a
+        # constraint: an MCP server that issues session IDs *would* need sticky
+        # sessions the gateway doesn't provide.
         replicas: 1
         strategy: Recreate
         containers:
@@ -30,13 +34,25 @@ spec:
               HOST: 0.0.0.0
               PORT: &port 3000
               # Second lock on the read-only door: even if the ServiceAccount
-              # were widened by mistake, the server refuses write tools.
+              # were widened by mistake, the server refuses write tools. Leaves
+              # kubectl_get, kubectl_describe, kubectl_logs, kubectl_context,
+              # kubectl_reconnect, explain_resource, list_api_resources, ping —
+              # dropping kubectl_generic, apply/create/patch/scale/rollout, the
+              # Helm tools and port-forward. Note this is stricter than
+              # ALLOW_ONLY_NON_DESTRUCTIVE_TOOLS, which still permits writes.
+              # Those survivors are generic over resource type, so rbac.yaml is
+              # what actually bounds this server's reach.
               ALLOW_ONLY_READONLY_TOOLS: "true"
               MASK_SECRETS: "true"
-              # Rejects requests whose Host header isn't listed. This is the
-              # gateway hostname. Cluster-DNS callers send
-              # mcp-kubernetes.mcp.svc.cluster.local instead — UNVERIFIED
-              # whether that path is accepted or whether this var takes a list.
+              # Holds exactly ONE host and replaces the default allow-list —
+              # upstream wraps it as [value], with no comma splitting. The SDK
+              # compares the Host header by exact string (port included) and
+              # answers 403 "Invalid Host header" on a miss.
+              # Consequence: every client must reach this through the gateway
+              # hostname. Calling the Service directly at
+              # mcp-kubernetes.mcp.svc.cluster.local:3000 is rejected, so
+              # in-cluster clients (n8n, Hermes) hairpin out through
+              # envoy-internal like the external ones. One URL for all clients.
               DNS_REBINDING_ALLOWED_HOST: mcp-kubernetes.${SECRET_DOMAIN}
               # The server shells out to kubectl, which writes a discovery cache
               # under $HOME/.kube. Pointing HOME at the emptyDir below is what

--- a/kubernetes/apps/mcp/mcp-kubernetes/app/kustomization.yaml
+++ b/kubernetes/apps/mcp/mcp-kubernetes/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml
+  - ./rbac.yaml

--- a/kubernetes/apps/mcp/mcp-kubernetes/app/ocirepository.yaml
+++ b/kubernetes/apps/mcp/mcp-kubernetes/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: mcp-kubernetes
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/mcp/mcp-kubernetes/app/rbac.yaml
+++ b/kubernetes/apps/mcp/mcp-kubernetes/app/rbac.yaml
@@ -1,19 +1,43 @@
 ---
 # Read-only cluster access for the Kubernetes MCP server.
 #
-# get/list/watch only, cluster-wide. Deliberate omissions, so a future reader
-# knows these were decided rather than forgotten:
-#   secrets      the server masks values, but the token shouldn't read them at
-#                all. Side effect: Helm stores release metadata in Secrets, so
-#                the server's Helm tools won't work. Accepted.
-#   pods/exec    exec runs arbitrary code as the target pod, which would make
-#                this role's ceiling the most privileged pod in the cluster.
-#   rbac.*       no privilege enumeration.
-#   write verbs  the cluster is GitOps-managed; writes get reverted by Flux or
-#                cause drift.
+# In readonly mode this server's tools are generic — kubectl_get,
+# kubectl_describe, kubectl_logs, explain_resource, list_api_resources — and
+# operate on any resource type. So this RBAC *is* the server's capability
+# surface, not a supplement to a fixed tool list. Anything omitted here comes
+# back as Forbidden.
 #
-# Adding an API group here widens the blast radius of any prompt injection that
-# reaches this server. Add per demonstrated need, not speculatively.
+# Scope is built in two layers:
+#   1. the built-in `view` ClusterRole (bound below). Aggregated, get/list/watch
+#      only, and verified to exclude secrets, pods/exec, pods/attach and
+#      pods/portforward. Covers most namespaced resources including the Flux,
+#      Knative, MariaDB and cert-manager CRDs, whose charts ship
+#      aggregate-to-view roles.
+#   2. the ClusterRole below, for what `view` cannot reach: cluster-scoped
+#      kinds, and operator CRD groups whose charts ship no aggregate-to-view
+#      role (Longhorn, Cilium, Prometheus, Envoy Gateway, …).
+#
+# Deliberate omissions, so a future reader knows these were decided rather than
+# forgotten:
+#   secrets            never; the token should not read them at all.
+#   pods/exec          exec runs arbitrary code as the target pod, which would
+#   pods/attach        make this role's ceiling the most privileged pod in the
+#   pods/portforward   cluster.
+#   rbac.*             no privilege enumeration.
+#   write verbs        the cluster is GitOps-managed; writes get reverted by
+#                      Flux or cause drift.
+#
+# Accepted trade-off of layer 1: `view` widens on its own when a newly installed
+# operator ships an aggregate-to-view ClusterRole, so read access can grow
+# without a PR in this repo. Chosen over hand-enumerating ~20 API groups that
+# would go stale on every operator install.
+#
+# Convention when copying this for the next MCP server: always name apiGroups
+# explicitly, never `*`. Within a single named group, `resources: ["*"]` is fine
+# when the whole group is in scope — used below for vendor CRD groups, whose
+# resource lists churn with every chart bump. Built-in Kubernetes groups stay
+# enumerated: they are short and stable, and each addition widens the blast
+# radius of any prompt injection that reaches this server.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -22,111 +46,79 @@ metadata:
     app.kubernetes.io/instance: *app
     app.kubernetes.io/name: *app
 rules:
+  # Cluster-scoped core kinds. `view` is namespaced-only, so it has neither.
   - apiGroups:
       - ""
     resources:
-      - configmaps
-      - endpoints
-      - events
-      - limitranges
-      - namespaces
       - nodes
-      - persistentvolumeclaims
       - persistentvolumes
-      - pods
-      - pods/log
-      - replicationcontrollers
-      - resourcequotas
-      - serviceaccounts
-      - services
     verbs: &readonly
       - get
       - list
       - watch
-  - apiGroups:
-      - apps
-    resources:
-      - daemonsets
-      - deployments
-      - replicasets
-      - statefulsets
-    verbs: *readonly
-  - apiGroups:
-      - batch
-    resources:
-      - cronjobs
-      - jobs
-    verbs: *readonly
-  - apiGroups:
-      - autoscaling
-    resources:
-      - horizontalpodautoscalers
-    verbs: *readonly
-  - apiGroups:
-      - policy
-    resources:
-      - poddisruptionbudgets
-    verbs: *readonly
-  - apiGroups:
-      - networking.k8s.io
-    resources:
-      - ingresses
-      - networkpolicies
-    verbs: *readonly
-  - apiGroups:
-      - gateway.networking.k8s.io
-    resources:
-      - gateways
-      - grpcroutes
-      - httproutes
-    verbs: *readonly
+  # Storage topology — the other half of any "why is this volume unhealthy"
+  # question, alongside the longhorn.io group below.
   - apiGroups:
       - storage.k8s.io
     resources:
+      - csidrivers
+      - csinodes
+      - csistoragecapacities
       - storageclasses
       - volumeattachments
     verbs: *readonly
+  # Lets explain_resource and list_api_resources describe CRDs, not just
+  # built-in kinds.
   - apiGroups:
       - apiextensions.k8s.io
     resources:
       - customresourcedefinitions
     verbs: *readonly
+  # cert-manager ships an aggregate-to-view role, but it covers only the
+  # namespaced kinds. ClusterIssuer is where letsencrypt-production lives.
   - apiGroups:
-      - metrics.k8s.io
+      - cert-manager.io
     resources:
-      - nodes
-      - pods
+      - clusterissuers
     verbs: *readonly
-  # Flux state — "why hasn't my change landed" is the question this server will
-  # field most in a GitOps cluster. Enumerated rather than wildcarded so the
-  # grant stays legible when this file is copied for the next MCP server.
+  # Vendor CRD groups with no aggregate-to-view role of their own. Whole group
+  # in scope, still read-only — see the `resources: ["*"]` note in the header.
   - apiGroups:
-      - source.toolkit.fluxcd.io
+      - cilium.io
+      - externaldns.k8s.io
+      - fluxcd.controlplane.io   # FluxInstance / FluxReport — cluster-wide Flux status
+      - gateway.envoyproxy.io
+      - gateway.networking.k8s.io
+      - k8s.cni.cncf.io
+      - longhorn.io
+      - monitoring.coreos.com
+      - monitoring.grafana.com
+      - operator.knative.dev
     resources:
-      - buckets
-      - gitrepositories
-      - helmcharts
-      - helmrepositories
-      - ocirepositories
-    verbs: *readonly
-  - apiGroups:
-      - kustomize.toolkit.fluxcd.io
-    resources:
-      - kustomizations
-    verbs: *readonly
-  - apiGroups:
-      - helm.toolkit.fluxcd.io
-    resources:
-      - helmreleases
-    verbs: *readonly
-  - apiGroups:
-      - notification.toolkit.fluxcd.io
-    resources:
-      - alerts
-      - providers
-      - receivers
+      - "*"
     verbs: *readonly
 ---
+# Layer 1: the built-in read-only role. Bound separately from the supplement so
+# `kubectl describe clusterrolebinding mcp-kubernetes-view` names its source.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: mcp-kubernetes-view
+  labels:
+    app.kubernetes.io/instance: mcp-kubernetes
+    app.kubernetes.io/name: mcp-kubernetes
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: view
+subjects:
+  - kind: ServiceAccount
+    name: mcp-kubernetes
+    # keep — ClusterRoleBinding is cluster-scoped, so the Flux Kustomization's
+    # targetNamespace does not rewrite this field.
+    namespace: mcp
+---
+# Layer 2: the supplement defined at the top of this file.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -141,6 +133,5 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: *app
-    # keep — ClusterRoleBinding is cluster-scoped, so the Flux Kustomization's
-    # targetNamespace does not rewrite this field.
+    # keep — see note above.
     namespace: mcp

--- a/kubernetes/apps/mcp/mcp-kubernetes/app/rbac.yaml
+++ b/kubernetes/apps/mcp/mcp-kubernetes/app/rbac.yaml
@@ -1,0 +1,146 @@
+---
+# Read-only cluster access for the Kubernetes MCP server.
+#
+# get/list/watch only, cluster-wide. Deliberate omissions, so a future reader
+# knows these were decided rather than forgotten:
+#   secrets      the server masks values, but the token shouldn't read them at
+#                all. Side effect: Helm stores release metadata in Secrets, so
+#                the server's Helm tools won't work. Accepted.
+#   pods/exec    exec runs arbitrary code as the target pod, which would make
+#                this role's ceiling the most privileged pod in the cluster.
+#   rbac.*       no privilege enumeration.
+#   write verbs  the cluster is GitOps-managed; writes get reverted by Flux or
+#                cause drift.
+#
+# Adding an API group here widens the blast radius of any prompt injection that
+# reaches this server. Add per demonstrated need, not speculatively.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: &app mcp-kubernetes
+  labels:
+    app.kubernetes.io/instance: *app
+    app.kubernetes.io/name: *app
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+      - endpoints
+      - events
+      - limitranges
+      - namespaces
+      - nodes
+      - persistentvolumeclaims
+      - persistentvolumes
+      - pods
+      - pods/log
+      - replicationcontrollers
+      - resourcequotas
+      - serviceaccounts
+      - services
+    verbs: &readonly
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - daemonsets
+      - deployments
+      - replicasets
+      - statefulsets
+    verbs: *readonly
+  - apiGroups:
+      - batch
+    resources:
+      - cronjobs
+      - jobs
+    verbs: *readonly
+  - apiGroups:
+      - autoscaling
+    resources:
+      - horizontalpodautoscalers
+    verbs: *readonly
+  - apiGroups:
+      - policy
+    resources:
+      - poddisruptionbudgets
+    verbs: *readonly
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingresses
+      - networkpolicies
+    verbs: *readonly
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
+      - gateways
+      - grpcroutes
+      - httproutes
+    verbs: *readonly
+  - apiGroups:
+      - storage.k8s.io
+    resources:
+      - storageclasses
+      - volumeattachments
+    verbs: *readonly
+  - apiGroups:
+      - apiextensions.k8s.io
+    resources:
+      - customresourcedefinitions
+    verbs: *readonly
+  - apiGroups:
+      - metrics.k8s.io
+    resources:
+      - nodes
+      - pods
+    verbs: *readonly
+  # Flux state — "why hasn't my change landed" is the question this server will
+  # field most in a GitOps cluster. Enumerated rather than wildcarded so the
+  # grant stays legible when this file is copied for the next MCP server.
+  - apiGroups:
+      - source.toolkit.fluxcd.io
+    resources:
+      - buckets
+      - gitrepositories
+      - helmcharts
+      - helmrepositories
+      - ocirepositories
+    verbs: *readonly
+  - apiGroups:
+      - kustomize.toolkit.fluxcd.io
+    resources:
+      - kustomizations
+    verbs: *readonly
+  - apiGroups:
+      - helm.toolkit.fluxcd.io
+    resources:
+      - helmreleases
+    verbs: *readonly
+  - apiGroups:
+      - notification.toolkit.fluxcd.io
+    resources:
+      - alerts
+      - providers
+      - receivers
+    verbs: *readonly
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: &app mcp-kubernetes
+  labels:
+    app.kubernetes.io/instance: *app
+    app.kubernetes.io/name: *app
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: *app
+subjects:
+  - kind: ServiceAccount
+    name: *app
+    # keep — ClusterRoleBinding is cluster-scoped, so the Flux Kustomization's
+    # targetNamespace does not rewrite this field.
+    namespace: mcp

--- a/kubernetes/apps/mcp/mcp-kubernetes/ks.yaml
+++ b/kubernetes/apps/mcp/mcp-kubernetes/ks.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: mcp-kubernetes
+spec:
+  interval: 1h
+  path: ./kubernetes/apps/mcp/mcp-kubernetes/app
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: mcp
+  wait: false

--- a/kubernetes/apps/mcp/namespace.yaml
+++ b/kubernetes/apps/mcp/namespace.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: mcp
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled


### PR DESCRIPTION
First MCP server on the cluster, and the reference implementation the remaining ~dozen (Proxmox, Gmail, Excalidraw, Prometheus, Grafana, Playwright, n8n, HuggingFace, …) will be copied from. Consumers are Hermes and n8n in-cluster, plus Claude Desktop and the VS Code devcontainer on the LAN.

## What this adds

```
kubernetes/apps/mcp/
├── namespace.yaml            # mcp, prune disabled
├── kustomization.yaml        # namespace transformer + sops component
└── mcp-kubernetes/
    ├── ks.yaml
    └── app/{kustomization,ocirepository,helmrelease,rbac}.yaml
```

`flux159/mcp-server-kubernetes:v4.1.3` on app-template 5.0.1, serving Streamable HTTP on `/mcp`:3000 through the image's **native** transport — no stdio bridge needed for this one.

## The contract future MCP servers inherit

Every MCP app exposes **Streamable HTTP on `/mcp`, container port 3000**, with an unauthenticated health path for probes. That uniformity is what makes one template and one client-config shape cover all of them. Two archetypes fit behind it: native HTTP (this app) and stdio-bridged via `supergateway` for the npx/uvx-only servers, which is most of the remaining list.

## Security posture

Read-only ClusterRole, `get/list/watch` only, enumerated rather than wildcarded. Deliberate omissions, documented inline so the next reader knows they were decided and not forgotten:

| Omitted | Why |
|---|---|
| `secrets` | The server masks values, but the token shouldn't read them at all. Side effect: Helm keeps release metadata in Secrets, so the server's Helm tools won't work. Accepted. |
| `pods/exec` | Exec is arbitrary code as the target pod, which would make this role's ceiling the most privileged pod in the cluster. |
| `rbac.*` | No privilege enumeration. |
| write verbs | GitOps-managed cluster — writes get reverted by Flux or cause drift. |

`ALLOW_ONLY_READONLY_TOOLS=true` is a second lock on the same door: widening the ServiceAccount by mistake isn't sufficient to enable writes. `readOnlyRootFilesystem: true`, all capabilities dropped, `MASK_SECRETS=true`.

**Unauthenticated by design for phase 1**, internal-only and path-scoped to `/mcp`. With no NetworkPolicies in this cluster that means the whole LAN can reach it — an accepted blast radius for a read-only Kubernetes view, and explicitly *not* the posture the Proxmox or Gmail servers should ship with. The ladder from here is additive, not a redesign: `MCP_AUTH_TOKEN` (`X-MCP-AUTH`) from a SOPS secret → an Envoy `SecurityPolicy` file targeting the HTTPRoute → `envoy-external` + Cloudflare Access, per the guacamole runbook.

## Notes for review

- **Single-label hostname is load-bearing.** The wildcard cert is `["${SECRET_DOMAIN}", "*.${SECRET_DOMAIN}"]`, so `mcp-kubernetes.mcp.${SECRET_DOMAIN}` would fail TLS in every client. Applies repo-wide.
- **Hostname scheme is `mcp-<target>`.** The existing `obsidian-mcp.${SECRET_DOMAIN}` is a deliberate exception, not drift — an existing app that also exposes MCP, versus a purpose-built MCP server. It should be listed in the catalog when the docs land.
- **One replica, `Recreate`.** Streamable HTTP sessions are stateful and pod-pinned; a second replica needs sticky sessions the gateway doesn't provide.
- **TCP probes, not HTTP.** Upstream documents that health/readiness exist and are unauthenticated but never gives the paths. Probing the socket beats guessing a URL and shipping a pod that never goes ready.

## Verification

DNS from the Mac confirmed working against an existing internal hostname. YAML parses, every kustomization path resolves, `chartRef`↔`OCIRepository` names match, ServiceAccount matches the ClusterRoleBinding subject, port 3000 consistent across env/probe/service/route.

**Not rendered locally** — `kustomize` isn't installed in the worktree, so Flux Local here is the first real structural check. Treat its diff as the review artifact.

## Known follow-ups after first reconcile

1. `readOnlyRootFilesystem: true` is backed by an emptyDir at `/tmp` with `HOME=/tmp`, since the server shells out to kubectl and kubectl caches discovery under `$HOME/.kube`. If it writes somewhere else, the pod CrashLoops on a read-only filesystem — **find the path it wanted and mount that**, don't flip the flag.
2. `runAsNonRoot` is unset because the image's UID is unverified and guessing wrong yields a pod that never starts. Resolve with `kubectl -n mcp exec deploy/mcp-kubernetes -- id`, then pin it.
3. `DNS_REBINDING_ALLOWED_HOST` currently holds only the gateway hostname. Cluster-DNS callers (n8n, Hermes) send `mcp-kubernetes.mcp.svc.cluster.local` — untested whether that's accepted, or whether the var takes a list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
