### PR TITLE
feat(mcp): pin non-root UID on mcp-kubernetes

### DIFF
--- a/kubernetes/apps/mcp/mcp-kubernetes/app/helmrelease.yaml
+++ b/kubernetes/apps/mcp/mcp-kubernetes/app/helmrelease.yaml
@@ -84,18 +84,30 @@ spec:
               limits:
                 memory: 256Mi
 
-    # Creates the ServiceAccount named `mcp-kubernetes`; rbac.yaml binds it to a
-    # read-only ClusterRole. The mounted token is the server's credential — it
-    # uses in-cluster auth, which outranks every KUBECONFIG_* / K8S_* source.
+    # Creates the ServiceAccount named `mcp-kubernetes`; rbac.yaml binds it to
+    # the built-in `view` role plus a read-only supplement. The mounted token is
+    # the server's credential — it uses in-cluster auth, which outranks every
+    # KUBECONFIG_* / K8S_* source.
     serviceAccount:
       mcp-kubernetes: {}
 
     defaultPodOptions:
       automountServiceAccountToken: true
-      # runAsNonRoot is not set: the image's UID is unverified, and guessing
-      # wrong yields a pod that never starts. Resolve on first deploy with
-      #   kubectl -n mcp exec deploy/mcp-kubernetes -- id
-      # then pin runAsUser/runAsGroup here.
+      securityContext:
+        # UID/GID read off the running pod rather than guessed —
+        # `kubectl -n mcp exec deploy/mcp-kubernetes -- id` reports
+        # uid=1001(appuser) gid=1001(appuser). This is the image's own USER, so
+        # pinning it changes nothing at runtime; it just stops the pod from
+        # being *able* to start as root if a future image tag drops its USER.
+        runAsNonRoot: true
+        runAsUser: 1001
+        runAsGroup: 1001
+        # Not needed by the /tmp emptyDir, which kubelet already creates
+        # writable. Set so that a copy of this template which swaps in a PVC
+        # gets a mount the non-root user can write to without a second debug
+        # round-trip.
+        fsGroup: 1001
+        fsGroupChangePolicy: OnRootMismatch
 
     persistence:
       # Writable scratch for the kubectl discovery cache (see HOME above).


### PR DESCRIPTION
Follow-up to #407. Closes the last open item on the MCP reference app.

## What

`mcp-kubernetes` shipped without `runAsNonRoot` because the image's UID was unverified — and guessing wrong yields a pod that never starts, which is a bad trade for a manifest that gets copied. The app has since reconciled, so the value is measured rather than assumed:

```console
$ kubectl -n mcp exec deploy/mcp-kubernetes -- id
uid=1001(appuser) gid=1001(appuser) groups=1001(appuser)
```

```yaml
defaultPodOptions:
  automountServiceAccountToken: true
  securityContext:
    runAsNonRoot: true
    runAsUser: 1001
    runAsGroup: 1001
    fsGroup: 1001
    fsGroupChangePolicy: OnRootMismatch
```

## Why it's safe

1001 is the image's own `USER`, so this is a no-op at runtime — the pod already runs as `appuser`. What it buys is that the pod can no longer *start* as root if a future image tag drops its `USER` directive, and it clears the standing Security Scan finding on the app the next dozen MCP servers get copied from.

`fsGroup` isn't required by the `/tmp` emptyDir — kubelet already creates that writable, which is why `readOnlyRootFilesystem: true` works today. It's set so a copy of this template that swaps in a PVC gets a writable mount without a second debug round-trip. Matches existing idiom in `bookshelf`, `prowlarr`, `thanos` and `scanner-files`.

Also corrects a stale comment: `rbac.yaml` binds the ServiceAccount to the built-in `view` role plus a supplement, not a single ClusterRole.

## Verification

Live state confirmed on the merged #407 before writing this:

| Check | Result |
|---|---|
| `id` in running container | `uid=1001(appuser) gid=1001(appuser)` |
| Pod restarts | 0 — `readOnlyRootFilesystem: true` holds with `HOME=/tmp` |
| Container securityContext | unchanged (`allowPrivilegeEscalation: false`, `drop: [ALL]`) |

Not verified locally: the rendered Deployment. `kustomize` isn't installed in the worktree, so Flux Local is the structural gate — treat its diff as the review artifact.

Expected post-merge: pod recreates (`strategy: Recreate`), comes back as the same UID, `/mcp` keeps answering through `envoy-internal`.