### PR TITLE
feat(lifeos): personal reporting Grafana with a two-plane config model

### DIFF
--- a/.taskfiles/lifeos/Taskfile.yaml
+++ b/.taskfiles/lifeos/Taskfile.yaml
@@ -1,0 +1,66 @@
+---
+# yaml-language-server: $schema=https://taskfile.dev/schema.json
+version: "3"
+
+vars:
+  # Quoted at every use site — a checkout path containing a space would
+  # otherwise split into two arguments.
+  DASHBOARD_EXPORT_SCRIPT: "{{.ROOT_DIR}}/scripts/lifeos-dashboard-export.sh"
+  LIFEOS_APP_DIR: "{{.ROOT_DIR}}/kubernetes/apps/lifeos/grafana/app"
+
+tasks:
+
+  dashboard:list:
+    desc: List dashboards in the LifeOS Grafana, with their uid and folder
+    summary: |
+      Shows both planes at once, so it doubles as the drift check: anything in
+      the GitOps folder came from a ConfigMap in this repo, everything else
+      lives only in Grafana's database and is a promotion candidate.
+    cmd: |
+      user="$(kubectl -n lifeos get secret grafana-secret -o jsonpath='{.data.admin-user}' | base64 -d)"
+      password="$(kubectl -n lifeos get secret grafana-secret -o jsonpath='{.data.admin-password}' | base64 -d)"
+
+      pf_log="$(mktemp)"
+      kubectl -n lifeos port-forward svc/grafana :80 >"$pf_log" 2>&1 &
+      pf_pid=$!
+      trap 'kill $pf_pid 2>/dev/null || true; rm -f "$pf_log"' EXIT
+
+      port=""
+      for _ in $(seq 1 50); do
+        port="$(sed -n 's/^Forwarding from 127\.0\.0\.1:\([0-9]*\).*/\1/p' "$pf_log" | head -1)"
+        [ -n "$port" ] && break
+        sleep 0.2
+      done
+      [ -n "$port" ] || { echo "port-forward never came up" >&2; cat "$pf_log" >&2; exit 1; }
+
+      curl -sS --fail --max-time 30 -u "$user:$password" \
+        "http://127.0.0.1:$port/api/search?type=dash-db" \
+        | jq -r '["UID","FOLDER","TITLE"], (.[] | [.uid, (.folderTitle // "General"), .title]) | @tsv' \
+        | column -t -s "$(printf '\t')"
+    preconditions:
+      - { msg: "Missing kubeconfig", sh: 'test -f "{{.KUBECONFIG}}"' }
+
+  dashboard:export:
+    desc: Promote a UI-authored dashboard into Git as a ConfigMap
+    summary: |
+      Args:
+        uid:    dashboard uid (required) — see `task lifeos:dashboard:list`
+        folder: Grafana folder for the provisioned copy (default: GitOps)
+
+      Fetches the dashboard over Grafana's API, strips the database-local id and
+      version fields, writes kubernetes/apps/lifeos/grafana/app/dashboard-<slug>.yaml
+      and registers it in that directory's kustomization.yaml.
+
+      The result is provisioned read-only, so delete the UI copy once Flux has
+      reconciled it — otherwise the same dashboard exists twice and only one of
+      them is under version control.
+
+      Example:
+        task lifeos:dashboard:export uid=lifeos-spend folder=Finance
+    requires:
+      vars: [uid]
+    cmd: bash "{{.DASHBOARD_EXPORT_SCRIPT}}" "{{.uid}}" "{{.folder | default `GitOps`}}" "{{.ROOT_DIR}}"
+    preconditions:
+      - { msg: "Missing kubeconfig", sh: 'test -f "{{.KUBECONFIG}}"' }
+      - { msg: "Missing export script", sh: 'test -f "{{.DASHBOARD_EXPORT_SCRIPT}}"' }
+      - { msg: "Missing lifeos grafana app directory", sh: 'test -d "{{.LIFEOS_APP_DIR}}"' }

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -22,6 +22,7 @@ env:
 includes:
   bootstrap: .taskfiles/bootstrap
   crd: .taskfiles/crd
+  lifeos: .taskfiles/lifeos
   mcp: .taskfiles/mcp
   talos: .taskfiles/talos
   template: .taskfiles/template

--- a/docs/lifeos-google-credentials.md
+++ b/docs/lifeos-google-credentials.md
@@ -1,0 +1,212 @@
+# Google credentials for LifeOS
+
+How the LifeOS Grafana authenticates to Google Sheets, and why it gets its own
+identity rather than borrowing n8n's.
+
+**Short version:** one GCP project for the homelab, one service account per
+consumer, and access granted by *sharing a Drive folder* with each service
+account — not by GCP IAM roles.
+
+---
+
+## Why not reuse the n8n credential
+
+Two reasons, and the first one settles it on its own.
+
+**The auth models don't match.** n8n's Google nodes default to OAuth2: you click
+through a consent screen and n8n stores a refresh token that lets it act *as
+you*. Grafana's Sheets plugin cannot do OAuth2 at all — it supports a service
+account (JWT), a plain API key (public sheets only), or GCE metadata (not
+available on Talos). So Grafana needs a service account whether or not n8n has
+one. There is nothing to reuse.
+
+Worth confirming what n8n is actually using — **Credentials** in the n8n UI. It
+isn't in this repo either way: n8n keeps credentials in its own encrypted store
+on its PVC, so unlike Grafana's, that credential is invisible to Git and to
+this documentation.
+
+**And even if the models matched, you'd still want them split:**
+
+- *Different verbs.* n8n writes to sheets; Grafana only ever reads. A read-only
+  identity means a compromised Grafana cannot mutate your data — a property you
+  lose the moment the two share a credential.
+- *Independent rotation.* Rotating a key because one system leaked it shouldn't
+  take the other one down with it.
+- *Legible audit and sharing.* Drive's "shared with" list and Google's audit
+  logs name the identity. `grafana-lifeos@…` and `n8n@…` tell you who read what;
+  one shared `homelab@…` tells you nothing.
+- *Quota isolation.* The Sheets API allows ~300 read requests/min per project
+  but only ~60 per minute **per identity**. A Grafana dashboard with a dozen
+  panels on a 1-minute refresh can eat a 60/min bucket by itself. Separate
+  service accounts mean a busy dashboard cannot starve an n8n workflow.
+
+---
+
+## The layout
+
+```
+GCP project  hiro-homelab                     ← one project: billing + API enablement
+├── SA  grafana-lifeos@…                      ← read-only reporting
+└── SA  n8n@…              (only if n8n ever moves off OAuth2)
+
+Google Drive
+└── 📁 LifeOS                                 ← shared once, with grafana-lifeos as Viewer
+    ├── 📄 spend-2026
+    ├── 📄 habits
+    └── …                                     ← new sheets inherit access
+```
+
+One project, because a project is a billing and API-enablement boundary, not a
+security boundary — two projects would double the maintenance for no isolation.
+The service account is the identity boundary, and that's where the split goes.
+
+The **shared folder** is the part worth getting right. Service accounts have no
+Drive of their own to browse; they see exactly the files shared with them. Share
+one folder as Viewer and every sheet you drop in it becomes visible
+automatically — otherwise you're back to per-sheet sharing every time you start
+a new report, and eventually you forget and debug an empty panel instead.
+
+---
+
+## Setup
+
+### 1. Project and APIs
+
+```sh
+PROJECT_ID=hiro-homelab          # or an existing project
+gcloud config set project "$PROJECT_ID"
+
+# Sheets API reads cell values. Drive API backs the spreadsheet picker in the
+# panel editor — skip it only if you intend to paste spreadsheet IDs by hand.
+gcloud services enable sheets.googleapis.com drive.googleapis.com
+```
+
+### 2. Service account and key
+
+```sh
+gcloud iam service-accounts create grafana-lifeos \
+  --display-name="Grafana LifeOS" \
+  --description="Read-only Google Sheets access for the LifeOS Grafana"
+
+SA_EMAIL="grafana-lifeos@${PROJECT_ID}.iam.gserviceaccount.com"
+
+umask 077
+gcloud iam service-accounts keys create ~/grafana-lifeos.json \
+  --iam-account="$SA_EMAIL"
+```
+
+**Do not grant the service account any project IAM role.** This trips people up:
+Sheets and Drive access comes from *file sharing*, not from `roles/viewer` or
+anything else in the IAM tab. A project role adds reach without adding access to
+a single spreadsheet.
+
+### 3. Share the data
+
+Create a **LifeOS** folder in Drive, move the sheets you want to report on into
+it, then share the folder with `$SA_EMAIL` as **Viewer** — the same dialog you'd
+use for a person. Uncheck "Notify people"; nobody's reading that mailbox.
+
+If your Drive is on a Google Workspace domain with external sharing restricted,
+a service account from a project outside the org counts as external. Either put
+the project in the same org, or share individual files, or ask the Workspace
+admin to allow it.
+
+### 4. Fill in the SOPS secret
+
+From the repo root, with the key file still on disk:
+
+```sh
+KEY=~/grafana-lifeos.json
+
+cat > kubernetes/apps/lifeos/grafana/app/secret.sops.yaml <<EOF
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: grafana-secret
+type: Opaque
+stringData:
+  admin-user: admin
+  admin-password: "$(openssl rand -base64 24)"
+  secret-key: "$(openssl rand -base64 32)"
+  googlesheets-client-email: "$(jq -r .client_email "$KEY")"
+  googlesheets-project-id: "$(jq -r .project_id "$KEY")"
+  googlesheets-private-key: |
+$(jq -r .private_key "$KEY" | sed 's/^/    /')
+EOF
+
+sops --encrypt --in-place kubernetes/apps/lifeos/grafana/app/secret.sops.yaml
+shred -u "$KEY"
+```
+
+`jq -r` is doing real work on the last field: the JSON key file stores the
+private key with literal `\n` escapes, and `-r` expands them into the actual
+newlines a PEM needs. Copy-pasting that field out of the JSON by hand is the
+single most common way this integration fails.
+
+`secret-key` is Grafana's own database encryption key, unrelated to Google. Set
+it once and never rotate it — see `docs/lifeos-grafana.md`.
+
+Check the round-trip before committing:
+
+```sh
+sops --decrypt kubernetes/apps/lifeos/grafana/app/secret.sops.yaml \
+  | yq '.stringData.googlesheets-private-key' | head -2
+# -----BEGIN PRIVATE KEY-----
+# MIIEv…
+```
+
+Then commit and push; Flux reconciles and Reloader restarts the pod.
+
+### 5. Verify
+
+In Grafana: **Connections → Data sources → Google Sheets → Save & test**. The
+data source is provisioned, so the form is read-only — the test button still
+works.
+
+- *"Invalid JWT" / "invalid_grant"* → the private key is mangled. Almost always
+  the `\n` problem from step 4.
+- *Test passes but a panel returns nothing* → the sheet isn't shared with
+  `$SA_EMAIL`, or it's outside the shared folder.
+- *"API has not been used in project…"* → step 1 didn't run, or ran against a
+  different project than the key belongs to.
+
+Pod-side: `kubectl -n lifeos logs deploy/grafana -c grafana | grep -i sheets`.
+
+---
+
+## Rotation
+
+Service account keys don't expire on their own, so this is on you. Rotating is
+additive — create the new key first, so there's no window without a valid one:
+
+```sh
+gcloud iam service-accounts keys create ~/grafana-lifeos-new.json \
+  --iam-account="$SA_EMAIL"
+# redo step 4 with the new file, commit, push
+# once the pod is up and the data source tests green:
+gcloud iam service-accounts keys list --iam-account="$SA_EMAIL"
+gcloud iam service-accounts keys delete <OLD_KEY_ID> --iam-account="$SA_EMAIL"
+```
+
+Reloader restarts the pod on the secret change, so no manual rollout.
+
+**Revoking entirely** — deleting the service account, or un-sharing the folder —
+takes effect immediately and touches nothing else. That independence is the
+whole point of not sharing an identity with n8n.
+
+---
+
+## Don't
+
+- **Domain-wide delegation.** It lets the service account impersonate every user
+  in a Workspace domain. It is occasionally the right tool and never the right
+  tool here; folder sharing does the job with none of the blast radius.
+- **API key auth.** The plugin supports it, but it only reads spreadsheets
+  published to "anyone with the link" — which is the opposite of what personal
+  data wants.
+- **Sharing your whole Drive** with the service account. Share the LifeOS folder;
+  a compromised key then reads your reports, not your tax returns.
+- **Committing the JSON key file.** Only the three extracted fields go into the
+  SOPS secret. `shred -u` the original, and mind your shell history — a leading
+  space keeps a command out of it in most shells.

--- a/docs/lifeos-grafana.md
+++ b/docs/lifeos-grafana.md
@@ -95,17 +95,16 @@ address*, exactly as if it were a colleague.
 
 ### One-time setup
 
-1. In a Google Cloud project, enable the **Google Sheets API** and the **Google
-   Drive API**.
-2. Create a service account, then create a JSON key for it and download it.
-3. Fill in `kubernetes/apps/lifeos/grafana/app/secret.sops.yaml` — the header
-   comment in that file has the exact commands. From the JSON key you need:
-   - `client_email` → `googlesheets-client-email`
-   - `project_id` → `googlesheets-project-id`
-   - `private_key` → `googlesheets-private-key`, as a real multi-line PEM with
-     the `\n` escapes expanded
-4. `sops --encrypt --in-place` the file, commit, push.
-5. Share each spreadsheet with the `client_email` address, Viewer is enough.
+Full walkthrough — project, service account, folder sharing, key rotation, and
+why this gets its own identity rather than n8n's — is in
+**`docs/lifeos-google-credentials.md`**. In outline:
+
+1. Enable the Sheets API and Drive API in a GCP project.
+2. Create a `grafana-lifeos` service account and a JSON key. No IAM roles.
+3. Put the reportable sheets in a **LifeOS** Drive folder, shared once with the
+   service account as Viewer.
+4. Extract `client_email` / `project_id` / `private_key` into
+   `kubernetes/apps/lifeos/grafana/app/secret.sops.yaml`, encrypt, push.
 
 The private key is mounted as a file (`privateKeyPath`) rather than passed
 through an environment variable, because PEM newlines survive a file mount and

--- a/docs/lifeos-grafana.md
+++ b/docs/lifeos-grafana.md
@@ -1,0 +1,167 @@
+# LifeOS Grafana
+
+A second Grafana, in the `lifeos` namespace, for personal reporting and
+aggregation — separate from `monitoring/kube-prometheus-stack`'s Grafana, which
+stays focused on the cluster.
+
+| | monitoring Grafana | LifeOS Grafana |
+|---|---|---|
+| Hostname | `grafana.${SECRET_DOMAIN}` | `lifeos.${SECRET_DOMAIN}` |
+| Chart | bundled in kube-prometheus-stack | `grafana-community/grafana` (standalone, versions independently) |
+| Data sources | Thanos, Loki, Prometheus | Google Sheets (first of several) |
+| Database | disposable — rebuild from Git | **load-bearing** — holds UI-authored work |
+| Storage class | `longhorn` | `longhorn` (3 replicas + S3 backups) |
+
+---
+
+## Why two planes
+
+The brief was "GitOps as much as possible, but I'll also design things in the
+UI." Those pull in opposite directions: anything Grafana provisions from files
+is authoritative and overwrites the database on every reconcile, and anything
+authored in the browser lives only in the database. Trying to run both against
+the same objects produces silent data loss in one direction or drift in the
+other.
+
+So they are separated by *folder*, and the boundary is enforced by Grafana
+rather than by discipline:
+
+**Git plane — the `GitOps` folder (and any other folder named by a
+`grafana_folder` annotation).** Dashboards come from ConfigMaps in
+`kubernetes/apps/lifeos/grafana/app/`. The provider sets
+`allowUiUpdates: false`, so Grafana disables Save for these dashboards. Drift is
+not "discouraged", it is impossible. Data sources and plugins live here too.
+
+**UI plane — every other folder.** Dashboards, folders, playlists, alert rules,
+API tokens, preferences, plugins installed from the catalogue. All of it in
+Grafana's SQLite database on the PVC.
+
+Draft in the UI plane. Promote what proves useful into the Git plane.
+
+### What this means for the volume
+
+The monitoring instance's PVC is a cache — delete it and Flux rebuilds the
+instance exactly. This one's is not: the UI plane exists nowhere else. It
+therefore uses the default `longhorn` class (3 replicas, recurring backups to
+`s3://hiro-longhorn-backups`), and **must not** be moved to a `-no-backup`
+class. See `docs/backup-recovery.md` for the restore path.
+
+`GF_SECURITY_SECRET_KEY` (from the SOPS secret) encrypts credential rows inside
+that database. Set it once. Rotating it makes every already-encrypted row —
+including any data source configured through the UI — permanently unreadable.
+
+---
+
+## Promoting a dashboard from UI to Git
+
+```sh
+task lifeos:dashboard:list                                  # find the uid
+task lifeos:dashboard:export uid=<uid> [folder=Finance]     # write the ConfigMap
+git add -A && git commit -m "feat(lifeos): add <name> dashboard"
+```
+
+The export strips the dashboard's `id` and `version` (database-local
+bookkeeping), keeps its `uid`, writes
+`kubernetes/apps/lifeos/grafana/app/dashboard-<slug>.yaml`, and registers the
+file in that directory's `kustomization.yaml`.
+
+Once Flux has reconciled, **delete the UI copy**. Otherwise the dashboard exists
+twice under the same uid and Grafana's provisioner and the database fight over
+it.
+
+Two things to check on the way through:
+
+- **Template variables.** Grafana writes them as `${var}`, which Flux's
+  `postBuild` substitution will happily replace with nothing. Escape each `$` as
+  `$$` in the committed ConfigMap. The export script reminds you.
+- **Data source references.** Panels must reference a data source by `uid`, not
+  by name. Provisioned sources here have explicit uids (`googlesheets`) for
+  exactly this reason.
+
+### Editing a promoted dashboard
+
+Edit the ConfigMap and let Flux reconcile — the browser will not let you save.
+For heavier redesigns: copy the dashboard to a UI folder (Dashboard settings →
+Save As), rework it there, re-export, delete the copy.
+
+---
+
+## Google Sheets
+
+The first integration. It authenticates as a **Google Cloud service account**,
+not as you, which has one consequence worth internalising: *Grafana cannot see a
+spreadsheet until that spreadsheet is shared with the service account's email
+address*, exactly as if it were a colleague.
+
+### One-time setup
+
+1. In a Google Cloud project, enable the **Google Sheets API** and the **Google
+   Drive API**.
+2. Create a service account, then create a JSON key for it and download it.
+3. Fill in `kubernetes/apps/lifeos/grafana/app/secret.sops.yaml` — the header
+   comment in that file has the exact commands. From the JSON key you need:
+   - `client_email` → `googlesheets-client-email`
+   - `project_id` → `googlesheets-project-id`
+   - `private_key` → `googlesheets-private-key`, as a real multi-line PEM with
+     the `\n` escapes expanded
+4. `sops --encrypt --in-place` the file, commit, push.
+5. Share each spreadsheet with the `client_email` address, Viewer is enough.
+
+The private key is mounted as a file (`privateKeyPath`) rather than passed
+through an environment variable, because PEM newlines survive a file mount and
+frequently do not survive env-var interpolation.
+
+Panel refresh is floored at 1 minute (`min_refresh_interval`): every refresh is
+a live Google API call, and the underlying data only changes when a human edits
+a sheet.
+
+### Adding more data sources
+
+- **Credentials belong in Git** → add the source to `datasources:` in
+  `helmrelease.yaml` with an explicit `uid`, and its secret to
+  `secret.sops.yaml`. Provisioned sources are locked for editing in the UI.
+- **Just trying something out** → configure it in the UI. It is stored encrypted
+  in the database and backed up with the volume. Move it into Git when it
+  becomes load-bearing.
+
+`yesoreyeram-infinity-datasource` (CSV/JSON/REST/GraphQL) is the usual next step
+for this kind of instance — add it to `plugins:` when needed.
+
+Note that cluster metrics are deliberately *not* wired in here. If a personal
+dashboard ever wants them, add Thanos as a second data source
+(`http://thanos-query.monitoring.svc.cluster.local:10902`) rather than moving
+the dashboard to the monitoring instance.
+
+---
+
+## Plugins
+
+Declared in `plugins:` in the HelmRelease, installed at pod start, and stored on
+the PVC.
+
+Plugin admin is left **enabled** in `grafana.ini` on purpose — trialling a data
+source plugin from the UI is part of how this instance is meant to be used. But
+a UI-installed plugin only exists on that volume: anything that earns a
+permanent place has to be added to `plugins:` in Git, or a rebuild will come up
+without it and every dashboard depending on it will break.
+
+---
+
+## Operating notes
+
+- **Access** is internal-only (`envoy-internal`), single local admin account,
+  sign-up and org creation disabled. There is no OIDC provider in the cluster
+  yet; when one arrives this is a natural early consumer.
+- **Metrics**: the instance ships a ServiceMonitor and is scraped by the
+  existing Prometheus — `serviceMonitorSelectorNilUsesHelmValues: false` means
+  cluster-wide discovery, so nothing in `monitoring/` needed to change.
+- **Ordering**: the app's `ks.yaml` depends on `kube-prometheus-stack` purely
+  for the `monitoring.coreos.com` CRDs that the ServiceMonitor needs.
+- **Restarts**: the HelmRelease carries
+  `secret.reloader.stakater.com/reload: grafana-secret`, so credential changes
+  roll the pod without manual intervention.
+- **Chart source**: the standalone Grafana chart left `grafana/helm-charts` on
+  2026-01-30 and is now maintained at `grafana-community/helm-charts`, pulled
+  here over OCI from `ghcr.io/grafana-community/helm-charts/grafana`. The
+  monitoring instance's Grafana still comes from the kube-prometheus-stack
+  bundle and is unaffected.

--- a/kubernetes/apps/default/homepage/app/configuration.yaml
+++ b/kubernetes/apps/default/homepage/app/configuration.yaml
@@ -57,6 +57,9 @@ data:
       Downloads:
         style: column
         icon: sonarr
+      LifeOS:
+        style: column
+        icon: grafana
       Monitoring:
         style: column
         icon: grafana

--- a/kubernetes/apps/lifeos/grafana/app/dashboard-lifeos-home.yaml
+++ b/kubernetes/apps/lifeos/grafana/app/dashboard-lifeos-home.yaml
@@ -1,0 +1,50 @@
+---
+# Seed dashboard for the Git plane. Two jobs: it documents the workflow where
+# the workflow is actually used, and it proves the ConfigMap → sidecar →
+# provisioning path works on day one, before any real dashboard depends on it.
+#
+# Copy this file's shape for real dashboards — label + folder annotation are
+# what the sidecar keys on.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-dashboard-lifeos-home
+  labels:
+    grafana_dashboard: "1"
+  annotations:
+    grafana_folder: GitOps
+data:
+  lifeos-home.json: |
+    {
+      "uid": "lifeos-home",
+      "title": "LifeOS — Start Here",
+      "tags": ["lifeos", "gitops"],
+      "editable": false,
+      "schemaVersion": 39,
+      "graphTooltip": 0,
+      "time": {"from": "now-6h", "to": "now"},
+      "annotations": {"list": []},
+      "templating": {"list": []},
+      "panels": [
+        {
+          "id": 1,
+          "type": "text",
+          "title": "Two planes",
+          "gridPos": {"h": 13, "w": 12, "x": 0, "y": 0},
+          "options": {
+            "mode": "markdown",
+            "content": "## Git plane (this folder)\n\nDashboards in **GitOps** come from ConfigMaps in `kubernetes/apps/lifeos/grafana/app/`. They are provisioned read-only — the Save button is disabled on purpose, so nothing here can drift from Git.\n\nTo change one, edit its ConfigMap and let Flux reconcile.\n\n## UI plane (every other folder)\n\nAnything created in the browser lives in Grafana's own database on the Longhorn volume. Draft freely: new dashboards, folders, alert rules, playlists, preferences.\n\nThe volume is on the backed-up storage class, so this plane survives a pod or node loss — but it is *not* reproducible from Git.\n\n## Promotion\n\nWhen a UI draft has earned it, move it into the Git plane:\n\n```\ntask lifeos:dashboard:export uid=<dashboard-uid>\n```\n\nThat writes the ConfigMap; commit it, let Flux apply, then delete the UI copy so there is exactly one source of truth."
+          }
+        },
+        {
+          "id": 2,
+          "type": "text",
+          "title": "Data sources",
+          "gridPos": {"h": 13, "w": 12, "x": 12, "y": 0},
+          "options": {
+            "mode": "markdown",
+            "content": "### Google Sheets — uid `googlesheets`\n\nAuthenticates as a Google Cloud **service account**, not as you. A spreadsheet is invisible to Grafana until it is shared with the service account's client email, exactly like sharing with a person.\n\nThe datasource is provisioned from Git and locked for editing; its credentials come from the SOPS secret in the app directory.\n\nPanel refresh is floored at **1m** — Sheets reads hit the Google API on every refresh and the data changes only when a human edits the sheet.\n\n### Adding another source\n\nSomething with credentials that belong in Git → add it to `datasources:` in the HelmRelease with an explicit `uid`.\n\nTrialling something → install it from **Administration → Plugins** and configure it in the UI. If it sticks, move the plugin into the `plugins:` list in Git so a rebuild reproduces it.\n\nFull write-up: `docs/lifeos-grafana.md`."
+          }
+        }
+      ]
+    }

--- a/kubernetes/apps/lifeos/grafana/app/helmrelease.yaml
+++ b/kubernetes/apps/lifeos/grafana/app/helmrelease.yaml
@@ -1,0 +1,233 @@
+---
+# yaml-language-server: $schema=https://lds-schemas.pages.dev/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: grafana
+spec:
+  interval: 1h
+  chartRef:
+    kind: OCIRepository
+    name: grafana
+  values:
+    # ------------------------------------------------------------------------
+    # Two planes of configuration, on purpose.
+    #
+    # This instance is deliberately NOT a clone of monitoring/grafana. That one
+    # is 100% declarative and disposable — wipe the PVC and Flux rebuilds it.
+    # This one is a personal workspace where dashboards get *drafted* in the UI,
+    # so its database holds state that exists nowhere else. The split:
+    #
+    #   Git plane  — everything below, plus dashboard ConfigMaps in this
+    #                directory. Provisioned read-only (allowUiUpdates: false),
+    #                so the UI physically cannot drift from Git.
+    #   UI plane   — dashboards, folders, playlists, alert rules, preferences
+    #                and API tokens created in the browser. Lives in the SQLite
+    #                DB on the PVC below.
+    #
+    # The PVC is therefore load-bearing, not a cache: it uses the backed-up
+    # `longhorn` class, unlike the monitoring instance. Draft in the UI, then
+    # promote what proves useful into Git (`task lifeos:dashboard:export`).
+    # See docs/lifeos-grafana.md.
+    # ------------------------------------------------------------------------
+
+    # RWO volume — a rolling update would deadlock on the old pod holding it.
+    deploymentStrategy:
+      type: Recreate
+
+    replicas: 1
+
+    # Deployment-level, which is where Reloader looks. The chart already
+    # checksums its own ConfigMaps into the pod template; this covers the
+    # Secret, so admin credentials and the Google key roll the pod on change.
+    annotations:
+      secret.reloader.stakater.com/reload: grafana-secret
+
+    persistence:
+      enabled: true
+      type: pvc
+      accessModes: ["ReadWriteOnce"]
+      # 3 replicas + recurring backups to S3. The UI plane is not reproducible
+      # from Git, so this is the only copy of it — do not downgrade to a
+      # -no-backup class.
+      storageClassName: longhorn
+      # SQLite DB, the plugin tree under /var/lib/grafana/plugins and the bleve
+      # search index. Single-user scale; 5Gi is headroom, not a projection.
+      size: 5Gi
+
+    admin:
+      existingSecret: grafana-secret
+      userKey: admin-user
+      passwordKey: admin-password
+
+    envValueFrom:
+      # Encrypts secureJsonData rows in the Grafana DB — datasource credentials
+      # entered through the UI, among others. Grafana falls back to a published
+      # default when unset. It must never change once set: rotating it makes
+      # every already-encrypted row undecryptable.
+      GF_SECURITY_SECRET_KEY:
+        secretKeyRef:
+          name: grafana-secret
+          key: secret-key
+      # Interpolated into the Google Sheets datasource below. These are
+      # identifiers rather than credentials, but they name a private GCP
+      # project, so they stay out of the manifests.
+      GF_GOOGLE_SA_CLIENT_EMAIL:
+        secretKeyRef:
+          name: grafana-secret
+          key: googlesheets-client-email
+      GF_GOOGLE_SA_PROJECT:
+        secretKeyRef:
+          name: grafana-secret
+          key: googlesheets-project-id
+
+    # The service-account private key is a multi-line PEM. Mounted as a file and
+    # referenced by path rather than pushed through env interpolation, which is
+    # where PEM newlines usually get mangled.
+    extraSecretMounts:
+      - name: googlesheets-sa
+        secretName: grafana-secret
+        mountPath: /etc/secrets/googlesheets
+        readOnly: true
+        # 0440 in decimal, spelled out because YAML octal parsing differs
+        # between the tools this file passes through. Group-readable, not
+        # owner-only: secret volumes are owned by root with the group set to
+        # fsGroup (472), and Grafana runs as 472 — 0400 would lock it out.
+        defaultMode: 288
+        items:
+          - key: googlesheets-private-key
+            path: privateKey
+
+    # Declared here so the plugin set is reproducible from Git. Plugin admin is
+    # left enabled in grafana.ini so plugins can be trialled from the UI — but
+    # anything that earns a permanent place belongs in this list, otherwise it
+    # only exists on the PVC.
+    plugins:
+      - grafana-googlesheets-datasource
+
+    # ---- Git plane: datasources -------------------------------------------
+    # Rendered into a ConfigMap and mounted at
+    # /etc/grafana/provisioning/datasources. editable: false keeps the UI from
+    # offering edits that the next reconcile would silently revert.
+    #
+    # Every datasource carries an explicit uid: dashboard JSON references
+    # datasources by uid, so a stable one is what makes an exported dashboard
+    # portable back into Git. Without it Grafana mints a random uid per
+    # provisioning run and dashboards break on reprovision.
+    datasources:
+      datasources.yaml:
+        apiVersion: 1
+        datasources:
+          - name: Google Sheets
+            uid: googlesheets
+            type: grafana-googlesheets-datasource
+            access: proxy
+            isDefault: true
+            editable: false
+            jsonData:
+              # jwt = service account. The alternative, `key` (an API key), only
+              # reads sheets published to "anyone with the link" — no good for
+              # personal data. Each sheet must be shared with the client email
+              # below, exactly as if it were a person.
+              authenticationType: jwt
+              # $VAR is Grafana's provisioning interpolation; $$ is the escape
+              # that stops Flux's postBuild substitution from eating it first.
+              # If a value ever arrives at Grafana un-interpolated, the fallback
+              # is to inline it here — neither field is a secret.
+              clientEmail: $$GF_GOOGLE_SA_CLIENT_EMAIL
+              defaultProject: $$GF_GOOGLE_SA_PROJECT
+              tokenUri: https://oauth2.googleapis.com/token
+              privateKeyPath: /etc/secrets/googlesheets/privateKey
+
+    # ---- Git plane: dashboards --------------------------------------------
+    # The sidecar watches ConfigMaps in this namespace labelled
+    # grafana_dashboard: "1" and drops them into the provisioning tree.
+    sidecar:
+      dashboards:
+        enabled: true
+        label: grafana_dashboard
+        # Unset = this namespace only. Left alone deliberately: the monitoring
+        # instance's dashboards should not leak into the personal one.
+        searchNamespace: null
+        folder: /tmp/dashboards
+        # Each dashboard ConfigMap picks its Grafana folder with a
+        # `grafana_folder` annotation; unannotated ones land in "GitOps".
+        folderAnnotation: grafana_folder
+        defaultFolderName: GitOps
+        provider:
+          name: gitops
+          foldersFromFilesStructure: true
+          # The load-bearing half of the two-plane split: dashboards that came
+          # from Git are read-only in the browser, so there is no way to make a
+          # UI edit that a reconcile would throw away. Draft in the UI plane
+          # instead, then promote.
+          allowUiUpdates: false
+          # Removing the ConfigMap removes the dashboard — Git stays the truth
+          # for this folder.
+          disableDelete: false
+      datasources:
+        # Datasources come from the chart's own values above, not from labelled
+        # ConfigMaps. Nothing to watch.
+        enabled: false
+
+    # Sidecar only needs to read ConfigMaps in its own namespace; no reason for
+    # a cluster-scoped role.
+    rbac:
+      create: true
+      namespaced: true
+
+    "grafana.ini":
+      server:
+        root_url: https://lifeos.${SECRET_DOMAIN}
+      analytics:
+        check_for_updates: false
+        reporting_enabled: false
+        feedback_links_enabled: false
+      users:
+        allow_sign_up: false
+        allow_org_create: false
+        default_theme: dark
+      auth.anonymous:
+        enabled: false
+      security:
+        cookie_secure: true
+        disable_gravatar: true
+      plugins:
+        # Deliberately on: trialling a datasource plugin from the UI is part of
+        # how this instance is meant to be used. Promote keepers to `plugins:`.
+        plugin_admin_enabled: true
+      dashboards:
+        # Sheets reads go through the Google API on every refresh; a 5s panel
+        # interval would burn the per-minute quota for no benefit on data that
+        # changes when a human edits a spreadsheet.
+        min_refresh_interval: 1m
+      dataproxy:
+        # Sheets responses are slower than a Prometheus query. The 30s default
+        # times out on wide ranges.
+        timeout: 60
+      date_formats:
+        default_timezone: ${TIMEZONE}
+      log:
+        mode: console
+
+    # Ingress is Gateway API here — see httproute.yaml.
+    ingress:
+      enabled: false
+
+    # Prometheus discovers ServiceMonitors cluster-wide
+    # (serviceMonitorSelectorNilUsesHelmValues: false), so this instance shows
+    # up in the monitoring stack without any change over there.
+    serviceMonitor:
+      enabled: true
+
+    resources:
+      requests:
+        cpu: 50m
+        memory: 128Mi
+      limits:
+        # No CPU limit — Grafana is bursty on dashboard load and throttling
+        # shows up as UI lag. Memory is the resource worth bounding.
+        memory: 512Mi
+
+    testFramework:
+      enabled: false

--- a/kubernetes/apps/lifeos/grafana/app/httproute.yaml
+++ b/kubernetes/apps/lifeos/grafana/app/httproute.yaml
@@ -1,0 +1,28 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/gateway.networking.k8s.io/httproute_v1.json
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: grafana
+  annotations:
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/icon: grafana
+    gethomepage.dev/title: LifeOS
+    gethomepage.dev/description: "Personal reporting & aggregation"
+    gethomepage.dev/group: "LifeOS"
+spec:
+  # Single-label hostname: the wildcard cert covers ${SECRET_DOMAIN} and
+  # *.${SECRET_DOMAIN} only, so a second label would fail TLS. `lifeos` rather
+  # than `grafana-lifeos` because this is the front door of the personal stack —
+  # future LifeOS apps get their own names alongside it.
+  hostnames: ["lifeos.${SECRET_DOMAIN}"]
+  parentRefs:
+    # Internal only, and not negotiable: this instance aggregates personal data
+    # and authenticates with a single local admin account.
+    - name: envoy-internal
+      namespace: network
+      sectionName: https
+  rules:
+    - backendRefs:
+        - name: grafana
+          port: 80

--- a/kubernetes/apps/lifeos/grafana/app/kustomization.yaml
+++ b/kubernetes/apps/lifeos/grafana/app/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./ocirepository.yaml
+  - ./helmrelease.yaml
+  - ./httproute.yaml
+  - ./secret.sops.yaml
+  # Git-plane dashboards. One ConfigMap per dashboard; add new ones here.
+  - ./dashboard-lifeos-home.yaml

--- a/kubernetes/apps/lifeos/grafana/app/ocirepository.yaml
+++ b/kubernetes/apps/lifeos/grafana/app/ocirepository.yaml
@@ -1,0 +1,18 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: grafana
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 12.10.4
+  # The standalone Grafana chart moved out of grafana/helm-charts on
+  # 2026-01-30; grafana-community is where it is maintained now. This is a
+  # different chart from the one embedded in kube-prometheus-stack — the two
+  # instances version independently on purpose.
+  url: oci://ghcr.io/grafana-community/helm-charts/grafana

--- a/kubernetes/apps/lifeos/grafana/app/secret.sops.yaml
+++ b/kubernetes/apps/lifeos/grafana/app/secret.sops.yaml
@@ -1,0 +1,64 @@
+# ┌──────────────────────────────────────────────────────────────────────────┐
+# │ PLACEHOLDER — NOT ENCRYPTED WITH A REAL KEY. DO NOT MERGE AS-IS.          │
+# │                                                                          │
+# │ The ENC[...] values below are structural placeholders written by an agent │
+# │ that has the repo's age *public* key only. Flux will fail to decrypt this │
+# │ file, which fails the whole lifeos Kustomization closed — by design, so a │
+# │ half-configured Grafana never reaches the cluster.                        │
+# │                                                                          │
+# │ To make it real, replace the whole file and encrypt in place:             │
+# │                                                                          │
+# │   cat > kubernetes/apps/lifeos/grafana/app/secret.sops.yaml <<'EOF'       │
+# │   ---                                                                    │
+# │   apiVersion: v1                                                         │
+# │   kind: Secret                                                           │
+# │   metadata:                                                              │
+# │     name: grafana-secret                                                 │
+# │   type: Opaque                                                           │
+# │   stringData:                                                            │
+# │     admin-user: admin                                                    │
+# │     admin-password: "$(openssl rand -base64 24)"                         │
+# │     secret-key: "$(openssl rand -base64 32)"                             │
+# │     googlesheets-client-email: ""                                        │
+# │     googlesheets-project-id: ""                                          │
+# │     googlesheets-private-key: ""                                         │
+# │   EOF                                                                    │
+# │   sops --encrypt --in-place \                                            │
+# │     kubernetes/apps/lifeos/grafana/app/secret.sops.yaml                  │
+# │                                                                          │
+# │ All six keys must be present even if empty — googlesheets-private-key is  │
+# │ mounted by `items:` and a missing key wedges the pod in ContainerCreating.│
+# │ Empty Google values are fine on day one: Grafana starts, the Sheets       │
+# │ datasource just fails its health check until they are filled in.          │
+# │                                                                          │
+# │ secret-key encrypts datasource credentials stored in the Grafana DB.      │
+# │ Set it once and never rotate it — see docs/lifeos-grafana.md.             │
+# └──────────────────────────────────────────────────────────────────────────┘
+apiVersion: v1
+kind: Secret
+metadata:
+    name: grafana-secret
+type: Opaque
+stringData:
+    admin-user: ENC[AES256_GCM,data:PLACEHOLDER,iv:PLACEHOLDER,tag:PLACEHOLDER,type:str]
+    admin-password: ENC[AES256_GCM,data:PLACEHOLDER,iv:PLACEHOLDER,tag:PLACEHOLDER,type:str]
+    # Grafana's encryption key for secureJsonData rows in its own database.
+    secret-key: ENC[AES256_GCM,data:PLACEHOLDER,iv:PLACEHOLDER,tag:PLACEHOLDER,type:str]
+    # Google Cloud service account used by the Sheets datasource. Create the SA,
+    # enable the Google Sheets API + Google Drive API on the project, download a
+    # JSON key, then share each spreadsheet with the client email as a Viewer.
+    googlesheets-client-email: ENC[AES256_GCM,data:PLACEHOLDER,iv:PLACEHOLDER,tag:PLACEHOLDER,type:str]
+    googlesheets-project-id: ENC[AES256_GCM,data:PLACEHOLDER,iv:PLACEHOLDER,tag:PLACEHOLDER,type:str]
+    # The `private_key` field of that JSON key, as a real multi-line PEM
+    # (-----BEGIN PRIVATE KEY----- … ), with the \n escapes expanded.
+    googlesheets-private-key: ENC[AES256_GCM,data:PLACEHOLDER,iv:PLACEHOLDER,tag:PLACEHOLDER,type:str]
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            PLACEHOLDER
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1gekuxnpd95l5j8gsvmpsn2mewnevd0c5y5v66p4trzcqhmpn0svqkmnyy7
+    encrypted_regex: ^(data|stringData)$
+    mac_only_encrypted: true
+    version: 3.13.3

--- a/kubernetes/apps/lifeos/grafana/app/secret.sops.yaml
+++ b/kubernetes/apps/lifeos/grafana/app/secret.sops.yaml
@@ -6,9 +6,12 @@
 # │ file, which fails the whole lifeos Kustomization closed — by design, so a │
 # │ half-configured Grafana never reaches the cluster.                        │
 # │                                                                          │
-# │ To make it real, replace the whole file and encrypt in place:             │
+# │ To make it real, replace the whole file and encrypt in place. KEY is the  │
+# │ service-account JSON from docs/lifeos-google-credentials.md, which also    │
+# │ covers the GCP side — service account, Drive folder sharing, rotation.    │
 # │                                                                          │
-# │   cat > kubernetes/apps/lifeos/grafana/app/secret.sops.yaml <<'EOF'       │
+# │   KEY=~/grafana-lifeos.json                                              │
+# │   cat > kubernetes/apps/lifeos/grafana/app/secret.sops.yaml <<EOF         │
 # │   ---                                                                    │
 # │   apiVersion: v1                                                         │
 # │   kind: Secret                                                           │
@@ -19,12 +22,17 @@
 # │     admin-user: admin                                                    │
 # │     admin-password: "$(openssl rand -base64 24)"                         │
 # │     secret-key: "$(openssl rand -base64 32)"                             │
-# │     googlesheets-client-email: ""                                        │
-# │     googlesheets-project-id: ""                                          │
-# │     googlesheets-private-key: ""                                         │
+# │     googlesheets-client-email: "$(jq -r .client_email "$KEY")"           │
+# │     googlesheets-project-id: "$(jq -r .project_id "$KEY")"               │
+# │     googlesheets-private-key: |                                          │
+# │   $(jq -r .private_key "$KEY" | sed 's/^/    /')                         │
 # │   EOF                                                                    │
 # │   sops --encrypt --in-place \                                            │
 # │     kubernetes/apps/lifeos/grafana/app/secret.sops.yaml                  │
+# │                                                                          │
+# │ `jq -r` on private_key is load-bearing: it expands the JSON's \n escapes  │
+# │ into the real newlines a PEM needs. Hand-copying that field is the usual  │
+# │ way this integration fails.                                              │
 # │                                                                          │
 # │ All six keys must be present even if empty — googlesheets-private-key is  │
 # │ mounted by `items:` and a missing key wedges the pod in ContainerCreating.│

--- a/kubernetes/apps/lifeos/grafana/ks.yaml
+++ b/kubernetes/apps/lifeos/grafana/ks.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: grafana
+spec:
+  # The app ships a ServiceMonitor, so the monitoring.coreos.com CRDs have to
+  # exist first. kube-prometheus-stack's Kustomization gates its own Ready
+  # condition on its HelmRelease, so this actually waits for the CRDs rather
+  # than just for apply to succeed.
+  dependsOn:
+    - name: kube-prometheus-stack
+      namespace: monitoring
+  interval: 1h
+  path: ./kubernetes/apps/lifeos/grafana/app
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: lifeos
+  wait: false

--- a/kubernetes/apps/lifeos/kustomization.yaml
+++ b/kubernetes/apps/lifeos/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: lifeos
+
+components:
+  - ../../components/sops
+
+resources:
+  - ./namespace.yaml
+  - ./grafana/ks.yaml

--- a/kubernetes/apps/lifeos/namespace.yaml
+++ b/kubernetes/apps/lifeos/namespace.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: lifeos
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled

--- a/scripts/lifeos-dashboard-export.sh
+++ b/scripts/lifeos-dashboard-export.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# Promote a dashboard from the LifeOS Grafana UI plane into the Git plane.
+#
+# Pulls the dashboard JSON over Grafana's API and writes it out as a ConfigMap
+# under kubernetes/apps/lifeos/grafana/app/, registering the file in that
+# directory's kustomization.yaml. After committing, Flux reconciles it into the
+# GitOps folder — read-only from then on, so the UI copy should be deleted to
+# leave exactly one source of truth.
+#
+# Talks to the pod through a port-forward rather than the gateway hostname:
+# lifeos.<domain> resolves only on the home network, and this needs to work from
+# a devcontainer or a worktree too.
+#
+# Invoked via: task lifeos:dashboard:export uid=<uid> [folder=<name>]
+set -o errexit
+set -o nounset
+set -o pipefail
+
+UID_ARG="${1:?dashboard uid is required}"
+FOLDER="${2:-GitOps}"
+REPO_ROOT="${3:-$(git rev-parse --show-toplevel)}"
+
+NAMESPACE="lifeos"
+SERVICE="grafana"
+SECRET="grafana-secret"
+APP_DIR="${REPO_ROOT}/kubernetes/apps/lifeos/grafana/app"
+
+for bin in kubectl jq curl; do
+  command -v "${bin}" >/dev/null || { echo "Missing required tool: ${bin}" >&2; exit 1; }
+done
+
+user="$(kubectl -n "${NAMESPACE}" get secret "${SECRET}" -o jsonpath='{.data.admin-user}' | base64 -d)"
+password="$(kubectl -n "${NAMESPACE}" get secret "${SECRET}" -o jsonpath='{.data.admin-password}' | base64 -d)"
+
+# Port 0 lets the kernel pick a free port, so concurrent runs and a
+# already-in-use 3000 are both non-issues. kubectl prints the port it got.
+pf_log="$(mktemp)"
+kubectl -n "${NAMESPACE}" port-forward "svc/${SERVICE}" :80 >"${pf_log}" 2>&1 &
+pf_pid=$!
+# shellcheck disable=SC2064  # expand pf_pid/pf_log now, not at trap time
+trap "kill ${pf_pid} 2>/dev/null || true; rm -f ${pf_log}" EXIT
+
+local_port=""
+for _ in $(seq 1 50); do
+  local_port="$(sed -n 's/^Forwarding from 127\.0\.0\.1:\([0-9]*\).*/\1/p' "${pf_log}" | head -1)"
+  [[ -n "${local_port}" ]] && break
+  sleep 0.2
+done
+if [[ -z "${local_port}" ]]; then
+  echo "port-forward to ${SERVICE} never came up:" >&2
+  cat "${pf_log}" >&2
+  exit 1
+fi
+
+api="http://127.0.0.1:${local_port}"
+for _ in $(seq 1 50); do
+  curl -sS -o /dev/null --max-time 2 "${api}/api/health" && break || true
+  sleep 0.2
+done
+
+response="$(curl -sS --fail --max-time 30 \
+  -u "${user}:${password}" "${api}/api/dashboards/uid/${UID_ARG}")" || {
+  echo "Could not fetch dashboard '${UID_ARG}'. List available uids with:" >&2
+  echo "  task lifeos:dashboard:list" >&2
+  exit 1
+}
+
+title="$(jq -r '.dashboard.title' <<<"${response}")"
+slug="$(tr '[:upper:]' '[:lower:]' <<<"${title}" | sed -e 's/[^a-z0-9]\+/-/g' -e 's/^-//' -e 's/-$//')"
+[[ -n "${slug}" ]] || slug="$(tr '[:upper:]' '[:lower:]' <<<"${UID_ARG}" | sed -e 's/[^a-z0-9]\+/-/g')"
+
+# `id` is the instance-local primary key and is meaningless in another database;
+# `version` is the DB's optimistic-locking counter. Both have to go or the
+# provisioner treats the file as a foreign edit. `uid` stays — it is what
+# dashboard links and this script's own round-trip key on.
+dashboard="$(jq --sort-keys 'del(.dashboard.id, .dashboard.version) | .dashboard' <<<"${response}")"
+
+out_file="${APP_DIR}/dashboard-${slug}.yaml"
+{
+  echo "---"
+  echo "# Exported from the LifeOS Grafana UI plane by"
+  echo "# \`task lifeos:dashboard:export uid=${UID_ARG}\`."
+  echo "# Provisioned read-only — edit here and reconcile, not in the browser."
+  echo "apiVersion: v1"
+  echo "kind: ConfigMap"
+  echo "metadata:"
+  echo "  name: grafana-dashboard-${slug}"
+  echo "  labels:"
+  echo "    grafana_dashboard: \"1\""
+  echo "  annotations:"
+  echo "    grafana_folder: ${FOLDER}"
+  echo "data:"
+  echo "  ${slug}.json: |"
+  sed 's/^/    /' <<<"${dashboard}"
+} >"${out_file}"
+
+resource_line="  - ./dashboard-${slug}.yaml"
+if ! grep -qxF "${resource_line}" "${APP_DIR}/kustomization.yaml"; then
+  printf '%s\n' "${resource_line}" >>"${APP_DIR}/kustomization.yaml"
+  echo "Registered dashboard-${slug}.yaml in kustomization.yaml"
+fi
+
+echo "Wrote ${out_file}"
+echo
+echo "Grafana substitutes \${...} in dashboard JSON for its own template"
+echo "variables, and Flux substitutes it for cluster-secrets. If this dashboard"
+echo "uses template variables, escape each \$ as \$\$ before committing."
+echo
+echo "Next: commit, let Flux reconcile, then delete the UI copy of '${title}'."


### PR DESCRIPTION
Adds a `lifeos` namespace group and a standalone Grafana for personal reporting and aggregation, separate from the cluster-focused Grafana bundled in kube-prometheus-stack. Google Sheets is wired up as the first datasource.

## ⚠️ Before merging

`kubernetes/apps/lifeos/grafana/app/secret.sops.yaml` contains **structural `ENC[...]` placeholders, not real ciphertext** — an agent only has the repo's age *public* key. Flux will fail to decrypt it, which fails the whole `lifeos` Kustomization closed on purpose, so a half-configured Grafana never reaches the cluster.

The file's header comment has a ready-to-paste block that writes the real values and runs `sops --encrypt --in-place`. All six keys must be present even if empty; `googlesheets-private-key` is mounted via `items:` and a missing key wedges the pod in `ContainerCreating`. The Google values can start empty — Grafana comes up fine and only the Sheets datasource health check fails.

## The strategy: two planes, separated by folder

The ask was "GitOps as much as possible, but I'll also design this from the UI." Those pull in opposite directions — provisioned config overwrites Grafana's database on every reconcile, UI-authored config lives *only* in that database. Running both against the same objects gives you silent data loss in one direction or permanent drift in the other.

So they're split by folder, with the boundary enforced by Grafana rather than by discipline:

| | Git plane | UI plane |
|---|---|---|
| Where | the `GitOps` folder, plus any folder named by a `grafana_folder` annotation | every other folder |
| What | dashboard ConfigMaps, datasources, plugin list | drafts, folders, alert rules, playlists, preferences, API tokens |
| Stored in | this repo | SQLite on the PVC |
| Editable in browser | **no** — `allowUiUpdates: false` disables Save | yes |

Drift isn't discouraged, it's impossible: Git-provisioned dashboards physically cannot be saved from the browser. Draft in the UI plane, promote what proves useful.

### Promotion path

```sh
task lifeos:dashboard:list                                # find the uid
task lifeos:dashboard:export uid=<uid> [folder=Finance]   # write the ConfigMap
```

Pulls the dashboard over Grafana's API through a port-forward, strips the database-local `id`/`version`, keeps the `uid`, writes `dashboard-<slug>.yaml` and registers it in the app `kustomization.yaml`. Then commit, let Flux reconcile, delete the UI copy.

### Consequence for storage

The monitoring instance's PVC is a cache — delete it and Flux rebuilds it exactly. This one's is not, so it uses the default `longhorn` class (3 replicas + recurring S3 backups) rather than a `-no-backup` class. `GF_SECURITY_SECRET_KEY` comes from the SOPS secret and must never be rotated once set, or every credential row already in the database becomes undecryptable.

## Google Sheets

Authenticates as a Google Cloud **service account**, not as you — so a spreadsheet is invisible to Grafana until it's shared with the service account's email, exactly like sharing with a person. Setup steps are in the docs.

The private key is mounted as a file (`privateKeyPath`) rather than pushed through env-var interpolation, which is where PEM newlines usually get mangled. Client email and project ID *are* interpolated from env (`$$GF_...`, `$$` escaping Flux's own substitution) — not because they're secret, but to keep a private GCP project name out of the manifests. Panel refresh is floored at 1m since every refresh is a live Google API call.

## Conventions followed

- Namespace group `lifeos` with the namespace transformer + `components: [../../components/sops]`; no changes under `kubernetes/flux/`.
- Canonical `ks.yaml`; the only addition is `dependsOn: kube-prometheus-stack` (monitoring), needed purely for the `monitoring.coreos.com` CRDs the ServiceMonitor uses.
- OCIRepository named after the app. Chart is `ghcr.io/grafana-community/helm-charts/grafana` — the standalone Grafana chart left `grafana/helm-charts` on 2026-01-30. Independent of the kube-prometheus-stack bundle, which is untouched.
- Gateway API `HTTPRoute` on `envoy-internal` (personal data, single local admin, no OIDC provider in the cluster yet), hostname `lifeos.${SECRET_DOMAIN}` — single-label so the wildcard cert covers it. Rename in one line if you'd rather keep `lifeos.` free for a future front door.
- Homepage annotations on the route, plus a `LifeOS` layout group in the homepage config.

## Files

- `kubernetes/apps/lifeos/` — namespace group + the Grafana app (HelmRelease, OCIRepository, HTTPRoute, SOPS secret, seed dashboard)
- `docs/lifeos-grafana.md` — the strategy, promotion workflow, Google setup, operating notes
- `.taskfiles/lifeos/` + `scripts/lifeos-dashboard-export.sh` — the promotion tooling
- The seed `LifeOS — Start Here` dashboard documents the workflow in the UI and proves the ConfigMap → sidecar → provisioning path works before any real dashboard depends on it

## Verification

No cluster or Helm access from this environment, so this is desk-checked: YAML and embedded dashboard JSON parse, `bash -n` clean, chart values checked field-by-field against `grafana-community/helm-charts@12.10.4` (`rbac.namespaced`, `sidecar.dashboards.folderAnnotation`/`defaultFolderName`, `extraSecretMounts.items`, `testFramework` all confirmed present). **Flux Local's render is the real gate here.**

Not tested and worth watching on first deploy: whether Grafana's provisioning interpolates `$GF_GOOGLE_SA_CLIENT_EMAIL` inside `jsonData` (fallback is to inline both values — neither is secret), and the `foldersFromFilesStructure` + `folderAnnotation` folder layout.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Faz7VVA1GbF9WfgYTwVqfC)_