### PR TITLE
fix(mcp): make mcp-kubernetes reachable from in-cluster clients

### DIFF
--- a/kubernetes/apps/mcp/mcp-kubernetes/app/helmrelease.yaml
+++ b/kubernetes/apps/mcp/mcp-kubernetes/app/helmrelease.yaml
@@ -44,16 +44,26 @@ spec:
               # what actually bounds this server's reach.
               ALLOW_ONLY_READONLY_TOOLS: "true"
               MASK_SECRETS: "true"
-              # Holds exactly ONE host and replaces the default allow-list —
-              # upstream wraps it as [value], with no comma splitting. The SDK
-              # compares the Host header by exact string (port included) and
-              # answers 403 "Invalid Host header" on a miss.
-              # Consequence: every client must reach this through the gateway
-              # hostname. Calling the Service directly at
-              # mcp-kubernetes.mcp.svc.cluster.local:3000 is rejected, so
-              # in-cluster clients (n8n, Hermes) hairpin out through
-              # envoy-internal like the external ones. One URL for all clients.
-              DNS_REBINDING_ALLOWED_HOST: mcp-kubernetes.${SECRET_DOMAIN}
+              # The server's Host allow-list holds exactly one value upstream
+              # (DNS_REBINDING_ALLOWED_HOST is wrapped as [value], no comma
+              # splitting), so it cannot cover both the gateway hostname and
+              # <svc>.<ns>.svc.cluster.local. This repo addresses every
+              # service-to-service call by Service DNS, and in-cluster pods
+              # can't resolve the gateway name anyway — CoreDNS forwards to
+              # 1.1.1.1/8.8.8.8, and internal-only hostnames exist only in
+              # k8s_gateway. So a single-value allow-list locks out n8n and
+              # Hermes no matter which value it holds.
+              #
+              # Turned off rather than worked around, because the check is
+              # redundant exactly where the threat is real: a rebinding attack
+              # arrives with Host: attacker.com, matches no HTTPRoute, and Envoy
+              # 404s it before this server sees the request. Pod IPs and
+              # ClusterIPs aren't reachable from a LAN browser at all. Envoy's
+              # hostname matching is the enforcement point; this was a second
+              # copy of it that only ever rejected legitimate callers.
+              #
+              # The server logs a startup warning about this. Expected.
+              DNS_REBINDING_PROTECTION: "false"
               # The server shells out to kubectl, which writes a discovery cache
               # under $HOME/.kube. Pointing HOME at the emptyDir below is what
               # lets readOnlyRootFilesystem stay true. In-cluster credentials


### PR DESCRIPTION
Follow-up to #407 / #408. Unblocks n8n and Hermes.

## The problem

Neither route into the server worked from inside the cluster. Verified from a pod:

| From a pod | Result |
|---|---|
| `mcp-kubernetes.mcp.svc.cluster.local:3000` | `403 Invalid Host header` |
| `mcp-kubernetes.${SECRET_DOMAIN}` | `NXDOMAIN` |

The second one is a bad assumption of mine from #407, corrected here. In-cluster pods never resolve the gateway hostname — CoreDNS forwards everything upstream with no stanza for the cluster domain:

```
forward . 1.1.1.1 8.8.8.8
```

Internal-only hostnames exist only in k8s_gateway (192.168.25.100), and nothing publishes them to Cloudflare because the route is on `envoy-internal`. So the "in-cluster clients hairpin out through the gateway" comment described a path that never worked. Only my Mac, sitting on the LAN behind the split-horizon resolver, could reach it.

The first is the server's own Host allow-list. Upstream wraps `DNS_REBINDING_ALLOWED_HOST` as `[value]` with no comma splitting, so one value can never cover both the gateway hostname and the Service DNS name — whichever it holds, the other side is locked out.

## The fix

```diff
-DNS_REBINDING_ALLOWED_HOST: mcp-kubernetes.${SECRET_DOMAIN}
+DNS_REBINDING_PROTECTION: "false"
```

Disabled rather than worked around, because the check is redundant exactly where the threat is real. A DNS rebinding attack arrives with `Host: attacker.com`, matches no HTTPRoute, and Envoy 404s it before this server sees the request. Pod IPs and ClusterIPs aren't reachable from a LAN browser at all. Envoy's hostname matching is the enforcement point — this was a second copy of it that only ever rejected legitimate callers.

## Addressing after this

Follows the convention already in the repo rather than inventing one — Service DNS for service-to-service (20+ instances, no exceptions; even cloudflare-tunnel reaches envoy-external that way), gateway hostname for workstation clients.

| Client | URL |
|---|---|
| n8n, Hermes (in-cluster) | `http://mcp-kubernetes.mcp.svc.cluster.local:3000/mcp` |
| Claude Desktop, devcontainer (LAN) | `https://mcp-kubernetes.${SECRET_DOMAIN}/mcp` |

## Notes for review

- The server logs a startup warning about the disabled protection. Expected, and the in-file comment explains why it's accepted.
- This is a template-level decision — every MCP server copied from this app inherits it. Revisit if one is ever exposed on `envoy-external`, where the threat model changes.
- Path-scoping on the HTTPRoute (`/mcp` only) and the read-only RBAC are unchanged. This does not widen what the server can do, only who can call it.

Post-merge check — should return `200` from a pod:

```
kubectl -n default run t --rm -i --restart=Never --image=curlimages/curl:8.11.1 --quiet -- \
  -sS -o /dev/null -w "%{http_code}\n" -X POST \
  http://mcp-kubernetes.mcp.svc.cluster.local:3000/mcp \
  -H 'Content-Type: application/json' \
  -H 'Accept: application/json, text/event-stream' \
  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'
```