### PR TITLE
fix(resources): correct under-booked memory requests for homepage, thanos-storegateway

### DIFF
--- a/kubernetes/apps/default/homepage/app/helmrelease.yaml
+++ b/kubernetes/apps/default/homepage/app/helmrelease.yaml
@@ -28,9 +28,13 @@ spec:
             # measured peak of 126.2Mi against the previous 200Mi limit. Steady
             # state is ~113Mi, so the kill came from a spike the 30s scrape
             # never sampled — headroom that looks sufficient on paper isn't.
+            # Request was still 10Mi (pre-measurement placeholder) — far below
+            # steady state, under-booking the node's schedulable memory and
+            # leaving the pod first in line for eviction under pressure.
+            # Bumped to match steady state (2026-08-08).
             resources:
               requests:
-                memory: 10Mi
+                memory: 128Mi
                 cpu: 10m
               limits:
                 memory: 384Mi

--- a/kubernetes/apps/monitoring/thanos/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/thanos/app/helmrelease.yaml
@@ -123,10 +123,13 @@ spec:
             # was 500.5Mi against the previous 512Mi limit — 2% headroom. 14d
             # average is ~220Mi, so this one runs hot continuously rather than
             # in bursts. 1Gi gives ~2x the observed peak.
+            # Request was still 128Mi — well under the ~220Mi average, so the
+            # scheduler was under-booking this node's memory for a pod that
+            # runs hot continuously. Bumped to match the average (2026-08-08).
             resources:
               requests:
                 cpu: 50m
-                memory: 128Mi
+                memory: 256Mi
               limits:
                 memory: 1Gi
             securityContext:

--- a/kubernetes/apps/monitoring/thanos/app/helmrelease.yaml
+++ b/kubernetes/apps/monitoring/thanos/app/helmrelease.yaml
@@ -125,7 +125,8 @@ spec:
             # in bursts. 1Gi gives ~2x the observed peak.
             # Request was still 128Mi — well under the ~220Mi average, so the
             # scheduler was under-booking this node's memory for a pod that
-            # runs hot continuously. Bumped to match the average (2026-08-08).
+            # runs hot continuously. Bumped to 256Mi for average+headroom
+            # (2026-08-08).
             resources:
               requests:
                 cpu: 50m


### PR DESCRIPTION
## Summary
- `homepage` requested 10Mi memory against a measured ~113Mi steady state (per the OOMKilled investigation comment already in the file) — bumped request to 128Mi.
- `thanos-storegateway` requested 128Mi against a measured ~220Mi steady average (runs hot continuously, not bursty) — bumped request to 256Mi.
- Under-booked requests mean the scheduler doesn't reserve enough memory for these pods on their node, and they land first in line for eviction under memory pressure. Limits are untouched (already sized ~2x observed peak from PR #401).

Flagged during the follow-up to PR #401/#403 as deferred work.

## Test plan
- [x] YAML parses (`python3 -c "yaml.safe_load_all(...)"`) on both files
- [ ] Flux Local CI diff on this PR