### PR TITLE
fix(monitoring): drop unconsumed control-plane workqueue/client histograms

### DIFF
--- a/kubernetes/apps/monitoring/kube-prometheus-stack/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/kube-prometheus-stack/app/helmrelease.yaml
@@ -107,6 +107,36 @@ spec:
           - action: drop
             sourceLabels: [__name__]
             regex: etcd_request_duration_seconds_bucket
+          # apiserver's own readiness-probe histogram and the client-go feature-gate
+          # gauge — internal bookkeeping, not consumed by any dashboard or rule.
+          #
+          # workqueue_{work,queue}_duration_seconds_bucket: client-go workqueue
+          # instrumentation, one series set per controller name. No consumer found
+          # (grep kubernetes/apps/); _count/_sum are not dropped so rate/avg still work.
+          - action: drop
+            sourceLabels: [__name__]
+            regex: prober_probe_duration_seconds_bucket|kubernetes_feature_enabled|workqueue_work_duration_seconds_bucket|workqueue_queue_duration_seconds_bucket
+
+    # Not otherwise customized — chart defaults for scrape config are fine. This
+    # block exists only to drop the same client-go workqueue/feature-gate series
+    # kubeApiServer drops above; kube-scheduler emits them too under its own job,
+    # so the apiserver-scoped rule above does not catch them (see the 192-series
+    # leak noted in #358 for the same class of gap on the etcd/apiserver drops).
+    kubeScheduler:
+      serviceMonitor:
+        metricRelabelings:
+          - action: drop
+            sourceLabels: [__name__]
+            regex: kubernetes_feature_enabled|workqueue_work_duration_seconds_bucket|workqueue_queue_duration_seconds_bucket
+
+    # See kubeScheduler above — same client-go workqueue/feature-gate series,
+    # emitted by kube-controller-manager under its own job.
+    kubeControllerManager:
+      serviceMonitor:
+        metricRelabelings:
+          - action: drop
+            sourceLabels: [__name__]
+            regex: kubernetes_feature_enabled|workqueue_work_duration_seconds_bucket|workqueue_queue_duration_seconds_bucket
 
     alertmanager:
       alertmanagerSpec:

--- a/kubernetes/apps/network/envoy-gateway/app/podmonitor.yaml
+++ b/kubernetes/apps/network/envoy-gateway/app/podmonitor.yaml
@@ -21,6 +21,12 @@ spec:
             - envoy_cluster_name
             - socket_match_name
           regex: envoy_cluster_total_match_count;httproute/default/knative-smoke;default
+        # Per-cluster config-update-duration histogram — not consumed by any
+        # dashboard or PrometheusRule (see #358). _count/_sum are not dropped,
+        # so rate/avg queries still work.
+        - action: drop
+          sourceLabels: [__name__]
+          regex: envoy_cluster_update_duration_bucket
   selector:
     matchLabels:
       app.kubernetes.io/component: proxy

--- a/kubernetes/apps/storage/longhorn-system/app/servicemonitor.yaml
+++ b/kubernetes/apps/storage/longhorn-system/app/servicemonitor.yaml
@@ -16,3 +16,11 @@ spec:
   endpoints:
     - port: manager
       interval: 30s
+      metricRelabelings:
+        # longhorn-manager's internal REST client histograms (calls between
+        # manager instances, plus its own workqueue instrumentation) — not
+        # consumed by any dashboard or PrometheusRule (see #358).
+        # _count/_sum are not dropped, so rate/avg queries still work.
+        - action: drop
+          sourceLabels: [__name__]
+          regex: longhorn_rest_client_rate_limiter_latency_seconds_bucket|longhorn_rest_client_request_latency_seconds_bucket|longhorn_workqueue_work_duration_seconds_bucket|longhorn_workqueue_queue_duration_seconds_bucket


### PR DESCRIPTION
## Summary

- Progress on #358: head series re-measured at 254,058, up from the 234,707 baseline despite prior apiserver/etcd drops — new scrape targets outpacing existing cuts.
- Extends `kubeApiServer` drop and adds `kubeScheduler`/`kubeControllerManager` blocks for client-go workqueue and feature-gate series (same job the apiserver-only rule doesn't reach, mirroring the 192-series leak also found in this pass).
- Adds `metricRelabelings` to Longhorn's ServiceMonitor (internal REST-client/workqueue histograms) and extends Envoy's PodMonitor (cluster-update-duration histogram).
- All targets confirmed zero dashboard/PrometheusRule consumers via `grep -rn <metric> kubernetes/apps/monitoring/`. `_count`/`_sum` variants retained everywhere, so rate/avg queries are unaffected — only percentile/`histogram_quantile()` shape on internal control-plane self-instrumentation is lost.
- Targets ~27.8k series (~11% of current head).

## Test plan

- [x] YAML parses (`python3 -c "yaml.safe_load_all(...)"` on all three files)
- [ ] Flux Local diff on this PR renders cleanly
- [ ] After merge, re-check `/api/v1/status/tsdb` `headStats.numSeries` — expect drop from 254,058 toward ~226k
- [ ] Spot-check Grafana dashboards (API Server, Longhorn, Envoy) unaffected

Related: #358

🤖 Generated with [Claude Code](https://claude.com/claude-code)