### PR TITLE
fix(hermes-ai-agent): stop credential-pool rotation onto metered Anthropic key

### DIFF
--- a/kubernetes/apps/default/hermes-ai-agent/README.md
+++ b/kubernetes/apps/default/hermes-ai-agent/README.md
@@ -43,22 +43,62 @@ should not duplicate managed keys once migration is verified (see "Post-merge").
   `curl -s -X POST -H 'Content-Type: application/json' "https://generativelanguage.googleapis.com/v1beta/models/<id>:generateContent?key=$GOOGLE_API_KEY" -d '{"contents":[{"parts":[{"text":"hi"}]}]}'`
   — check for a `candidates` response, not just a non-404 status (a bare `-w '%{http_code}'`
   check without `-H 'Content-Type: application/json'` can itself 404 and mislead).
-- **Fallback: Claude** — resilience only; `fallback_providers` fires on Gemini
-  rate-limit/overload/connection errors, **not** on task difficulty.
+- **Fallback: Claude Haiku 4.5** — resilience only; `fallback_providers` fires on Gemini
+  rate-limit/overload/connection errors, **not** on task difficulty. Pinned to
+  `claude-haiku-4-5` (alias) rather than Sonnet — see the cap section below.
 - **Claude selectively for hard tasks** — manual `/model claude-sonnet-4-6` in Telegram,
   or per-cron `-m claude-sonnet-4-6`. Not automatic by design.
 
-### ⚠️ Claude subscription-OAuth is a LIVE POLICY RISK
+### Claude subscription-OAuth: what actually limits it
 
 Claude via `CLAUDE_CODE_OAUTH_TOKEN` routes through the Pro subscription instead of
-pay-per-token. Anthropic flipped this policy repeatedly through 2026 (banned Apr →
-reinstated May with an Agent-SDK credit → credit split paused mid-June). Treat it as
-unstable. **The dependency is isolated to one secret key.**
+pay-per-token, and **this works** — subscription OAuth is not blocked for programmatic
+use. Verified 2026-08-09 on the live token, same headers, same second:
 
-**Reversibility (one step):** if OAuth breaks, blank `CLAUDE_CODE_OAUTH_TOKEN` in the
-secret — Claude falls back to `ANTHROPIC_API_KEY` (raw pay-per-token, already stored).
-Nothing else changes. Do **not** design cron/mission-critical work around OAuth; point
-those at Gemini.
+| model | result |
+|---|---|
+| `claude-haiku-4-5` | 200 OK (plan-billed) |
+| `claude-sonnet-4-6` | 429 `rate_limit_error` |
+| `claude-opus-5` | 429 `rate_limit_error` |
+
+**What runs out is the per-model-tier weekly cap, not the plan.** Symptom when the Sonnet
+cap trips: `HTTP 400 "You're out of extra usage. Add more at claude.ai/settings/usage"`.
+That is *not* "plan quota gone" — Anthropic offers extra usage as the overflow lane once a
+tier cap is hit, and with a $0 extra-usage balance the request 400s while the plan still
+shows plenty of headroom. Don't read that 400 as a policy revocation.
+
+Corollary: pin unattended work to the cheapest adequate tier. Haiku had full headroom at
+the moment Sonnet and Opus were both capped, which is why fallback targets Haiku.
+
+### ⚠️ The credential pool rotates onto metered billing by itself
+
+Hermes does **not** treat the Anthropic credentials as "primary + manual backup". On every
+`load_pool()` it auto-seeds *every* Anthropic env var it finds into one pool
+(`agent/credential_pool.py::_seed_from_env`; priority OAuth 1, `ANTHROPIC_API_KEY` 4) and
+walks it with the `fill_first` strategy, marking a credential `exhausted` for 1h on a
+400/429. So the moment the OAuth entry is capped, the pool **silently rotates onto
+`ANTHROPIC_API_KEY`** — a separate metered Console org (verified: OAuth org `3878b11e-…`
+vs API-key org `67b048cd-…`). Nothing announces this: Hermes logs failures only, and the
+pool's own `request_count` counters stay at 0.
+
+`ANTHROPIC_API_KEY` is therefore **deliberately blank** in `secret.sops.yaml`, which makes
+the pool OAuth-only. Inspect the pool with:
+
+```sh
+kubectl -n default exec deploy/hermes-ai-agent -c app -- hermes auth list
+kubectl -n default exec deploy/hermes-ai-agent -c app -- hermes auth reset anthropic  # clear stale exhaustion flags
+```
+
+If a metered backstop is ever wanted, refill the key **knowingly** — the old value is
+recoverable from git history with `age.key`. `hermes auth remove anthropic <N>` also
+suppresses a pool entry durably, but that flag lives on the PVC, not in Git.
+
+**Token scope gotcha:** a `claude setup-token` carries `user:inference` but not
+`user:profile`, so `GET /api/oauth/usage` returns
+`403 permission_error: OAuth token does not meet scope requirement user:profile` and
+`hermes`'s own usage/billing views cannot read the plan windows. `hermes login` mints a
+full-scope refreshable token instead — worth doing if you want cap visibility from inside
+the pod rather than from claude.ai.
 
 ## Web dashboard
 
@@ -150,14 +190,26 @@ Run inside the pod (`kubectl -n default exec -it deploy/hermes-ai-agent -c app -
 ```sh
 hermes backup
 hermes config set model.provider gemini
-hermes config set model.default gemini-2.5-flash
+hermes config set model.default gemini-flash-latest   # alias, not a pin — see "Why an alias" above
 hermes config set skills.write_approval true       # skill writes need approval
 hermes config set skills.guard_agent_created true  # guard agent-created skills
 hermes curator pause
 # Fallback must be added interactively (writes full provider metadata):
-hermes fallback add        # pick: anthropic / claude-sonnet-4-6
+hermes fallback add        # pick: anthropic / claude-haiku-4-5
 hermes fallback list       # verify
 ```
+
+`hermes fallback` has **no non-interactive flags** (`add`/`remove` are pickers only), so
+retargeting an existing chain from a script means editing `/opt/data/config.yaml` directly.
+Back the file up first — the shape is minimal:
+
+```yaml
+fallback_providers:
+  - provider: anthropic
+    model: claude-haiku-4-5
+```
+
+Then restart the pod to reload (see "Restart to reload config.yaml").
 
 ### Post-merge (after the Secret lands via Flux and the pod restarts)
 
@@ -165,7 +217,9 @@ Provider keys now arrive as env from the Secret. Collapse the dual source so Git
 authoritative:
 
 ```sh
-# 1. Confirm env injection worked (names only):
+# 1. Confirm env injection worked (names only).
+#    Expected: ANTHROPIC_API_KEY EMPTY (intentional — see the credential-pool section),
+#    everything else set.
 kubectl -n default exec deploy/hermes-ai-agent -c app -- sh -c \
   'for v in GOOGLE_API_KEY ANTHROPIC_API_KEY CLAUDE_CODE_OAUTH_TOKEN TELEGRAM_BOT_TOKEN; do \
    eval x=\$$v; [ -n "$x" ] && echo "$v set" || echo "$v EMPTY"; done'

--- a/kubernetes/apps/default/hermes-ai-agent/app/secret.sops.yaml
+++ b/kubernetes/apps/default/hermes-ai-agent/app/secret.sops.yaml
@@ -3,49 +3,66 @@
 # Injected as container env via HelmRelease `envFrom: secretRef`.
 #
 # PROVIDER ROUTING (see README):
-#   Primary  : Gemini  -> GOOGLE_API_KEY  (Google AI Pro / AI Studio key)
+#   Primary  : Gemini  -> GOOGLE_API_KEY  (currently a FREE-tier key — 429s constantly,
+#              which is what forces the Claude fallback on nearly every turn)
 #   Fallback : Claude  -> CLAUDE_CODE_OAUTH_TOKEN  (Pro subscription OAuth via `claude setup-token`)
-#     *** LIVE POLICY RISK ***: Anthropic flipped subscription-OAuth for programmatic
-#     use repeatedly in 2026. REVERSIBILITY: blank CLAUDE_CODE_OAUTH_TOKEN and Claude
-#     falls back to ANTHROPIC_API_KEY (raw pay-per-token). No other change needed.
+#
+# ANTHROPIC_API_KEY IS DELIBERATELY BLANK — DO NOT REFILL WITHOUT READING THIS.
+#   Hermes does not treat the Anthropic credentials as "primary + manual backup". It
+#   auto-seeds EVERY Anthropic env var it finds into one credential pool
+#   (agent/credential_pool.py::_seed_from_env, priority: OAuth 1, ANTHROPIC_API_KEY 4)
+#   and rotates down that pool with `fill_first`. So whenever the OAuth entry is marked
+#   exhausted — e.g. the plan's per-model weekly cap for Sonnet trips — the pool silently
+#   rotates onto ANTHROPIC_API_KEY, which bills a SEPARATE metered Console org
+#   (verified 2026-08-09: OAuth org 3878b11e-…, API-key org 67b048cd-…). That rotation is
+#   the credit-spend path, and nothing in the logs announces it (only failures log).
+#   Keeping this blank makes the pool OAuth-only. Old value is recoverable from git
+#   history with age.key if a metered backstop is ever wanted again.
+#
+# Plan billing DOES work for Hermes — subscription OAuth is not blocked (verified
+# 2026-08-09: claude-haiku-4-5 returned 200 on this token while claude-sonnet-4-6 and
+# claude-opus-5 both 429'd). What runs out is the per-model-tier weekly cap, not the plan.
+# Fallback is therefore pinned to Haiku in /opt/data/config.yaml, not Sonnet.
 #
 # Fill/rotate:  sops kubernetes/apps/default/hermes-ai-agent/app/secret.sops.yaml
-# Set CLAUDE_CODE_OAUTH_TOKEN with the output of `claude setup-token` to enable OAuth (or blank it to fall back to ANTHROPIC_API_KEY).
+# Set CLAUDE_CODE_OAUTH_TOKEN with the output of `claude setup-token`. Note a setup-token
+# carries no `user:profile` scope, so /api/oauth/usage 403s and `hermes` cannot read your
+# plan windows; `hermes login` mints a full-scope, refreshable token instead.
 apiVersion: v1
 kind: Secret
 metadata:
-    name: hermes-ai-agent-secret
-    namespace: default
-    labels:
-        app.kubernetes.io/name: hermes-ai-agent
+  name: hermes-ai-agent-secret
+  namespace: default
+  labels:
+    app.kubernetes.io/name: hermes-ai-agent
 type: Opaque
 stringData:
-    API_SERVER_KEY: ENC[AES256_GCM,data:+6Rp/0kis3a+f2WOkYADaBbXhh4NDmwrlRqaNMP3+5/fhf7If6HCQVR7j3LohWop/7lgyUF+ZY/d4s8b7WF4Sw==,iv:I2bgyT2rSQjqFowSq+0I5GK6yB9upr9yGQBjdpks+JE=,tag:bOtnajxFjgouaWzUFZdITw==,type:str]
-    GOOGLE_API_KEY: ENC[AES256_GCM,data:RwGWFZWj0pY5OzaBn9fhpVIjhB/L0EJz266rk/48Ou+TdOO9BHQQf1zTaNOH9AfRQZ52Qm0=,iv:NT5sAptrzYvgFo6XLkjetb6qf6hQHRpz12uE25k4Lx8=,tag:rPrkUFrBzGOs2eMhwxT2xg==,type:str]
-    ANTHROPIC_API_KEY: ENC[AES256_GCM,data:0dqLu62OifmPOpNH0rKOADrX/eAK4ujvHrPThoABJAAZDjbz1kiwPhk5fAeCVzvIVuD393kwgoESf7Fb6Rie5LgBJ2t1141qkf+xGdnPjckDd6LAdNjQn2n7hkuVmti3RFTfwi3/rNcwY8fM,iv:pizVplmoG/bWIhDU0nT47fby2+Tdiw+Nvacw2N/Rmj8=,tag:c85OCXiTpJNdfcOJ3HF+qQ==,type:str]
-    CLAUDE_CODE_OAUTH_TOKEN: ENC[AES256_GCM,data:60q3ppsHTcUfwDqoerp5aEtBWreDM6SAJ0X3iu2uFMk2yedaJ59uZ1KrtBhaThQMjixrHbWWZOL/8izp1h3+1Bn2n7BItNhwMhihSIJMw8y0jPMEKkw3EyHI0lsBtzEEm0FdjGaG/fDa64lj,iv:gMxTYervLGMOQklmIvDLlG2iF5zT5IbnrDZ760Npx7s=,tag:rlDI4LFMDHoKr8CnW2wdtg==,type:str]
-    OPENROUTER_API_KEY: ENC[AES256_GCM,data:aS0VJFyHzTSCJi/+YK0NVixx3qBhqchl79A8ixveYvof81t4pOJZvoM8OGLLTX3ZYu8OBpiThZEv/X3sE+gUxWS2s2RfUvlMng==,iv:IBpMC28MAVs4ZDxWYe5TnepklIFRxDyKbTAkIJKcpEQ=,tag:5q7rNyGOUWKFsqINyeQvDg==,type:str]
-    FAL_KEY: ENC[AES256_GCM,data:PazMu5nDcYJBT6xC5h8ZyyQikWvih4b9eZEaCwyMI059cSF3nazcwFe50HQBvlYJ0IJn96Zzpshquk/urh1OeF0OTRKr,iv:D7kttmqWZJ2QIP2WJvxrWSaAH4oUu1F7+rKtQhV0CFQ=,tag:QX4oTDoimQHDmdHuvJlDsA==,type:str]
-    TELEGRAM_BOT_TOKEN: ENC[AES256_GCM,data:MytwMPUpF7uPsOPD25GeQ18fW7/7ugVo9L5JCHIdb/YaZIDLZ86UUUo0U1P5Bg==,iv:2raHx2kG+bmUdhpSMZ2T8XOE5jr2ZAQI9acXIkX87UU=,tag:7u7GQNssfKUfcmkzfgIhmw==,type:str]
-    TELEGRAM_ALLOWED_USERS: ENC[AES256_GCM,data:OKXYNULq8pgAbg==,iv:TpOLTZCBQ7SX8O0TyFp5mW8a1nyVVI3pSUm/LKrsHj4=,tag:u4ixqAr0KbPNzzIX2rQRKg==,type:str]
-    TELEGRAM_HOME_CHANNEL: ENC[AES256_GCM,data:obei1dNKeQqsfQ==,iv:n5n+SKWIM2yZHWyJSnS6n4vqmk7OGswe7/wz1EA+ch4=,tag:5b2LZJpWTwGkSlyc08GHgQ==,type:str]
-    TERMINAL_ENV: ENC[AES256_GCM,data:OTBX/7I=,iv:FOCzHqWRFeyy+NEytjGfcK9vFHZEJo4h/e/CHc4JYOM=,tag:HyfZeRCnzlkWYBo4bnAeMg==,type:str]
-    HERMES_DASHBOARD_BASIC_AUTH_USERNAME: ENC[AES256_GCM,data:BC5t4A==,iv:iYk4x61OIpzyJLT5cUc6veZrx0XDdS2Utht0yLWR3kA=,tag:BZfvPTiveiywB7ZgDJDXqw==,type:str]
-    HERMES_DASHBOARD_BASIC_AUTH_PASSWORD_HASH: ENC[AES256_GCM,data:g40bthRgF1jwN6Tap4sW1tNeOi2Wl/+3NXoDdEdEwVFyAa1xL1g5Inv65EsSRiWPyT0T4N/q9qMc94HK48+hkGTdR0OwLXQva1IgOEWxBBM4IYngOgY=,iv:C0/mVA0+PjzNeH6a784UFkbrRQPoRIXqGSAqH8Fq3CI=,tag:McXKfkijvMiLiJgvPYZNnw==,type:str]
-    HERMES_DASHBOARD_BASIC_AUTH_SECRET: ENC[AES256_GCM,data:vvVesfZHvJPr0A8g3A+kxKxoLRFPKXELeegQFIze8vK5wqy3fqOIng5P/cD4I1y1qkDAA5DFbqnyRZZn4N2PNg==,iv:OQpwVozDeQHmVapcgMQ1ZRSLf+F0d2ZbBuaDj+TyWpw=,tag:TToGIND0vEmLB3VipPtJ8Q==,type:str]
+  API_SERVER_KEY: ENC[AES256_GCM,data:+6Rp/0kis3a+f2WOkYADaBbXhh4NDmwrlRqaNMP3+5/fhf7If6HCQVR7j3LohWop/7lgyUF+ZY/d4s8b7WF4Sw==,iv:I2bgyT2rSQjqFowSq+0I5GK6yB9upr9yGQBjdpks+JE=,tag:bOtnajxFjgouaWzUFZdITw==,type:str]
+  GOOGLE_API_KEY: ENC[AES256_GCM,data:RwGWFZWj0pY5OzaBn9fhpVIjhB/L0EJz266rk/48Ou+TdOO9BHQQf1zTaNOH9AfRQZ52Qm0=,iv:NT5sAptrzYvgFo6XLkjetb6qf6hQHRpz12uE25k4Lx8=,tag:rPrkUFrBzGOs2eMhwxT2xg==,type:str]
+  ANTHROPIC_API_KEY: ""
+  CLAUDE_CODE_OAUTH_TOKEN: ENC[AES256_GCM,data:60q3ppsHTcUfwDqoerp5aEtBWreDM6SAJ0X3iu2uFMk2yedaJ59uZ1KrtBhaThQMjixrHbWWZOL/8izp1h3+1Bn2n7BItNhwMhihSIJMw8y0jPMEKkw3EyHI0lsBtzEEm0FdjGaG/fDa64lj,iv:gMxTYervLGMOQklmIvDLlG2iF5zT5IbnrDZ760Npx7s=,tag:rlDI4LFMDHoKr8CnW2wdtg==,type:str]
+  OPENROUTER_API_KEY: ENC[AES256_GCM,data:aS0VJFyHzTSCJi/+YK0NVixx3qBhqchl79A8ixveYvof81t4pOJZvoM8OGLLTX3ZYu8OBpiThZEv/X3sE+gUxWS2s2RfUvlMng==,iv:IBpMC28MAVs4ZDxWYe5TnepklIFRxDyKbTAkIJKcpEQ=,tag:5q7rNyGOUWKFsqINyeQvDg==,type:str]
+  FAL_KEY: ENC[AES256_GCM,data:PazMu5nDcYJBT6xC5h8ZyyQikWvih4b9eZEaCwyMI059cSF3nazcwFe50HQBvlYJ0IJn96Zzpshquk/urh1OeF0OTRKr,iv:D7kttmqWZJ2QIP2WJvxrWSaAH4oUu1F7+rKtQhV0CFQ=,tag:QX4oTDoimQHDmdHuvJlDsA==,type:str]
+  TELEGRAM_BOT_TOKEN: ENC[AES256_GCM,data:MytwMPUpF7uPsOPD25GeQ18fW7/7ugVo9L5JCHIdb/YaZIDLZ86UUUo0U1P5Bg==,iv:2raHx2kG+bmUdhpSMZ2T8XOE5jr2ZAQI9acXIkX87UU=,tag:7u7GQNssfKUfcmkzfgIhmw==,type:str]
+  TELEGRAM_ALLOWED_USERS: ENC[AES256_GCM,data:OKXYNULq8pgAbg==,iv:TpOLTZCBQ7SX8O0TyFp5mW8a1nyVVI3pSUm/LKrsHj4=,tag:u4ixqAr0KbPNzzIX2rQRKg==,type:str]
+  TELEGRAM_HOME_CHANNEL: ENC[AES256_GCM,data:obei1dNKeQqsfQ==,iv:n5n+SKWIM2yZHWyJSnS6n4vqmk7OGswe7/wz1EA+ch4=,tag:5b2LZJpWTwGkSlyc08GHgQ==,type:str]
+  TERMINAL_ENV: ENC[AES256_GCM,data:OTBX/7I=,iv:FOCzHqWRFeyy+NEytjGfcK9vFHZEJo4h/e/CHc4JYOM=,tag:HyfZeRCnzlkWYBo4bnAeMg==,type:str]
+  HERMES_DASHBOARD_BASIC_AUTH_USERNAME: ENC[AES256_GCM,data:BC5t4A==,iv:iYk4x61OIpzyJLT5cUc6veZrx0XDdS2Utht0yLWR3kA=,tag:BZfvPTiveiywB7ZgDJDXqw==,type:str]
+  HERMES_DASHBOARD_BASIC_AUTH_PASSWORD_HASH: ENC[AES256_GCM,data:g40bthRgF1jwN6Tap4sW1tNeOi2Wl/+3NXoDdEdEwVFyAa1xL1g5Inv65EsSRiWPyT0T4N/q9qMc94HK48+hkGTdR0OwLXQva1IgOEWxBBM4IYngOgY=,iv:C0/mVA0+PjzNeH6a784UFkbrRQPoRIXqGSAqH8Fq3CI=,tag:McXKfkijvMiLiJgvPYZNnw==,type:str]
+  HERMES_DASHBOARD_BASIC_AUTH_SECRET: ENC[AES256_GCM,data:vvVesfZHvJPr0A8g3A+kxKxoLRFPKXELeegQFIze8vK5wqy3fqOIng5P/cD4I1y1qkDAA5DFbqnyRZZn4N2PNg==,iv:OQpwVozDeQHmVapcgMQ1ZRSLf+F0d2ZbBuaDj+TyWpw=,tag:TToGIND0vEmLB3VipPtJ8Q==,type:str]
 sops:
-    age:
-        - enc: |
-            -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBEamgyZVU5VG5TUmZoTFF6
-            TE0wd29PeUZPdURDaXdrL2VRR0ppRmFZQWc4Ck5ic3ppajBzdUM4WTJ0UEJURWlk
-            WWM1MGsxZ01UU0kza251Q0tQOFFHRVUKLS0tIHJZSUhCMVYvMVhaSGtQNWo0cUg1
-            bVFnNlVqcHVYQWc4eDRsVThWTWNxcDAKIdFj2mriL+A5NfpzIxPeAn/gszs+Cych
-            m7VKFMJjh7/aA5MIgScY/2yWVoEqcop6AUZrJ6lqPUl3VOLTmpzhng==
-            -----END AGE ENCRYPTED FILE-----
-          recipient: age1gekuxnpd95l5j8gsvmpsn2mewnevd0c5y5v66p4trzcqhmpn0svqkmnyy7
-    encrypted_regex: ^(data|stringData)$
-    lastmodified: "2026-07-31T15:08:35Z"
-    mac: ENC[AES256_GCM,data:R8WC8VwNx2D+KNLKz/LwXuBVqbAIQU8LtsgWlXnEyvPQ8mEemPscepQyDmKCpAe27bCbsZbD62YxoT/31jkW8ftAgfJYhVboD+3PcB+o+mvDO3xatRj7GPgKA7oxSbUnXLkKtEKjb09/p0vjGHiBwjGvj6CQhE/kuBebZ1MtMug=,iv:/kKkkF9v3+S7irlaXyhrKoGqUSYdsXqGL2vOccgKY5c=,tag:cwhhC22T4Q1qhnRgXodeBg==,type:str]
-    mac_only_encrypted: true
-    version: 3.13.3
+  age:
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBEamgyZVU5VG5TUmZoTFF6
+        TE0wd29PeUZPdURDaXdrL2VRR0ppRmFZQWc4Ck5ic3ppajBzdUM4WTJ0UEJURWlk
+        WWM1MGsxZ01UU0kza251Q0tQOFFHRVUKLS0tIHJZSUhCMVYvMVhaSGtQNWo0cUg1
+        bVFnNlVqcHVYQWc4eDRsVThWTWNxcDAKIdFj2mriL+A5NfpzIxPeAn/gszs+Cych
+        m7VKFMJjh7/aA5MIgScY/2yWVoEqcop6AUZrJ6lqPUl3VOLTmpzhng==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1gekuxnpd95l5j8gsvmpsn2mewnevd0c5y5v66p4trzcqhmpn0svqkmnyy7
+  encrypted_regex: ^(data|stringData)$
+  lastmodified: "2026-08-09T14:15:49Z"
+  mac: ENC[AES256_GCM,data:p1RW+B92mLeI5uYk4pB5Id/fIa6q9yjUIOQo6w1aRmU1CC0XIxYqFgROx09nStT5aVU2+0EXbjSj9VGjODC9VHXA7cOIeql36SptxpxspxQay3TXZhpo/hfJgjqVnJ/b57ITOEagstD52Xu/TFS99uDDik85uBcbZWuQssAcBf4=,iv:bOUStvYH3wE1jnCLLE0z6dQGkZXokQUMkackIROEZ7Q=,tag:RWzvyqVfCvCaws3Hsx52BQ==,type:str]
+  mac_only_encrypted: true
+  version: 3.13.3


### PR DESCRIPTION
## What was happening

Hermes appeared to be spending Anthropic API credits as a Gemini fallback, while the Claude Pro plan showed plenty of headroom. Both observations were correct, for a reason neither the README nor the secret comments described.

`agent/credential_pool.py::_seed_from_env` auto-seeds **every** Anthropic env var it finds into one credential pool (priority: OAuth 1, `ANTHROPIC_API_KEY` 4) and walks it with the `fill_first` strategy, marking a credential `exhausted` for 1h on a 400/429. There is no "primary + manual backup" — the presence of the key in the Secret *is* the enrollment. So when the OAuth entry tripped the plan's per-model weekly cap for Sonnet, the pool silently rotated onto `ANTHROPIC_API_KEY`, which bills a **separate metered Console org**:

| credential | org | probe result |
|---|---|---|
| `CLAUDE_CODE_OAUTH_TOKEN` | `3878b11e-2378-…` (subscription) | 429 on Sonnet/Opus, **200 on Haiku** |
| `ANTHROPIC_API_KEY` | `67b048cd-0b08-…` (Console, metered) | 200 — live and billable |

Nothing announces the rotation: Hermes logs failures only, so successful metered calls leave no trace, and the pool's own `request_count` counters stay at 0.

## Plan billing is not blocked

Subscription OAuth for programmatic use works. Verified on the live token, same headers, same second:

| model | result |
|---|---|
| `claude-haiku-4-5` | 200 OK (plan-billed) |
| `claude-sonnet-4-6` | 429 `rate_limit_error` |
| `claude-opus-5` | 429 `rate_limit_error` |

What runs out is the **per-model-tier weekly cap**, not the plan. The resulting `HTTP 400 "You're out of extra usage. Add more at claude.ai/settings/usage"` is the overflow lane reporting a $0 balance — it reads like plan exhaustion but isn't. The previous comments had this backwards and presented the metered rotation as intended reversibility.

## Changes

- **`secret.sops.yaml`** — `ANTHROPIC_API_KEY` blanked, making the pool OAuth-only. Decrypt + MAC verified; every other value confirmed byte-identical (key→length map diffed against `HEAD`). Old value recoverable from git history with `age.key` if a metered backstop is ever wanted again. Note `sops set` reindented the file 4→2 spaces, hence the line count for a one-value edit — now matches `.editorconfig`.
- **`README.md`** — replaced the inverted policy-risk section with the cap-tier probe table, the pool-rotation warning, and the `user:profile` scope gotcha (a `claude setup-token` can't read `/api/oauth/usage`, so `hermes` cannot see your plan windows; `hermes login` mints a full-scope refreshable token). Bootstrap sequence updated: `gemini-flash-latest` instead of the retired `gemini-2.5-flash` pin, Haiku instead of Sonnet for fallback, plus a note that `hermes fallback` has no non-interactive flags.

## Applied out-of-band (runtime plane, not Git)

`fallback_providers` retargeted Sonnet → `claude-haiku-4-5` in `/opt/data/config.yaml`, since `hermes fallback add` is an interactive picker only. Backup at `config.yaml.bak-pre-haiku-fallback-20260809T141501Z` plus a `hermes backup` zip. `hermes auth reset anthropic` cleared the stale exhaustion flags.

## Known-remaining

`GOOGLE_API_KEY` is on the **free tier** — Hermes says so explicitly in its 429 handler — which is what forces the Claude fallback on nearly every turn. Deliberately out of scope here; fixing it (billing-enabled project + key rotation) would remove most of the pressure that makes any of this matter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
