### PR TITLE
fix(monitoring): stop Alertmanager blackholing alerts outside the monitoring namespace

### DIFF
--- a/kubernetes/apps/monitoring/kube-prometheus-stack/app/alertmanagerconfig.yaml
+++ b/kubernetes/apps/monitoring/kube-prometheus-stack/app/alertmanagerconfig.yaml
@@ -12,6 +12,21 @@ spec:
     groupWait: 30s
     groupInterval: 5m
     repeatInterval: 4h
+    # Required companion to alertmanagerConfigMatcherStrategy.type: None on the
+    # HelmRelease. Without that setting this route also carried an injected
+    # namespace="monitoring" matcher, which happened to exclude Watchdog. With
+    # the injection gone the route has no matchers left, so it matches
+    # everything — and because the operator inserts CR routes *before* the
+    # chart's own routes and sets continue: true, Watchdog would match here
+    # first and only then reach the chart's Watchdog-to-null route.
+    #
+    # Watchdog is the deadman's switch: it fires permanently by design. Left
+    # unmatched it would send a Telegram message every repeatInterval (4h),
+    # forever. Drop it explicitly.
+    matchers:
+      - name: alertname
+        value: Watchdog
+        matchType: "!="
   receivers:
     - name: telegram
       telegramConfigs:

--- a/kubernetes/apps/monitoring/kube-prometheus-stack/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/kube-prometheus-stack/app/helmrelease.yaml
@@ -111,6 +111,25 @@ spec:
     alertmanager:
       alertmanagerSpec:
         replicas: 1
+        # Without this, the operator defaults to OnNamespace and silently
+        # injects a namespace="monitoring" matcher into every route our
+        # AlertmanagerConfig CR contributes. Alerts are then only deliverable
+        # if they carry that exact label — which excludes every alert about a
+        # workload outside the monitoring namespace, and every alert whose
+        # expression aggregates the label away (all of prometheusrule-n8n.yaml
+        # uses sum() / sum by (workflow_id), so none of those alerts have a
+        # namespace label at all). Everything else fell through to the chart's
+        # root "null" receiver and was dropped. Verified 2026-08-08: all 10
+        # active alerts were reporting receivers: [null].
+        #
+        # This is a silent failure mode — Alertmanager reports no error, and
+        # the homelab-alerts Grafana dashboard still shows the alerts, so the
+        # path looks alive. To re-check delivery:
+        #   kubectl -n monitoring get --raw "/api/v1/namespaces/monitoring/\
+        #     services/kube-prometheus-stack-alertmanager:http-web/proxy/api/v2/alerts"
+        # Any alert listing receivers: [null] is being blackholed.
+        alertmanagerConfigMatcherStrategy:
+          type: None
         # Disable the chart's own podAntiAffinity convenience default (it
         # defaults to "soft" and renders its own podAntiAffinity block under
         # the same affinity key as our custom one below, which is a duplicate


### PR DESCRIPTION
## Problem

The `telegram` AlertmanagerConfig CR was only ever reachable by alerts labelled `namespace="monitoring"`. Nothing in this repo asks for that — the Prometheus Operator defaults `alertmanagerConfigMatcherStrategy.type` to `OnNamespace`, which **injects** a namespace matcher into every route a CR contributes.

From the live generated config:

```yaml
route:
  receiver: "null"
  routes:
  - receiver: monitoring/telegram/telegram
    matchers:
    - namespace="monitoring"        # injected by the operator, not authored here
    continue: true
  - receiver: "null"
    matchers: [alertname = "Watchdog"]
```

Everything else falls through to the chart's root `"null"` receiver and is dropped.

**Verified against the cluster: all 10 active alerts were reporting `receivers: [null]`** — `KubeJobFailed` (ns `default`/`storage`), `RecordingAnnotatorIndexBackupJobFailed` (ns `default`), `RecordingAnnotatorMediaReplicationNotConfigured` (no ns label), `Watchdog`.

Two classes are affected:

- Alerts for workloads outside `monitoring` (`ns=default`, `ns=storage`).
- Alerts whose expression aggregates the label away. Every rule in `prometheusrule-n8n.yaml` uses `sum(...)` or `sum by (workflow_id)(...)`, so **none of the n8n alerts carry a namespace label at all** and none could ever be delivered — including `N8nWorkflowFailed`, which that file's own comments document as the safety net around n8n's Error Trigger workflow.

It went unnoticed because monitoring-namespace alerts *do* get through, and the `homelab-alerts` Grafana dashboard shows alerts regardless of delivery — so the path looks alive.

## Fix

Two parts, both required in the same change.

1. **`alertmanagerConfigMatcherStrategy.type: None`** on `alertmanagerSpec`, so the route matches on what it actually declares.
2. **`alertname != "Watchdog"`** matcher on the CR route.

Part 1 alone is a regression. The operator inserts CR routes *ahead* of the chart's own routes with `continue: true`, so with the injected matcher gone the permanently-firing `Watchdog` deadman matches telegram first and only then reaches the chart's Watchdog-to-null route — a Telegram message every `repeat_interval` (4h), forever.

Rejected alternative: stamping `namespace: monitoring` labels onto the n8n rules. It would be false (n8n runs in `default`) and it corrupts the inhibit rules, which group on `equal: [namespace, alertname]`.

## Verification done

- `helm show values kube-prometheus-stack --version 88.0.1` — confirmed the values key exists and defaults to `{}` (falsy, hence omitted from the CR, hence the operator default won).
- `helm template` with this PR's values — Alertmanager CR now renders `alertmanagerConfigMatcherStrategy: {type: None}`.
- `AlertmanagerConfig` validated against the **live CRD schema**; `matchType: "!="` is in the enum.
- `kubectl kustomize` on the app directory builds.

Route ordering and `continue: true` above are read off the live generated config, not inferred.

## After merge

This bug class is silent, so confirm rather than assume:

```sh
kubectl -n monitoring get secret alertmanager-kube-prometheus-stack-alertmanager-generated \
  -o jsonpath='{.data.alertmanager\.yaml\.gz}' | base64 -d | gunzip
```

The telegram route's `matchers:` should show only `alertname!="Watchdog"` — no `namespace=`. (That output contains the plaintext bot token.)

```sh
kubectl -n monitoring get --raw \
  "/api/v1/namespaces/monitoring/services/kube-prometheus-stack-alertmanager:http-web/proxy/api/v2/alerts"
```

Anything still showing `receivers: [null]` is being dropped.

**Expect a burst of Telegram messages on first delivery.** Those 10 suppressed alerts are real and have been accumulating unseen — worth triaging rather than treating as noise from this change.

## Context

Found while wiring up a catch-all n8n Error Workflow that notifies the same Telegram chat. That workflow is configured in n8n directly and is not part of this repo; this PR is only the Alertmanager-side fix. The two notifiers are intended to run together — per-execution detail from n8n, metrics-side backstop from `N8nWorkflowFailed` — which is exactly the backstop that has never worked. Follow-on from #405.

🤖 Generated with [Claude Code](https://claude.com/claude-code)