### PR TITLE
feat(recording-annotator): bump to v0.2.0, the first image with the backup API

### DIFF
--- a/kubernetes/apps/default/recording-annotator/app/helmrelease.yaml
+++ b/kubernetes/apps/default/recording-annotator/app/helmrelease.yaml
@@ -28,7 +28,7 @@ spec:
           app:
             image:
               repository: ghcr.io/jasonkoopmans/recordingannotator
-              tag: "0.1.1"
+              tag: "0.2.0"
             env:
               Storage__Provider: Minio
               Storage__Endpoint: recording-annotator-minio.storage.svc.cluster.local:9000
@@ -241,7 +241,7 @@ spec:
             # touches the live PVC — only a temp download into its own emptyDir below.
             image:
               repository: ghcr.io/jasonkoopmans/recordingannotator
-              tag: "0.1.1"
+              tag: "0.2.0"
             args: ["restore-verify"]
             env:
               Backup__Provider: S3


### PR DESCRIPTION
The currently-deployed `0.1.1` predates `BackupController` and `ReconciliationController` — neither the controllers nor their DI registrations exist on that tag. `/internal/backup/index` and `/internal/reconcile` don't exist, so both CronJobs have been "succeeding" against the SPA fallback's 200 since day one, not against real backup logic.

`v0.2.0` is the first tag with both. Cut from `main`.

### Verified main was safe to cut from

`main` showed `ahead_by: 30, behind_by: 2` against `v0.1.1`. Didn't assume — diffed the two "behind" commits by file content hash rather than commit message, since a rebase can make a real commit look "missing" by SHA. They turned out to be the identical presign/`PublicEndpoint` work already on `main` under a different SHA. `main` is a clean superset; nothing from `v0.1.1` is lost by tagging from it.

### Confirmed published

CI run for the `v0.2.0` tag is green: https://github.com/JasonKoopmans/RecordingAnnotator/actions/runs/31289710632

Image confirmed pushed as `ghcr.io/jasonkoopmans/recordingannotator:0.2.0` (tag drops the `v`, matching the existing `0.1.1` convention) from the build log's `DOCKER_METADATA_OUTPUT_TAGS`. I could not independently verify it's *pullable* — my token lacks `read:packages` and an anonymous GHCR manifest check needs a different auth flow than I had available. Worth confirming the pod actually pulls cleanly rather than assuming from CI success alone.

### Left alone on purpose

`Backup__MinArtifacts` stays at `0`. I have no way to read the real LiteDB artifact count, and a guessed floor risks failing the very first restore drill for the wrong reason. Set it once the real count is known — probably right after the first hourly index-backup runs against this image.

### What to watch after merge

- Pod should roll on the new tag; confirm `kubectl -n default get pods -l app.kubernetes.io/name=recording-annotator` shows a fresh image digest and no `ImagePullBackOff`.
- Next `recording-annotator-index-backup` and `-reconciliation` runs should hit real endpoints. `RecordingAnnotatorIndexBackupNotSucceeding` / `-Stale` should start reflecting truth instead of a false-positive "success" that was never real to begin with.
- `restore-drill` will run for the first time against real code next scheduled cycle — first genuine test of the whole backup chain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)