### PR TITLE
feat(mcp): add onboarding template, scaffold task and docs

### DIFF
--- a/.taskfiles/mcp/Taskfile.yaml
+++ b/.taskfiles/mcp/Taskfile.yaml
@@ -1,0 +1,61 @@
+---
+# yaml-language-server: $schema=https://taskfile.dev/schema.json
+version: "3"
+
+vars:
+  # Quoted at every use site — a checkout path containing a space would
+  # otherwise split into two arguments.
+  MCP_NEW_SCRIPT: "{{.ROOT_DIR}}/scripts/mcp-new.sh"
+  MCP_PROBE_SCRIPT: "{{.ROOT_DIR}}/scripts/mcp-probe.sh"
+  MCP_APPS_DIR: "{{.ROOT_DIR}}/kubernetes/apps/mcp"
+
+tasks:
+
+  new:
+    desc: Scaffold a new MCP server app under kubernetes/apps/mcp
+    summary: |
+      Args:
+        name:      app name (required). The mcp- prefix is added if absent, so
+                   `name=proxmox` and `name=mcp-proxmox` both yield mcp-proxmox.
+        archetype: native-http (default) or stdio.
+                   native-http — the upstream image speaks Streamable HTTP.
+                   stdio       — supergateway wraps a stdio-only server.
+                                 UNVERIFIED; no app uses it yet.
+
+      Generates the app directory and registers it in the namespace group.
+      The result is not deployable as-is: every TODO marker must be resolved
+      first. See docs/mcp-onboarding.md.
+
+      Examples:
+        task mcp:new name=proxmox
+        task mcp:new name=playwright archetype=stdio
+    requires:
+      vars: [name]
+    cmd: bash "{{.MCP_NEW_SCRIPT}}" "{{.name}}" "{{.archetype | default `native-http`}}" "{{.ROOT_DIR}}"
+    preconditions:
+      - { msg: "Missing scaffold script", sh: 'test -f "{{.MCP_NEW_SCRIPT}}"' }
+      - { msg: "Missing mcp namespace group", sh: 'test -d "{{.MCP_APPS_DIR}}"' }
+
+  todo:
+    desc: List unresolved TODO markers across MCP apps
+    summary: |
+      Scaffolded apps ship with TODO markers for the things that cannot be
+      filled in from the desk — image tag, transport env vars, and the UID pin
+      that is only knowable after the first deploy. This finds the stragglers.
+    cmd: grep -rn "TODO" "{{.MCP_APPS_DIR}}" || echo "No TODO markers — all MCP apps are fully configured."
+
+  probe:
+    desc: Check every MCP endpoint in the cluster over its in-cluster Service
+    summary: |
+      Runs a throwaway curl pod and calls tools/list on each MCP Service, which
+      exercises DNS, the Service, the transport and the server's own health in
+      one shot. Uses Service DNS rather than the gateway hostname because
+      in-cluster pods cannot resolve internal-only hostnames — CoreDNS forwards
+      to public resolvers and those records live only in k8s_gateway.
+
+      Expects HTTP 200 from each. A 406 means the Accept header was lost; a 403
+      means a host allow-list is rejecting the Service DNS name.
+    cmd: bash "{{.MCP_PROBE_SCRIPT}}"
+    preconditions:
+      - { msg: "Missing kubeconfig", sh: 'test -f "{{.KUBECONFIG}}"' }
+      - { msg: "Missing probe script", sh: 'test -f "{{.MCP_PROBE_SCRIPT}}"' }

--- a/.taskfiles/mcp/resources/native-http/app/helmrelease.yaml
+++ b/.taskfiles/mcp/resources/native-http/app/helmrelease.yaml
@@ -1,0 +1,131 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+#
+# MCP server, "native HTTP" archetype: the upstream image speaks Streamable
+# HTTP itself. Reference implementation: kubernetes/apps/mcp/mcp-kubernetes.
+# Read docs/mcp-onboarding.md before editing — the port, path and hostname are
+# a contract shared by every MCP server, not per-app choices.
+#
+# TODO markers below are the ones you cannot fill in from the desk; each says
+# how to resolve it.
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app __APP__
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: *app
+  interval: 1h
+  values:
+    controllers:
+      main:
+        # One replica by default because MCP traffic is low, not because of a
+        # transport constraint. Check before raising it: a server that issues
+        # session IDs needs sticky sessions the gateway does not provide, while
+        # a stateless one (fresh transport per request) scales fine.
+        replicas: 1
+        strategy: Recreate
+        containers:
+          app:
+            image:
+              # TODO: pin a specific tag, never `latest` — Renovate tracks tags.
+              repository: TODO
+              tag: TODO
+            env:
+              # The contract: HTTP on 3000, MCP at /mcp. Keep these three even
+              # if upstream defaults match — they document the contract, and
+              # they are what the probes, Service and route below anchor to.
+              HOST: 0.0.0.0
+              PORT: &port 3000
+              TZ: ${TIMEZONE}
+              # TODO: whatever the image needs to select Streamable HTTP and
+              # its path. Names vary wildly between servers — read the image's
+              # source, don't assume. Watch for two traps seen already:
+              #   * a "host allow-list" / DNS-rebinding check that accepts only
+              #     ONE value. It cannot cover both the gateway hostname and
+              #     <svc>.mcp.svc.cluster.local, so it locks out either the
+              #     workstation clients or the in-cluster ones. Envoy's
+              #     HTTPRoute hostname matching already rejects the attack it
+              #     defends against, so turning it off is usually correct.
+              #   * a read-only / non-destructive toggle. Prefer the strictest
+              #     one; they are not synonyms.
+            probes:
+              # TCP by default: MCP servers rarely document a health path, and
+              # /mcp itself is a POST endpoint that 406s a bare GET. Swap to
+              # httpGet once you have confirmed a real health path exists.
+              liveness: &probes
+                enabled: true
+                custom: true
+                spec:
+                  tcpSocket:
+                    port: *port
+                  initialDelaySeconds: 10
+                  periodSeconds: 10
+                  timeoutSeconds: 3
+                  failureThreshold: 3
+              readiness: *probes
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: { drop: ["ALL"] }
+            resources:
+              requests:
+                cpu: 10m
+                memory: 64Mi
+              limits:
+                memory: 256Mi
+
+    defaultPodOptions:
+      # No ServiceAccount token unless the server actually calls the Kubernetes
+      # API. If it does, add rbac.yaml and set this true.
+      automountServiceAccountToken: false
+      # TODO: pin the image's UID after the first deploy. Do NOT guess — a wrong
+      # value yields a pod that never starts. Deploy without this block, then:
+      #   kubectl -n mcp exec deploy/__APP__ -- id
+      # and fill in the reported uid/gid:
+      # securityContext:
+      #   runAsNonRoot: true
+      #   runAsUser: <uid>
+      #   runAsGroup: <gid>
+      #   fsGroup: <gid>
+      #   fsGroupChangePolicy: OnRootMismatch
+
+    persistence:
+      # Writable scratch so readOnlyRootFilesystem can stay true. app-template
+      # mounts an unqualified volume at /<name>, so this lands on /tmp. If the
+      # server crashes on a read-only filesystem, find the path it wanted and
+      # mount that as well — never flip readOnlyRootFilesystem to false.
+      tmp:
+        type: emptyDir
+
+    service:
+      main:
+        controller: main
+        ports:
+          http:
+            port: *port
+
+    route:
+      main:
+        # Single-label hostname is required, not stylistic: the wildcard cert is
+        # ["${SECRET_DOMAIN}", "*.${SECRET_DOMAIN}"] and does not cover a second
+        # label, so __APP__.mcp.${SECRET_DOMAIN} fails TLS in every client.
+        hostnames: ["__APP__.${SECRET_DOMAIN}"]
+        parentRefs:
+          # envoy-internal unless the server is deliberately public. Anything on
+          # envoy-external must carry auth first — see the ladder in
+          # docs/mcp-onboarding.md.
+          - name: envoy-internal
+            namespace: network
+            sectionName: https
+        rules:
+          # Path-scoped: phase-1 endpoints are unauthenticated, so only the MCP
+          # endpoint should be reachable. Widen only for a client that needs
+          # /.well-known OAuth discovery.
+          - matches:
+              - path:
+                  value: /mcp
+            backendRefs:
+              - identifier: main
+                port: *port

--- a/.taskfiles/mcp/resources/native-http/app/kustomization.yaml
+++ b/.taskfiles/mcp/resources/native-http/app/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml
+  # - ./rbac.yaml          # only if the server talks to the Kubernetes API
+  # - ./secret.sops.yaml   # upstream credentials, SOPS-encrypted

--- a/.taskfiles/mcp/resources/native-http/app/ocirepository.yaml
+++ b/.taskfiles/mcp/resources/native-http/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: __APP__
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/.taskfiles/mcp/resources/native-http/ks.yaml
+++ b/.taskfiles/mcp/resources/native-http/ks.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: __APP__
+spec:
+  interval: 1h
+  path: ./kubernetes/apps/mcp/__APP__/app
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: mcp
+  wait: false

--- a/.taskfiles/mcp/resources/stdio/app/helmrelease.yaml
+++ b/.taskfiles/mcp/resources/stdio/app/helmrelease.yaml
@@ -1,0 +1,134 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+#
+# MCP server, "stdio bridged" archetype: the upstream server speaks stdio only,
+# so supergateway fronts it with Streamable HTTP.
+#
+# UNVERIFIED ARCHETYPE. No app in this repo uses it yet. The flags below are
+# taken from supergateway's README, but nothing here has been run against a
+# real server — expect to debug the first one, and update this template with
+# what you learn. The native-HTTP archetype is the proven one.
+#
+# supergateway is NOT a sidecar. It launches the stdio server as a child
+# process inside its own container, because stdio cannot cross a container
+# boundary. Two consequences worth understanding before choosing this path:
+#   * `npx -y pkg@ver` fetches from npmjs.org at pod start, so cold starts
+#     depend on an external registry being up, and a crashloop can turn into a
+#     download loop.
+#   * the version pin lives inside an argument string, not an image tag, so
+#     Renovate does not see it. Pin it and bump it by hand.
+# If either bites, build a thin per-server image instead (see the containers/
+# directory pattern) and use the native-http archetype against it.
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app __APP__
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: *app
+  interval: 1h
+  values:
+    controllers:
+      main:
+        # Real constraint here, unlike the native-http template: --stateful
+        # makes supergateway keep per-session state in memory, so a second
+        # replica would need sticky sessions the gateway does not provide.
+        # Drop --stateful below if the wrapped server tolerates it, and this
+        # becomes a load decision again.
+        replicas: 1
+        strategy: Recreate
+        containers:
+          app:
+            image:
+              repository: ghcr.io/supercorp-ai/supergateway
+              # TODO: pin a real tag. Renovate tracks this one.
+              tag: TODO
+            args:
+              # TODO: the wrapped server and its pinned version. Renovate cannot
+              # see this string — bump it by hand.
+              - --stdio
+              - "npx -y @modelcontextprotocol/server-TODO@0.0.0"
+              - --outputTransport
+              - streamableHttp
+              # Both are supergateway defaults; stated explicitly because they
+              # are the cluster-wide MCP contract, not this app's preference.
+              - --streamableHttpPath
+              - /mcp
+              - --port
+              - "3000"
+              - --stateful
+            env:
+              TZ: ${TIMEZONE}
+              # npx writes into $HOME/.npm at startup. Both must point at the
+              # emptyDir below or the container dies immediately under
+              # readOnlyRootFilesystem — this is the single most likely reason
+              # a first deploy of this archetype crashloops.
+              HOME: /tmp
+              npm_config_cache: /tmp/.npm
+            probes:
+              # Startup is slow and variable here: the npm download happens
+              # before anything listens. Generous failureThreshold on the
+              # liveness probe so a slow registry doesn't cause a restart loop.
+              liveness: &probes
+                enabled: true
+                custom: true
+                spec:
+                  tcpSocket:
+                    port: &port 3000
+                  initialDelaySeconds: 30
+                  periodSeconds: 10
+                  timeoutSeconds: 3
+                  failureThreshold: 6
+              readiness: *probes
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: { drop: ["ALL"] }
+            resources:
+              requests:
+                cpu: 10m
+                # Higher floor than native-http: a node runtime plus an npm
+                # install at boot needs more than a compiled server does.
+                memory: 128Mi
+              limits:
+                memory: 512Mi
+
+    defaultPodOptions:
+      automountServiceAccountToken: false
+      # TODO: pin after first deploy — `kubectl -n mcp exec deploy/__APP__ -- id`
+      # securityContext:
+      #   runAsNonRoot: true
+      #   runAsUser: <uid>
+      #   runAsGroup: <gid>
+      #   fsGroup: <gid>
+      #   fsGroupChangePolicy: OnRootMismatch
+
+    persistence:
+      # Holds both $HOME and the npm cache (see env above).
+      tmp:
+        type: emptyDir
+
+    service:
+      main:
+        controller: main
+        ports:
+          http:
+            port: *port
+
+    route:
+      main:
+        # Single-label hostname is required — the wildcard cert does not cover
+        # a second label. See the native-http template for the full note.
+        hostnames: ["__APP__.${SECRET_DOMAIN}"]
+        parentRefs:
+          - name: envoy-internal
+            namespace: network
+            sectionName: https
+        rules:
+          - matches:
+              - path:
+                  value: /mcp
+            backendRefs:
+              - identifier: main
+                port: *port

--- a/.taskfiles/mcp/resources/stdio/app/kustomization.yaml
+++ b/.taskfiles/mcp/resources/stdio/app/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml
+  # - ./rbac.yaml          # only if the server talks to the Kubernetes API
+  # - ./secret.sops.yaml   # upstream credentials, SOPS-encrypted

--- a/.taskfiles/mcp/resources/stdio/app/ocirepository.yaml
+++ b/.taskfiles/mcp/resources/stdio/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: __APP__
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/.taskfiles/mcp/resources/stdio/ks.yaml
+++ b/.taskfiles/mcp/resources/stdio/ks.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: __APP__
+spec:
+  interval: 1h
+  path: ./kubernetes/apps/mcp/__APP__/app
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: mcp
+  wait: false

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -22,6 +22,7 @@ env:
 includes:
   bootstrap: .taskfiles/bootstrap
   crd: .taskfiles/crd
+  mcp: .taskfiles/mcp
   talos: .taskfiles/talos
   template: .taskfiles/template
   sops: .taskfiles/sops

--- a/docs/mcp-onboarding.md
+++ b/docs/mcp-onboarding.md
@@ -1,0 +1,230 @@
+# MCP server onboarding
+
+How to run a [Model Context Protocol](https://modelcontextprotocol.io) server in
+this cluster so that n8n, Hermes, Claude Desktop and VS Code devcontainers can
+all consume it. The goal is that adding the tenth MCP server is a copy, not a
+design exercise — so most of this document is the contract those servers share
+and the traps that cost real debugging time on the first one.
+
+Reference implementation: `kubernetes/apps/mcp/mcp-kubernetes/`. It is the app to
+copy from, and every claim in this document was verified against it running.
+
+## Quickstart
+
+```sh
+task mcp:new name=proxmox                    # native-http archetype (default)
+task mcp:new name=playwright archetype=stdio # supergateway-wrapped stdio server
+```
+
+That scaffolds `kubernetes/apps/mcp/mcp-<name>/` and registers it in the
+namespace group. The result is **not deployable as-is** — it ships `TODO`
+markers for the things that cannot be known from the desk:
+
+```sh
+task mcp:todo   # list unresolved markers across all MCP apps
+```
+
+Then open a PR. Flux Local's diff is the real gate; there is no unit-test suite.
+
+## The contract
+
+Every MCP server in this cluster honours the same shape. The uniformity is the
+whole point — one template and one client-config shape cover all of them.
+
+| Thing | Value | Why fixed |
+|---|---|---|
+| Transport | Streamable HTTP | The one all four clients speak |
+| Container port | `3000` | Arbitrary but shared, so probes/Service/route templates never change |
+| MCP path | `/mcp` | HTTPRoute is path-scoped to it |
+| Hostname | `mcp-<target>.${SECRET_DOMAIN}` | Single label — see below |
+| Gateway | `envoy-internal` | Public exposure requires auth first |
+| Namespace | `mcp` | One group for all of them |
+
+Directory name, app name, Service name, `chartRef` and hostname are all the same
+string (`mcp-proxmox`), so there is nothing to keep in sync.
+
+**`obsidian-mcp.${SECRET_DOMAIN}` is a deliberate exception**, not drift. It is an
+existing app that also exposes an MCP endpoint — a different category from a
+purpose-built MCP server. Don't "fix" it to match.
+
+## Archetypes
+
+**`native-http`** — the upstream image speaks Streamable HTTP itself. Preferred:
+Renovate tracks the image tag normally, and startup depends on nothing external.
+`mcp-kubernetes` is this, and it is the proven path.
+
+**`stdio`** — the server speaks stdio only, so `supergateway` fronts it.
+**Unverified: no app in this repo uses it yet.** Two things to understand before
+choosing it:
+
+- supergateway is **not a sidecar**. It launches the stdio server as a child
+  process inside its own container, because stdio cannot cross a container
+  boundary.
+- `npx -y pkg@ver` fetches from npmjs.org at pod start. Cold starts depend on an
+  external registry, and the version pin lives in an argument string where
+  Renovate cannot see it.
+
+If either bites, build a thin per-server image (see the `containers/` pattern)
+and use `native-http` against it instead.
+
+## Client wiring
+
+There are two URLs, not one. This is not a preference — in-cluster pods **cannot
+resolve** the gateway hostname:
+
+```
+# kubectl -n kube-system get cm coredns -o jsonpath='{.data.Corefile}'
+forward . 1.1.1.1 8.8.8.8
+```
+
+CoreDNS forwards everything to public resolvers, and internal-only hostnames
+exist only in k8s_gateway (192.168.25.100), unpublished to Cloudflare because
+the route is on `envoy-internal`. A pod asking for `mcp-kubernetes.${SECRET_DOMAIN}`
+gets `NXDOMAIN`.
+
+| Client | URL |
+|---|---|
+| n8n, Hermes (in-cluster) | `http://mcp-<name>.mcp.svc.cluster.local:3000/mcp` |
+| Claude Desktop, devcontainer (LAN) | `https://mcp-<name>.${SECRET_DOMAIN}/mcp` |
+
+Service DNS in-cluster matches what every other service-to-service call in this
+repo already does — there are 20+ instances and no exceptions.
+
+## Security posture
+
+Phase 1 is **internal-only and unauthenticated, by explicit choice**. Worth being
+precise about what that means: this cluster has effectively no NetworkPolicies,
+so "internal-only" means the whole LAN plus every pod. That is an acceptable
+trade for a read-only Kubernetes view. It is **not** acceptable for Proxmox or
+Gmail — those should ship at step 2 or later of the ladder below.
+
+### Auth ladder
+
+Each step is an added file, not a redesign. Nothing about phase 1 forecloses them.
+
+1. **None.** Internal-only, path-scoped route. Where we are.
+2. **App-level token.** Most servers support one (`MCP_AUTH_TOKEN` +
+   `X-MCP-AUTH` in `mcp-server-kubernetes`), read from a SOPS secret.
+   **Claude Desktop breaks here** — its connector UI has no custom-header field,
+   so it needs an `mcp-remote` bridge from this step on.
+3. **Envoy `SecurityPolicy`** targeting the HTTPRoute (apiKeyAuth / JWT / OIDC /
+   extAuth). Moves auth off the app and in front of it.
+4. **`envoy-external` + Cloudflare Access.** See
+   `docs/runbook-guacamole-cloudflare-access.md` for the established pattern.
+
+### RBAC, for servers that call the Kubernetes API
+
+Only `mcp-kubernetes` needs this today, but the reasoning generalises to any MCP
+server holding credentials to something.
+
+Its readonly mode leaves eight tools — `kubectl_get`, `kubectl_describe`,
+`kubectl_logs`, `kubectl_context`, `kubectl_reconnect`, `explain_resource`,
+`list_api_resources`, `ping` — and they are **generic over resource type**. So the
+ClusterRole is the server's entire capability surface, not a supplement to a
+fixed tool list. Anything omitted answers `Forbidden`.
+
+Scope is built in two layers:
+
+1. Bind the built-in **`view`** ClusterRole. It is `get`/`list`/`watch` only and
+   excludes `secrets`, `pods/exec`, `pods/attach` and `pods/portforward` — every
+   omission we wanted anyway. It also picks up the `aggregate-to-view` roles
+   shipped by cert-manager, flux, flux-operator, knative and mariadb-operator.
+2. A **supplement ClusterRole** for what `view` cannot reach: cluster-scoped kinds
+   (nodes, PVs, storage, CRDs, ClusterIssuer) and the vendor CRD groups whose
+   charts ship no aggregate-to-view role — Longhorn, Cilium, Prometheus, Envoy
+   Gateway, external-dns, Multus, Knative operator, flux-operator's own
+   `FluxInstance`/`FluxReport`.
+
+Accepted trade-off: `view` widens on its own when a new operator ships an
+aggregate-to-view role, so read access can grow without a PR here. Chosen over
+hand-enumerating ~20 API groups that go stale on every operator install. The
+first draft did exactly that and covered 5 of the cluster's 22 CRD groups.
+
+Convention: name `apiGroups` explicitly, never `*`. `resources: ["*"]` within a
+single named vendor group is fine — `view` itself does this.
+
+## Known traps
+
+All of these were hit for real on the first server.
+
+**Hostnames must be single-label.** The wildcard cert is
+`["${SECRET_DOMAIN}", "*.${SECRET_DOMAIN}"]`, which does not cover a second
+label. `anything.mcp.${SECRET_DOMAIN}` fails TLS in every client. Applies
+repo-wide, not just to MCP.
+
+**`Accept` must list both media types.** Responses are SSE. Omit
+`text/event-stream` and you get a bare `406` with no explanation:
+
+```sh
+curl -sS -X POST https://mcp-kubernetes.${SECRET_DOMAIN}/mcp \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: application/json, text/event-stream' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'
+```
+
+**Host allow-lists take one value and lock out half your clients.**
+`mcp-server-kubernetes` wraps `DNS_REBINDING_ALLOWED_HOST` as `[value]` with no
+comma splitting, and the MCP SDK compares the `Host` header by exact string
+including port, returning `403 Invalid Host header`. One value cannot cover both
+the gateway hostname and the Service DNS name. We disable the check
+(`DNS_REBINDING_PROTECTION: "false"`) because it is redundant where the threat is
+real: a rebinding attack arrives with `Host: attacker.com`, matches no HTTPRoute,
+and Envoy 404s it before the server sees it. Check for an equivalent setting on
+every new image.
+
+**Don't guess the container UID.** A wrong `runAsUser` yields a pod that never
+starts. Deploy without it, then read it off the running pod and pin it:
+
+```sh
+kubectl -n mcp exec deploy/mcp-<name> -- id
+```
+
+**Don't disable `readOnlyRootFilesystem`.** If the server needs scratch, find the
+path it wanted and mount it. `mcp-kubernetes` shells out to kubectl, which writes
+a discovery cache under `$HOME/.kube`; `persistence.tmp: {type: emptyDir}` plus
+`HOME: /tmp` solves it. app-template mounts an unqualified volume at `/<name>`.
+
+**Streamable HTTP does not necessarily pin sessions.** `mcp-server-kubernetes`
+leaves `sessionIdGenerator` undefined, so it is stateless and would scale
+horizontally; `replicas: 1` there is a load decision. supergateway with
+`--stateful` is the opposite — one replica is a real constraint. Verify per image
+rather than copying either comment.
+
+**Templates live outside `kubernetes/`.** `scripts/kubeconform.sh` runs
+`kustomize build` on every directory under `kubernetes/apps` containing a
+`kustomization.yaml`, so placeholder manifests there would break `task validate`.
+They live in `.taskfiles/mcp/resources/` instead.
+
+## Verifying
+
+```sh
+task mcp:probe   # tools/list against every MCP Service, over in-cluster DNS
+```
+
+Expects `200` from each. A `406` means the `Accept` header was lost; a `403`
+means a host allow-list is rejecting the Service DNS name.
+
+For a server that reaches the Kubernetes API, the end-to-end check is a real
+query — it exercises RBAC, the ServiceAccount token and the transport at once:
+
+```sh
+curl -sS -X POST https://mcp-kubernetes.${SECRET_DOMAIN}/mcp \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: application/json, text/event-stream' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"kubectl_get","arguments":{"resourceType":"nodes","output":"name"}}}'
+```
+
+To check what a ServiceAccount may read, query the group rather than the kind —
+wildcard grants print as `*.<group>`, so grepping for a resource name finds
+nothing even when access works:
+
+```sh
+kubectl auth can-i --list --as=system:serviceaccount:mcp:mcp-kubernetes | grep longhorn
+```
+
+## Catalog
+
+| App | Archetype | Auth | Notes |
+|---|---|---|---|
+| `mcp/mcp-kubernetes` | native-http | none (phase 1) | Read-only cluster access |
+| `default/obsidian` | — | none | Existing app exposing `/mcp` at `obsidian-mcp.${SECRET_DOMAIN}` |

--- a/scripts/mcp-new.sh
+++ b/scripts/mcp-new.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# Scaffold a new MCP server app under kubernetes/apps/mcp/.
+#
+# Copies one of the archetype templates in .taskfiles/mcp/resources/, renames
+# __APP__ throughout, and registers the app in the mcp namespace group's
+# kustomization.yaml. It deliberately does not commit or reconcile anything —
+# the generated manifests still contain TODO markers that only a human (or an
+# agent reading the upstream image) can resolve.
+#
+# Invoked via: task mcp:new name=<name> [archetype=native-http|stdio]
+set -o errexit
+set -o nounset
+set -o pipefail
+
+NAME="${1:-}"
+ARCHETYPE="${2:-native-http}"
+REPO_ROOT="${3:-$(git rev-parse --show-toplevel)}"
+
+RESOURCES_DIR="${REPO_ROOT}/.taskfiles/mcp/resources"
+GROUP_DIR="${REPO_ROOT}/kubernetes/apps/mcp"
+GROUP_KUSTOMIZATION="${GROUP_DIR}/kustomization.yaml"
+
+die() { echo "error: $*" >&2; exit 1; }
+
+[[ -n "${NAME}" ]] || die "name is required (task mcp:new name=proxmox)"
+
+# The mcp- prefix is the repo convention, so accept either form and normalise.
+# Directory name, app name, Service name and hostname are all the same string.
+NAME="${NAME#mcp-}"
+APP="mcp-${NAME}"
+
+# RFC 1123 label: hostnames derive directly from this, and the wildcard cert
+# only covers a single label, so an invalid name fails late and confusingly.
+[[ "${APP}" =~ ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$ ]] \
+  || die "'${APP}' is not a valid RFC 1123 label (lowercase alphanumerics and '-')"
+[[ ${#APP} -le 63 ]] || die "'${APP}' exceeds 63 characters"
+
+[[ -d "${RESOURCES_DIR}/${ARCHETYPE}" ]] \
+  || die "unknown archetype '${ARCHETYPE}' (expected: native-http, stdio)"
+[[ -f "${GROUP_KUSTOMIZATION}" ]] \
+  || die "missing ${GROUP_KUSTOMIZATION} — is the mcp namespace group present?"
+
+DEST="${GROUP_DIR}/${APP}"
+[[ ! -e "${DEST}" ]] || die "${DEST} already exists — remove it or pick another name"
+
+cp -R "${RESOURCES_DIR}/${ARCHETYPE}" "${DEST}"
+
+# Rename the placeholder. Kept as a distinctive token so it cannot collide with
+# Flux post-build variables like ${SECRET_DOMAIN}, which must survive verbatim.
+while IFS= read -r -d '' file; do
+  # BSD and GNU sed disagree on -i; write to a temp file to work on both.
+  sed "s/__APP__/${APP}/g" "${file}" > "${file}.tmp" && mv "${file}.tmp" "${file}"
+done < <(find "${DEST}" -type f -name '*.yaml' -print0)
+
+ENTRY="  - ./${APP}/ks.yaml"
+if grep -qF "${ENTRY}" "${GROUP_KUSTOMIZATION}"; then
+  echo "already registered in $(basename "${GROUP_KUSTOMIZATION}"): ${ENTRY}"
+else
+  # Append to the resources list, then sort just the ./<app>/ks.yaml lines so
+  # the file stays alphabetised without disturbing ./namespace.yaml at the top.
+  printf '%s\n' "${ENTRY}" >> "${GROUP_KUSTOMIZATION}"
+  awk -v out="${GROUP_KUSTOMIZATION}.tmp" '
+    /^  - \.\/.*\/ks\.yaml$/ { ks[n++] = $0; next }
+    { print > out }
+    END {
+      # asort() is a gawk extension; insertion sort keeps this portable.
+      for (i = 0; i < n; i++) {
+        v = ks[i]; j = i - 1
+        while (j >= 0 && ks[j] > v) { ks[j+1] = ks[j]; j-- }
+        ks[j+1] = v
+      }
+      for (i = 0; i < n; i++) print ks[i] > out
+    }
+  ' "${GROUP_KUSTOMIZATION}"
+  mv "${GROUP_KUSTOMIZATION}.tmp" "${GROUP_KUSTOMIZATION}"
+  echo "registered in $(basename "${GROUP_KUSTOMIZATION}"): ${ENTRY}"
+fi
+
+echo
+echo "Scaffolded ${APP} (${ARCHETYPE}) at kubernetes/apps/mcp/${APP}"
+echo
+echo "Next:"
+echo "  1. grep -rn TODO kubernetes/apps/mcp/${APP}   # resolve every marker"
+echo "  2. read docs/mcp-onboarding.md                # contract + known traps"
+echo "  3. kustomize build kubernetes/apps/mcp/${APP}/app"
+echo "  4. open a PR — Flux Local's diff is the real gate"
+echo
+echo "The UID pin and any host-allow-list setting can only be resolved after"
+echo "the first deploy. Both are marked TODO in the HelmRelease."

--- a/scripts/mcp-probe.sh
+++ b/scripts/mcp-probe.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Probe every MCP endpoint in the cluster by calling tools/list on it.
+#
+# Uses in-cluster Service DNS rather than the gateway hostname on purpose:
+# pods cannot resolve internal-only hostnames. CoreDNS forwards to public
+# resolvers, and those records live only in k8s_gateway. See
+# docs/mcp-onboarding.md.
+#
+# Invoked via: task mcp:probe
+set -o errexit
+set -o nounset
+set -o pipefail
+
+NAMESPACE="${1:-mcp}"
+
+services="$(kubectl -n "${NAMESPACE}" get svc \
+  -o jsonpath='{range .items[*]}{.metadata.name}:{.spec.ports[0].port}{"\n"}{end}')"
+
+if [[ -z "${services}" ]]; then
+  echo "No Services in the ${NAMESPACE} namespace."
+  exit 0
+fi
+
+# Build one shell script for a single throwaway pod rather than one pod per
+# Service — pod startup dominates the runtime otherwise.
+#
+# The leading sleep is load-bearing: `kubectl run -i` races its own attach, and
+# anything the container prints before the stream is established is silently
+# lost. Results are also collected and printed in one block at the end for the
+# same reason.
+probe_script="sleep 2; out=''; "
+while IFS=: read -r name port; do
+  [[ -n "${name}" ]] || continue
+  url="http://${name}.${NAMESPACE}.svc.cluster.local:${port}/mcp"
+  probe_script+="code=\$(curl -sS -o /dev/null -w '%{http_code}' --max-time 15 "
+  probe_script+="-X POST '${url}' "
+  probe_script+="-H 'Content-Type: application/json' "
+  # Both media types are required — a bare application/json gets a 406.
+  probe_script+="-H 'Accept: application/json, text/event-stream' "
+  probe_script+="-d '{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/list\"}' "
+  probe_script+="2>/dev/null || echo unreachable); "
+  probe_script+="out=\"\${out}\$(printf '%-32s %s' '${name}' \"\${code}\")\n\"; "
+done <<< "${services}"
+probe_script+="printf '%b' \"\${out}\""
+
+echo "Probing MCP endpoints in namespace '${NAMESPACE}' (expect 200)"
+echo
+
+kubectl -n "${NAMESPACE}" run "mcp-probe-$$" \
+  --rm -i --restart=Never --quiet \
+  --image=curlimages/curl:8.11.1 -- sh -c "${probe_script}"
+
+echo
+echo "200 = healthy.  406 = Accept header lost.  403 = host allow-list rejecting Service DNS."


### PR DESCRIPTION
Completes phase 1. Follows #407, #408, #409 — the reference app is deployed and verified, so this generalises it.

## What

```
task mcp:new name=proxmox                     # native-http (default)
task mcp:new name=playwright archetype=stdio  # supergateway-wrapped
task mcp:todo                                 # unresolved TODO markers
task mcp:probe                                # tools/list every MCP endpoint
```

| File | Purpose |
|---|---|
| `.taskfiles/mcp/resources/native-http/` | Proven archetype, mirrors `mcp-kubernetes` |
| `.taskfiles/mcp/resources/stdio/` | supergateway archetype — **labelled UNVERIFIED** |
| `scripts/mcp-new.sh` | Scaffold + register in the namespace group |
| `scripts/mcp-probe.sh` | Health check across all MCP Services |
| `docs/mcp-onboarding.md` | Contract, client URLs, RBAC model, auth ladder, traps |

## Design notes worth reviewing

**Templates live outside `kubernetes/`.** `scripts/kubeconform.sh` runs `kustomize build` on *every* directory under `kubernetes/apps` containing a `kustomization.yaml`. Placeholder manifests there would break `task validate`, so they sit in `.taskfiles/mcp/resources/` — matching the existing `.taskfiles/template/resources/` precedent.

**The stdio archetype is honestly labelled.** No app uses it; its flags come from upstream's README, not from anything that has run here. The file says so at the top rather than implying parity with the proven path. Its comments carry the two non-obvious consequences — supergateway is *not* a sidecar (stdio can't cross a container boundary, so it forks the server as a child process), and `npx -y pkg@ver` fetches from npmjs.org at pod start, putting the version pin in an argument string where Renovate can't see it. It also pins `HOME` and `npm_config_cache` at the emptyDir, which is the most likely first-deploy crashloop under `readOnlyRootFilesystem`.

**The scaffold refuses to guess.** Image tag, transport env vars and the UID pin ship as `TODO`, each carrying the command that resolves it. Guessing `runAsUser` yields a pod that never starts — which is exactly why the reference app needed two passes.

**`mcp-probe.sh` sleeps before printing.** `kubectl run -i` races its own attach and silently drops whatever the container writes first. Found by writing the probe, running it, and getting a bare `200` with no Service name attached.

## Verification

Everything here was exercised, not just written:

- Scaffolded three throwaway apps (`native-http` ×2, `stdio` ×1); asserted the port / path / `chartRef` / `ks.path` contract held in generated output, and that `${SECRET_DOMAIN}` survived substitution while `__APP__` did not
- Exercised all three error paths: duplicate directory, invalid RFC 1123 name, unknown archetype
- Confirmed `mcp-` prefix normalisation (`name=mcp-gmail` and `name=gmail` both yield `mcp-gmail`) and that the group kustomization stays sorted with `./namespace.yaml` pinned first
- Removed all three afterwards; the group kustomization is byte-identical to `main`
- `bash -n` on both scripts; both Taskfiles parse; no literal domain leaked into templates or docs
- `mcp:probe` run against the live cluster:

```
mcp-kubernetes                   200
```

Not verified: the stdio archetype end-to-end. That needs a real stdio server, and pretending otherwise is how the DNS assumption in #407 got through.

## Next

Client wiring — n8n first (in-cluster, Service DNS), then devcontainer/Claude Code, then Claude Desktop. Hermes needs a capability check that its build speaks HTTP-transport MCP at all, plus a runbook step, since its config is mutable PVC state rather than Git.