### PR TITLE
docs(mcp): wire Hermes to mcp-kubernetes, record the add-command traps

### DIFF
--- a/docs/mcp-onboarding.md
+++ b/docs/mcp-onboarding.md
@@ -215,9 +215,12 @@ proven rather than assumed.
 
 Three things that cost time:
 
-- **`hermes mcp add` is interactive and has no non-interactive flag.** It
-  cancels rather than defaulting when there is no TTY, so it needs `exec -i`
-  with piped answers. Hence the `printf` above.
+- **`hermes mcp add` is interactive and has no non-interactive flag** — the
+  global `--yolo` does not bypass it either. What it needs is answers on
+  **stdin**, not a TTY: the command above has no TTY and works, whereas a plain
+  `kubectl exec` without `-i` leaves the prompts unanswered and cancels *after*
+  it has already connected and discovered every tool. Hence `exec -i` and the
+  `printf`.
 - **The authentication prompt defaults to yes.** Left to its default it attaches
   an empty bearer token. The `n` in that `printf` is the answer to it; the `y`
   enables all discovered tools. `hermes mcp test` prints `Auth: none` when it
@@ -225,9 +228,10 @@ Three things that cost time:
 - **Use the FQDN.** The `obsidian` entry gets away with a bare Service name
   because it shares the `default` namespace; anything in `mcp` does not.
 
-On success it reports saving to `~/./config.yaml`, which is misleading — `HOME`
-is `/root` but the file goes to `$HERMES_HOME`, i.e. `/opt/data/config.yaml` on
-the Longhorn PVC, which is what makes it survive a restart. Confirm with
+On success it prints `~/./config.yaml` — quoted verbatim, the odd `/./` is its
+output and not a typo here — which is misleading. `HOME` is `/root`, but the
+file goes to `$HERMES_HOME`, i.e. `/opt/data/config.yaml` on the Longhorn PVC,
+which is what makes it survive a restart. Confirm with
 `grep -l mcp-kubernetes /opt/data/config.yaml` rather than trusting the message.
 Existing Hermes sessions do not pick up new tools; new ones do.
 

--- a/docs/mcp-onboarding.md
+++ b/docs/mcp-onboarding.md
@@ -195,10 +195,41 @@ have ended up with regardless.
 
 ### Hermes
 
-**Not wired up, and not yet established that it can be.** Whether its build
-speaks Streamable HTTP MCP at all is unverified — settle that before designing
-anything around it. Like n8n, its config is mutable PVC state rather than Git,
-so the outcome is a runbook step, not a manifest change.
+Wired up and verified. Like n8n this is PVC state, so it is a runbook step
+rather than a manifest change:
+
+```sh
+printf 'n\ny\n' | kubectl -n default exec -i deploy/hermes-ai-agent -c app -- \
+  hermes mcp add kubernetes \
+    --url http://mcp-kubernetes.mcp.svc.cluster.local:3000/mcp \
+    --connect-timeout 30
+
+kubectl -n default exec deploy/hermes-ai-agent -c app -- hermes mcp test kubernetes
+```
+
+`hermes mcp` also has `list`, `remove` and `serve` (the last exposes Hermes
+itself as an MCP server — not used here). `--url` takes an HTTP endpoint;
+`--command`/`--args` is the stdio path. Hermes already ran one HTTP MCP server
+before this (`obsidian` at `http://obsidian:27124/mcp`), so the pattern was
+proven rather than assumed.
+
+Three things that cost time:
+
+- **`hermes mcp add` is interactive and has no non-interactive flag.** It
+  cancels rather than defaulting when there is no TTY, so it needs `exec -i`
+  with piped answers. Hence the `printf` above.
+- **The authentication prompt defaults to yes.** Left to its default it attaches
+  an empty bearer token. The `n` in that `printf` is the answer to it; the `y`
+  enables all discovered tools. `hermes mcp test` prints `Auth: none` when it
+  is right.
+- **Use the FQDN.** The `obsidian` entry gets away with a bare Service name
+  because it shares the `default` namespace; anything in `mcp` does not.
+
+On success it reports saving to `~/./config.yaml`, which is misleading — `HOME`
+is `/root` but the file goes to `$HERMES_HOME`, i.e. `/opt/data/config.yaml` on
+the Longhorn PVC, which is what makes it survive a restart. Confirm with
+`grep -l mcp-kubernetes /opt/data/config.yaml` rather than trusting the message.
+Existing Hermes sessions do not pick up new tools; new ones do.
 
 ## Security posture
 


### PR DESCRIPTION
Step 2 of MCP phase 2. Hermes was the last open unknown from phase 1 — it had never been established that its build speaks HTTP-transport MCP at all.

## It does, and more fully than expected

`hermes mcp` ships `add` / `list` / `test` / `remove` / `serve`, with `--url` for HTTP endpoints and `--command` / `--args` for stdio. Better still, Hermes was **already running an HTTP MCP server** — `obsidian` at `http://obsidian:27124/mcp` over in-cluster Service DNS. So the pattern was proven, not inferred.

Connected and verified:

```
Transport: HTTP → http://mcp-kubernetes.mcp.svc.cluster.local:3000/mcp
Auth: none
✓ Connected (260ms)
✓ Tools discovered: 8
```

No repo change — Hermes config is PVC state, so this is a runbook step, same category as n8n.

## Three traps worth writing down

None of these are visible in `--help`:

1. **`hermes mcp add` is interactive with no non-interactive flag**, and *cancels* rather than defaulting when there's no TTY. The first attempt discovered all 8 tools and then threw them away at the final prompt. Needs `exec -i` with piped answers.
2. **The authentication prompt defaults to yes.** Left alone it attaches an empty bearer token to an unauthenticated server. `hermes mcp test` printing `Auth: none` is the check that it went in right.
3. **It reports saving to `~/./config.yaml`, which is misleading.** `HOME` is `/root`, but the file actually lands at `$HERMES_HOME` — `/opt/data/config.yaml`, on the Longhorn PVC. That distinction is exactly the difference between config that survives a pod restart and config that silently doesn't, and the HelmRelease pins `HERMES_HOME` for that reason. Verified with `df` that `/opt/data` is the PVC mount rather than trusting the message.

Also noted: the `obsidian` entry gets away with a bare Service name because it shares the `default` namespace. Anything in `mcp` needs the FQDN.

## Status

All four clients from the original brief are now wired: n8n, Claude Code/devcontainer, Claude Desktop, Hermes.

Remaining before parallelizing new servers: prove one `stdio`/supergateway server end to end, since that archetype is still unverified.

## CI

Docs only — no files under `kubernetes/**`, so Flux Local and Security Scan are both skipped by path filter. Every command in the added section was run against the live pod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)