### PR TITLE
fix(recording-annotator-minio): repair S3 replication bootstrap

### DIFF
--- a/kubernetes/apps/storage/recording-annotator-minio/app/recording-annotator-replication-bootstrap-job.yaml
+++ b/kubernetes/apps/storage/recording-annotator-minio/app/recording-annotator-replication-bootstrap-job.yaml
@@ -24,11 +24,17 @@
 # and every prior version stays behind Object Lock. "existing-objects" backfills blobs written before the rule
 # existed, so the first sync is complete rather than only-new-writes.
 #
-# Re-running: the Job is one-shot, and prune:false + ssa:IfNotPresent keep the completed object around, so it
-# will NOT re-run if the replication config is later lost (e.g. the Minio PVC is rebuilt while the cluster
-# stands). RecordingAnnotatorMediaReplicationNotConfigured is the alert that catches exactly that; to re-run,
-# delete the completed Job and let Flux recreate it:
+# Re-running: the Job is one-shot, and prune:false + ssa:IfNotPresent keep the object around, so it will NOT
+# re-run if the replication config is later lost (e.g. the Minio PVC is rebuilt while the cluster stands).
+# RecordingAnnotatorMediaReplicationNotConfigured is the alert that catches exactly that.
+#
+# The same two annotations mean EDITING THE SCRIPT BELOW IS NOT ENOUGH ON ITS OWN. A Job's spec.template is
+# immutable, and ssa:IfNotPresent tells kustomize-controller to skip the resource entirely while it exists, so
+# Flux will neither update nor replace it. Delete it and let Flux recreate it from the new spec:
 #   kubectl -n storage delete job recording-annotator-replication-bootstrap
+#   flux -n storage reconcile kustomization recording-annotator-minio
+# This is also required after a failed run: a Job left in BackoffLimitExceeded keeps kube-prometheus-stack's
+# KubeJobFailed firing until the object is gone.
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -66,26 +72,50 @@ spec:
                 echo "waiting for minio... (attempt $RETRIES/$MAX_RETRIES)"; sleep 5
               done
 
-              # Credentials go in argv, so no URL-encoding of the AWS secret key is needed.
-              mc alias set s3backup "$AWS_S3_ENDPOINT" \
-                "$BACKUP_ACCESS_KEY" "$BACKUP_SECRET_KEY" --api S3v4
-
               # Replication requires versioning on the source. Idempotent; the S3 target already has it, since
               # enabling Object Lock at bucket creation implies versioning.
               mc version enable local/"$SOURCE_BUCKET"
 
-              # Idempotent: match on the destination bucket name, which appears in any rule already pointing at
-              # it, so a re-run never stacks a duplicate rule.
-              if mc replicate ls local/"$SOURCE_BUCKET" --json 2>/dev/null | grep -q "$BACKUP_BUCKET"; then
-                echo "replication rule for $BACKUP_BUCKET already present, skipping"
-              else
-                mc replicate add local/"$SOURCE_BUCKET" \
-                  --remote-bucket s3backup/"$BACKUP_BUCKET" \
-                  --replicate "existing-objects" \
-                  --region "$AWS_REGION" \
-                  --priority 1
-                echo "replication rule added (delete markers and version deletions NOT replicated)"
-              fi
+              # Percent-encode for the credential URL below. AWS secret keys are base64 and routinely contain
+              # '/', '+' and '=', which would otherwise terminate the userinfo field early.
+              #
+              # Encoding every byte rather than only the reserved ones is deliberate: it is valid (%41 decodes
+              # to 'A'), and it avoids the per-character substring loop the upstream script uses. That loop
+              # needs braced parameter expansion (substring and string-length), and braced expansions are
+              # exactly what Flux's postBuild envsubst rewrites before the shell ever sees them — including
+              # inside a comment, since kustomize does not strip comments from a command body. Designing them
+              # out removes the whole class of bug. It also relies only on od and tr: the mc image ships no
+              # grep, awk or sed.
+              urlencode() {
+                printf '%s' "$1" | od -An -v -tx1 | tr -d '\n' | tr -s ' ' '%'
+              }
+              ENC_AK=$(urlencode "$BACKUP_ACCESS_KEY")
+              ENC_SK=$(urlencode "$BACKUP_SECRET_KEY")
+
+              # The remote target MUST be given as a credential URL. Passing an mc alias
+              # (--remote-bucket s3backup/bucket) is only supported for MinIO-to-MinIO site replication: against
+              # AWS S3 the endpoint is never transmitted and the server rejects it with
+              #   "Remote service connection error (Remote service endpoint  not available ...)"
+              # — note the empty endpoint. Verified against this exact mc release and bucket.
+              REMOTE_URL="https://$ENC_AK:$ENC_SK@$AWS_S3_HOST/$BACKUP_BUCKET"
+
+              # Idempotent without grep: POSIX case does the substring match as a shell builtin. `mc replicate
+              # ls` exits non-zero with "replication configuration not set" when no rule exists, hence the
+              # `|| true` — that is the normal first-run path, not an error.
+              RULES=$(mc replicate ls local/"$SOURCE_BUCKET" --json 2>/dev/null || true)
+              case "$RULES" in
+                *"$BACKUP_BUCKET"*)
+                  echo "replication rule for $BACKUP_BUCKET already present, skipping"
+                  ;;
+                *)
+                  mc replicate add local/"$SOURCE_BUCKET" \
+                    --remote-bucket "$REMOTE_URL" \
+                    --replicate "existing-objects" \
+                    --region "$AWS_REGION" \
+                    --priority 1
+                  echo "replication rule added (delete markers and version deletions NOT replicated)"
+                  ;;
+              esac
 
               mc replicate ls local/"$SOURCE_BUCKET"
               echo "recording-annotator minio replication ready"
@@ -98,8 +128,9 @@ spec:
               value: hiro-recording-annotator-media-backup
             - name: AWS_REGION
               value: us-east-1
-            - name: AWS_S3_ENDPOINT
-              value: https://s3.us-east-1.amazonaws.com
+            # Host only, no scheme — it is interpolated into the credential URL, which supplies https://
+            - name: AWS_S3_HOST
+              value: s3.us-east-1.amazonaws.com
             - name: MINIO_ROOT_USER
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
The Job from #397 fails in-cluster — currently sitting in `BackoffLimitExceeded`. Three defects, all found by running it rather than reading it.

### 1. The mc image has no `grep`

Nor `awk` or `sed` — only `tr`, `cut`, `od`. The idempotency guard piped `mc replicate ls` into `grep -q`:

```
/bin/sh: line 23: grep: command not found
```

Not fatal by itself — the failed pipeline made the `if` take the else branch, which *is* the intended first-run path — but it was noise sitting on top of the real error. Replaced with a POSIX `case`, a shell builtin.

### 2. `--remote-bucket <alias>/<bucket>` does not work against AWS S3

This was the actual failure:

```
mc: <ERROR> unable to configure remote target. Remote service connection error
    (Remote service endpoint  not available. Health check timed out after 3 seconds).
```

Note the **empty endpoint** where the host should be. The alias form is only supported for MinIO-to-MinIO site replication; against S3 the endpoint is never transmitted. Switched to the credential-URL form, which is what mc's own help text uses for third-party targets. Confirmed: with the URL form the error changes to naming the real bucket and access key, so the target now reaches AWS.

### 3. The URL form needs percent-encoding

Base64 secrets routinely contain `/`, `+`, `=`, which terminate the userinfo field early. Rather than the upstream script's per-character substring loop, this encodes every byte via `od`/`tr`. Over-encoding is valid (`%41` is `A`), needs only tools the image actually has, and — the real reason — needs **no braced parameter expansion**.

That matters more than it looks: Flux's `postBuild` envsubst rewrites `${...}` before the shell sees it, **including inside comments**, because kustomize does not strip comments from a command body. My first draft of this fix tripped exactly that by *describing* the substring syntax in a comment. Built output now contains no braced vars except the two intentional `${SECRET_DOMAIN}` hostnames.

Verified byte-identical to the substring encoder against a key containing `/`, `+` and `=`.

### ⚠️ Merging this is not sufficient — two manual steps

**a) The IAM policy is short two permissions.** Not fixed here since it's an AWS-side change. Probed directly with the live credentials: `ListBucket` and bucket `stat` succeed, **`ListBucketVersions` is denied**. MinIO's remote-target health check needs it on a versioned destination. Add `s3:ListBucketVersions` and `s3:GetBucketLocation` to the bucket-level statement of `recording-annotator-minio-replication`. Until then the Job still fails with `Access Denied`.

**b) The failed Job must be deleted by hand.** A Job's `spec.template` is immutable and `ssa: IfNotPresent` makes Flux skip the resource while it exists — so editing the script does *not* cause a replacement. Required regardless, since a Job in `BackoffLimitExceeded` keeps `KubeJobFailed` firing until the object is gone:

```
kubectl -n storage delete job recording-annotator-replication-bootstrap
flux -n storage reconcile kustomization recording-annotator-minio
```

Both now documented in the manifest header.

### Separately — worth verifying

`mc retention info` on `hiro-recording-annotator-media-backup` reports **"Object locking is not enabled"**, and `mc stat` shows `Versioning: Enabled` but no object-lock property. If that reading is right, the media replica is versioned but not WORM, which is weaker than the design in `docs/backup-recovery.md` §3 assumes. Object Lock can only be enabled at bucket creation, so it would mean recreating the bucket. I could not confirm with the AWS CLI (not available here) and the reading could be a permissions artifact — worth one `aws s3api get-object-lock-configuration --bucket hiro-recording-annotator-media-backup` before acting on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)