### PR TITLE
feat(freshrss): add FreshRSS RSS aggregator to default namespace

### DIFF
--- a/kubernetes/apps/default/freshrss/app/helmrelease.yaml
+++ b/kubernetes/apps/default/freshrss/app/helmrelease.yaml
@@ -1,0 +1,98 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app freshrss
+spec:
+  interval: 1h
+  chartRef:
+    kind: OCIRepository
+    name: freshrss
+  install:
+    remediation:
+      retries: -1
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  values:
+    controllers:
+      main:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        # Official image's entrypoint (Apache + cron) runs as root and writes
+        # into /var/www/FreshRSS/data at start — no PUID/PGID support like
+        # linuxserver images. Default (root) pod security context is
+        # intentional, not an oversight.
+        containers:
+          app:
+            image:
+              repository: docker.io/freshrss/freshrss
+              tag: "1.29.1"
+            envFrom:
+              - secretRef:
+                  name: freshrss-secret
+            env:
+              TZ: ${TIMEZONE}
+              BASE_URL: https://freshrss.${SECRET_DOMAIN}
+              # sqlite is the default when DB_HOST is unset; pinned explicitly
+              # so the unattended installer's DB choice doesn't rely on that
+              # implicit default.
+              DB_TYPE: sqlite
+              ADMIN_EMAIL: admin@${SECRET_DOMAIN}
+              DEFAULT_USER: admin
+              # Twice-hourly feed refresh cron, run by the container's own cron.
+              CRON_MIN: "1,31"
+              LANGUAGE: en
+            probes:
+              liveness: &probe
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /
+                    port: &port 80
+                  initialDelaySeconds: 30
+                  periodSeconds: 30
+                  timeoutSeconds: 10
+                  failureThreshold: 6
+              readiness: *probe
+            resources:
+              requests:
+                cpu: 25m
+                memory: 256Mi
+              limits:
+                memory: 512Mi
+
+    service:
+      main:
+        controller: main
+        ports:
+          http:
+            port: *port
+
+    route:
+      main:
+        annotations:
+          gethomepage.dev/enabled: "true"
+          gethomepage.dev/icon: freshrss
+          gethomepage.dev/title: FreshRSS
+          gethomepage.dev/description: "RSS feed aggregator"
+          gethomepage.dev/group: "Reading"
+        hostnames:
+          - freshrss.${SECRET_DOMAIN}
+        parentRefs:
+          - name: envoy-external
+            namespace: network
+            sectionName: https
+        rules:
+          - backendRefs:
+              - identifier: main
+                port: *port
+
+    persistence:
+      data:
+        existingClaim: freshrss-data
+        globalMounts:
+          - path: /var/www/FreshRSS/data

--- a/kubernetes/apps/default/freshrss/app/kustomization.yaml
+++ b/kubernetes/apps/default/freshrss/app/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./secret.sops.yaml
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml
+  - ./pvc.yaml

--- a/kubernetes/apps/default/freshrss/app/ocirepository.yaml
+++ b/kubernetes/apps/default/freshrss/app/ocirepository.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: freshrss
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/default/freshrss/app/pvc.yaml
+++ b/kubernetes/apps/default/freshrss/app/pvc.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: freshrss-data
+spec:
+  accessModes: ["ReadWriteOnce"]
+  resources:
+    requests:
+      storage: 200Mi
+  storageClassName: longhorn

--- a/kubernetes/apps/default/freshrss/app/secret.sops.yaml
+++ b/kubernetes/apps/default/freshrss/app/secret.sops.yaml
@@ -1,0 +1,25 @@
+# ADMIN_PASSWORD: FreshRSS admin login, set at first boot via unattended install.
+# ADMIN_API_PASSWORD: separate password gating the Fever/GReader API (mobile apps).
+apiVersion: v1
+kind: Secret
+metadata:
+  name: freshrss-secret
+stringData:
+  ADMIN_PASSWORD: ENC[AES256_GCM,data:YXvzVr8S06uCCXS9WjgemdEUpx8=,iv:4yOcorVPujHBuY1krE9Cp7JSk83j7m9VKVr6M6tjcvo=,tag:urTa5hXwDYrKPyA8TP7mVw==,type:str]
+  ADMIN_API_PASSWORD: ENC[AES256_GCM,data:D1E3dAf/MVpSvu6jB864I3TodimIlm7m2kv5In80uWcJwTMYJJOxlGhO839QASY=,iv:My9pEwC8hFkyVH7Pq6NcOnfX10pwnn2yiIFqLNbHkT8=,tag:XioulJ29DB+HZ4rfG1XAHg==,type:str]
+sops:
+  age:
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBzelZuZC82Q2Q3cWVuSU5o
+        dnlHZThsbno1blNWZmdGRngxVHpWamFaOGhrClI3T1VOYzQxNmI0NlZDNlVUVmNY
+        ajlWODM4YXBUdzRpWVd2N0V5N3dUWVkKLS0tIDFKb0RkTUY4cjhaNm1IOVBlODlp
+        OExYUnNxMlFwVHNCOWIvUktkRW5ER28KZDEW+cULGtdRAD0cHJygfTXRphp0/OPV
+        3SMlHrdlCVMv3q68mul+feB8lqMXCdh8kiJ3rE41bG5Ph1dwjLypHQ==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age1gekuxnpd95l5j8gsvmpsn2mewnevd0c5y5v66p4trzcqhmpn0svqkmnyy7
+  encrypted_regex: ^(data|stringData)$
+  lastmodified: "2026-08-09T17:34:30Z"
+  mac: ENC[AES256_GCM,data:L9Ub2ZZZnIpL4QT/wJlX/TyjhU6iTw7O4tUYHkraMgA7slMPnrlICwiydwOs9r7uh6z8kmFV5FVslmW/ZPR/2ZJoyMhdG67oSFjPoWsT5+898wZWd8HE1TTECH6egR6NFCigLXdtTIVAY/+OB2sNCIvLCP4WBV6dPD2jeyXuUYQ=,iv:Tj07RalWCM+Va5vH/Hx5ThdcWzg54NwIpDGNXcfVFSQ=,tag:Xl2f1mzoRxbRknWAfLmYhg==,type:str]
+  mac_only_encrypted: true
+  version: 3.13.3

--- a/kubernetes/apps/default/freshrss/ks.yaml
+++ b/kubernetes/apps/default/freshrss/ks.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: freshrss
+spec:
+  interval: 1h
+  path: ./kubernetes/apps/default/freshrss/app
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: default
+  wait: false

--- a/kubernetes/apps/default/kustomization.yaml
+++ b/kubernetes/apps/default/kustomization.yaml
@@ -29,3 +29,4 @@ resources:
   - ./freecad/ks.yaml
   - ./audacity/ks.yaml
   - ./recording-annotator/ks.yaml
+  - ./freshrss/ks.yaml


### PR DESCRIPTION
## Summary
- New app: FreshRSS (RSS feed aggregator), `default` namespace, app-template chart, SQLite backend
- Public route via `envoy-external` at `freshrss.${SECRET_DOMAIN}`; admin account created via unattended install envs at first boot, so there's no unauthenticated setup window on the public URL
- 200Mi longhorn PVC for `/var/www/FreshRSS/data` (sqlite db + config + favicon cache) — small on purpose, resizable later if feed/article volume grows it
- Admin/API passwords in `secret.sops.yaml`, already filled and encrypted

## Test plan
- [ ] Flux Local CI diff on this PR renders clean
- [ ] After merge, `kubectl -n default logs deploy/freshrss` — confirm unattended install completed (not stuck on manual installer page)
- [ ] Confirm liveness/readiness probes (`GET /`) pass, pod goes Ready
- [ ] Log in at `https://freshrss.${SECRET_DOMAIN}` with the admin password from the secret
- [ ] Add a feed, confirm cron refresh (`CRON_MIN=1,31`) picks it up within the hour
- [ ] Verify `ADMIN_API_PASSWORD` env actually gates FreshRSS's API (unverified against upstream docs at PR time — flagged in review)

🤖 Generated with [Claude Code](https://claude.com/claude-code)